### PR TITLE
configure:remove remaining instances of bigfile

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -356,13 +356,6 @@ int main() {
  CFLAGS=$OLD_CFLAGS
 fi
 
-# Enable big files?
-AC_MSG_CHECKING(if --enable-bigfile option specified)
-AC_ARG_ENABLE(bigfile,
-	[AC_HELP_STRING([--enable-bigfile], [enable Linux, AIX, HP/UX, Solaris big files.])],
-	[db_cv_bigfile="$enable_bigfile"], [db_cv_bigfile="yes"])
-AC_MSG_RESULT($db_cv_bigfile)
-
 AC_SYS_LARGEFILE
 
 # Add the -mimpure-text option on Solaris with GCC and libstc++ that is not shared

--- a/db/acinclude.m4
+++ b/db/acinclude.m4
@@ -366,12 +366,6 @@ dnl @(#)options.m4	11.5 (Sleepycat) 10/15/99
 dnl Process user-specified options.
 AC_DEFUN([AM_OPTIONS_SET], [
 
-AC_MSG_CHECKING(if --enable-bigfile option specified)
-AC_ARG_ENABLE(bigfile,
-	[  --enable-bigfile       Enable Linux, AIX, HP/UX, Solaris big files.],
-	[db_cv_bigfile="$enable_bigfile"], [db_cv_bigfile="yes"])
-AC_MSG_RESULT($db_cv_bigfile)
-
 AC_MSG_CHECKING(if --enable-debug option specified)
 AC_ARG_ENABLE(debug,
 	[  --enable-debug          Build a debugging version.],

--- a/docs/FAQ.html
+++ b/docs/FAQ.html
@@ -720,14 +720,6 @@
     -D_THREAD_SAFE out of CPPFLAGS, and setting LIBS to null, in
     db/dist/configure.</p>
 
-    <strong>3.5. <a name="q3.5">I'm compiling on HP/UX and I get a complaint about
-    "Large Files not supported."</a></strong><br>
-    <p>The db/ pacakge, included with hl://Dig seems to be unable to complete
-    on HP/UX 10.20 in particular. After running the top-level configure
-    script, cd into db/dist and type:</p>
-    <code>./configure --disable-bigfile</code>
-    <p>Then continue with the normal compilation.</p>
-
     <strong>3.6. <a name="q3.6">I'm compiling on Solaris and when I run the
     programs I get complaints about not finding libstdc++.</a></strong><br>
     <p>Answer contributed by Adam Rice &lt;adam@newsquest.co.uk&gt;</p>

--- a/docs/infiles/FAQ.sct
+++ b/docs/infiles/FAQ.sct
@@ -657,14 +657,6 @@ layout:default
     -D_THREAD_SAFE out of CPPFLAGS, and setting LIBS to null, in
     db/dist/configure.</p>
 
-    <strong>3.5. <a name="q3.5">I'm compiling on HP/UX and I get a complaint about
-    "Large Files not supported."</a></strong><br>
-    <p>The db/ pacakge, included with hl://Dig seems to be unable to complete
-    on HP/UX 10.20 in particular. After running the top-level configure
-    script, cd into db/dist and type:</p>
-    <code>./configure --disable-bigfile</code>
-    <p>Then continue with the normal compilation.</p>
-
     <strong>3.6. <a name="q3.6">I'm compiling on Solaris and when I run the
     programs I get complaints about not finding libstdc++.</a></strong><br>
     <p>Answer contributed by Adam Rice &lt;adam@newsquest.co.uk&gt;</p>

--- a/docs/infiles/install.sct
+++ b/docs/infiles/install.sct
@@ -424,14 +424,3 @@ layout:default
     This is really system dependent and you must check your
     documentation.
   </p>
-  <hr noshade>
-  <h2>
-  <a name="OSs">Notes for particular operating systems</a>
-  </h2>
-  <p>
-  <strong>Solaris</strong> cc has problems with long file offsets.
-      Use<br> <code>./configure --disable-bigfile</code>.
-  </p>
-  <p>
-  <strong>HP-UX 10.20</strong> does not handle ./configure.  Sorry.
-  </p>

--- a/docs/install.html
+++ b/docs/install.html
@@ -487,17 +487,6 @@
     This is really system dependent and you must check your
     documentation.
   </p>
-  <hr noshade>
-  <h2>
-  <a name="OSs">Notes for particular operating systems</a>
-  </h2>
-  <p>
-  <strong>Solaris</strong> cc has problems with long file offsets.
-      Use<br> <code>./configure --disable-bigfile</code>.
-  </p>
-  <p>
-  <strong>HP-UX 10.20</strong> does not handle ./configure.  Sorry.
-  </p>
     </div>
   </div>
 

--- a/scripts/xtraconfigure.sh
+++ b/scripts/xtraconfigure.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-./configure --prefix=$PWD/testing --with-zlib  --enable-bigfile
+./configure --prefix=$PWD/testing --with-zlib


### PR DESCRIPTION
This is paired with
https://github.com/solbu/hldig/commit/7e86c6ef05ca12826d7f8c9f1c1da8b9d75e3708#diff-67e997bcfdac55191033d57a16d1408a

Instead of channging the option in the .html docs, I removed those
sections. I don't know how outdated that info is about specific systems.
And if largefiles are a problem for people, they will generally know to
checkout for a --disable-largefile option, which we still have.
[skip ci](fixes #120)