### PR TITLE
Makefile.am:suppress useless warnings [skip ci]

### DIFF
--- a/docs/src/Makefile.am
+++ b/docs/src/Makefile.am
@@ -1,7 +1,7 @@
 AUTOMAKE_OPTIONS = subdir-objects foreign no-dependencies
 
 bin_PROGRAMS=simplecgen
-AM_CFLAGS=	-Wall -pedantic -std=c99 -g
+AM_CFLAGS=	-Wall -std=c99 -g
 simplecgen_SOURCES=		\
 simplecgen.c	\
 utils.c	\


### PR DESCRIPTION
The warnings generated are from the libary this is using, and are not
anything we need to worry about.

Skip ci test because it won't be accurate until after automake is run by
maintainer