### PR TITLE
.gitignore:remove autom4te.cache [skip ci]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 Makefile
 *.log
-autom4te.cache
 *~
 testing
 temp


### PR DESCRIPTION
This fixes the problem where in some cases, running `make` will cause an
error that it can't find autoheader

More info here and in the comments at the bottom:

https://github.com/theimpossibleastronaut/rmw/commit/90200c2df06b16f16b5d21d25c51966c0ee65b23

After this patch is applied, the maintainer should push that directory
and files within to the master branch. xD