### PR TITLE
configure.ac:add PACKAGE_URL and AC_SYS_LARGEFILE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@
 
 AC_PREREQ(2.57)
 
-AC_INIT([hldig], [0.2.0], [https://github.com/solbu/hldig/issues/])
+AC_INIT([hldig], [0.2.0], [https://github.com/solbu/hldig/issues/], ,['https://github.com/solbu/hldig/'])
 AC_CONFIG_SRCDIR([hldig/hldig.cc])
 AM_INIT_AUTOMAKE
 
@@ -363,17 +363,7 @@ AC_ARG_ENABLE(bigfile,
 	[db_cv_bigfile="$enable_bigfile"], [db_cv_bigfile="yes"])
 AC_MSG_RESULT($db_cv_bigfile)
 
-# Vendors are doing 64-bit lseek in different ways.
-# Linux, AIX, HP/UX and Solaris all use _FILE_OFFSET_BITS to specify a "big-file"
-# environment.
-if test "$db_cv_bigfile" = yes; then
-	case "$host_os" in
-	bsdi*|aix*|hpux*|solaris*)	AC_DEFINE(HAVE_FILE_OFFSET_BITS,,['big-file' environment]);;
-	linux*)	AC_DEFINE(HAVE_FILE_OFFSET_BITS,,['big-file' environment])
-		AC_DEFINE(HAVE_LARGEFILE_SOURCE,,[large file sources])
-		;;
-	esac
-fi
+AC_SYS_LARGEFILE
 
 # Add the -mimpure-text option on Solaris with GCC and libstc++ that is not shared
 if test "$GXX" = "yes"

--- a/db/configure.ac
+++ b/db/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.57)
-AC_INIT([hldig_db], [m4_esyscmd_s([cat ../VERSION])])
+AC_INIT([hldig_db], [m4_esyscmd_s([cat ../VERSION])], [https://github.com/solbu/hldig/issues/], ,['https://github.com/solbu/hldig/'])
 AC_CONFIG_SRCDIR([db_byteorder.c])
 AM_INIT_AUTOMAKE
 


### PR DESCRIPTION
The change at the top will add PACKAGE_URL to include/config.h (when
it's generated after running `./configure`). It will also put that URL
in a few other spots, which will be seen after autoreconf -ivf is run.

The second change I think is all that's needed now to test for large
file support. It will change the option for big/large file (shown when
`./configure --help` is used)