### PR TITLE
Makefile.conf:remove -pedantic flag

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -17,7 +17,7 @@ AUTOMAKE_OPTIONS = foreign no-dependencies
 PACKAGE = @PACKAGE@
 VERSION = @VERSION@
 
-AM_CPPFLAGS=-pedantic										\
+AM_CPPFLAGS=	\
 		-DDEFAULT_CONFIG_FILE=\"$(DEFAULT_CONFIG_FILE)\" \
 		-I$(top_srcdir)/include -I$(top_srcdir)/htlib \
 		-I$(top_srcdir)/htnet -I$(top_srcdir)/htcommon \


### PR DESCRIPTION
It may be worth enabling this after all other warnings are gone, but not
very useful, atm.