### PR TITLE
Replace char* with const char* to fix write string warnings, fixes #34

### DIFF
--- a/hlcommon/URL.h
+++ b/hlcommon/URL.h
@@ -127,7 +127,7 @@ private:
 //String &encodeURL(String &, char *valid = "?_@.=&/:");
 //String &encodeURL(String &, char *reserved = ";/?:@&=+$,");
 //                         char *unreserved = "-_.!~*'()");
-String & encodeURL (String &, char *valid = (char *) UNRESERVED);
+String & encodeURL (String &, const char *valid = UNRESERVED);
 
 String & decodeURL (String &);
 

--- a/hlcommon/URLTrans.cc
+++ b/hlcommon/URLTrans.cc
@@ -70,7 +70,7 @@ String & decodeURL (String & str)
 //   escaped.  The escape character is '%' and is followed by 2 hex
 //   digits representing the octet.
 //
-String & encodeURL (String & str, char *valid)
+String & encodeURL (String & str, const char *valid)
 {
   String temp;
   string digits = "0123456789ABCDEF";

--- a/hlcommon/conf_parser.cxx
+++ b/hlcommon/conf_parser.cxx
@@ -104,7 +104,7 @@ using namespace std;
 #include "htString.h"
 /*#define YYDEBUG 1*/
 #define YYPARSE_PARAM aConf
-int yyerror(const HtConfiguration *aConf, char *s);
+int yyerror(const HtConfiguration *aConf, const char *s);
 int yylex(void);  
 #undef DEBUG
 #ifdef DEBUG
@@ -1778,7 +1778,7 @@ yyreturn:
 
 
 int
-yyerror (const HtConfiguration *, char *s)  /* Called by yyparse on error */
+yyerror (const HtConfiguration *, const char *s)  /* Called by yyparse on error */
 {
    extern int yylineno;
    extern int include_stack_ptr;

--- a/hldig/ExternalTransport.cc
+++ b/hldig/ExternalTransport.cc
@@ -216,7 +216,7 @@ Transport::DocStatus ExternalTransport::Request ()
 
   // OK, now parse the stuff we got back from the handler...
   String line;
-  char *
+  const char *
     token1;
   int
     in_header = 1;

--- a/hldig/HTML.cc
+++ b/hldig/HTML.cc
@@ -411,8 +411,8 @@ HTML::parse (Retriever & retriever, URL & baseURL)
       tag.append ((char *) position, q - position);
       while (isspace (*position))
         position++;
-      if (!in_space && spacebeforetags.CompareWord ((char *) position)
-          || !in_space && !in_punct && *position != '/')
+      if ((!in_space && spacebeforetags.CompareWord ((char *) position))
+          || (!in_space && !in_punct && *position != '/'))
       {
         // These opening tags cause a space to be inserted
         // before anything they insert.

--- a/hlfuzzy/hlfuzzy.cc
+++ b/hlfuzzy/hlfuzzy.cc
@@ -251,10 +251,10 @@ usage()
 
 
 //*****************************************************************************
-// void reportError(char *msg)
+// void reportError(const char *msg)
 //
 void
-reportError(char *msg)
+reportError(const char *msg)
 {
     cout << "hlfuzzy: " << msg << "\n\n";
     exit(1);

--- a/hlfuzzy/hlfuzzy.h
+++ b/hlfuzzy/hlfuzzy.h
@@ -47,7 +47,7 @@ using namespace std;
 
 extern int    debug;
 
-extern void reportError(char *msg);
+extern void reportError(const char *msg);
 
 #endif
 

--- a/hllib/StringMatch.cc
+++ b/hllib/StringMatch.cc
@@ -91,7 +91,7 @@ StringMatch::~StringMatch ()
 //   Compile the given pattern into a state transition table
 //
 void
-StringMatch::Pattern (char *pattern, char sep)
+StringMatch::Pattern (const char *pattern, char sep)
 {
   if (!pattern || !*pattern)
   {
@@ -111,7 +111,7 @@ StringMatch::Pattern (char *pattern, char sep)
   // for each string in the pattern, we can subtract the number
   // of separators.  Wins for small but numerous strings in
   // the pattern.
-  char *tmpstr;
+  const char *tmpstr;
   for (tmpstr = pattern; (tmpstr = strchr (tmpstr, sep)) != NULL; tmpstr++)     // Pass the separator.
     n--;
 

--- a/hllib/StringMatch.h
+++ b/hllib/StringMatch.h
@@ -52,7 +52,7 @@ public:
   // be in the form <string1>|<string2>|...  If in the form of a
   // List, it should be a list of String objects.
   //
-  void Pattern (char *pattern, char sep = '|');
+  void Pattern (const char *pattern, char sep = '|');
 
   //
   // Search for any of the strings in the pattern in the given

--- a/hllib/String_fmt.cc
+++ b/hllib/String_fmt.cc
@@ -32,7 +32,7 @@ static char buf[10000];
 //*****************************************************************************
 // char *form(char *fmt, ...)
 //
-char *
+const char *
 form (const char *fmt, ...)
 {
   va_list args;

--- a/hllib/htString.h
+++ b/hllib/htString.h
@@ -95,7 +95,7 @@ public:
     append (s, l);
     return *this;
   }
-  inline String & set (char *s)
+  inline String & set (const char *s)
   {
     trunc ();
     append (s, strlen (s));
@@ -271,7 +271,7 @@ private:
   friend class StringIndex;
 };
 
-extern char *form (const char *, ...);
+extern const char *form (const char *, ...);
 extern char *vform (const char *, va_list);
 
 //

--- a/hlsearch/Display.cc
+++ b/hlsearch/Display.cc
@@ -734,7 +734,7 @@ Display::setVariables (int pageNumber, List * matches)
     vars.Add ("NEXTPAGE", str);
 
     str = new String ();
-    char *p;
+    const char *p;
     QuotedStringList pnt (config->Find ("page_number_text"), " \t\r\n");
     QuotedStringList npnt (config->Find ("no_page_number_text"), " \t\r\n");
     QuotedStringList sep (config->Find ("page_number_separator"), " \t\r\n");
@@ -1961,8 +1961,8 @@ Display::logSearch (int page, List * matches)
   int nMatches = 0;
   int level = LOG_LEVEL;
   int facility = LOG_FACILITY;
-  char *host = getenv ("REMOTE_HOST");
-  char *ref = getenv ("HTTP_REFERER");
+  const char *host = getenv ("REMOTE_HOST");
+  const char *ref = getenv ("HTTP_REFERER");
 
   if (host == NULL)
     host = getenv ("REMOTE_ADDR");

--- a/hlsearch/HtURLSeedScore.cc
+++ b/hlsearch/HtURLSeedScore.cc
@@ -160,7 +160,7 @@ ScoreAdjustItem::~ScoreAdjustItem ()
 
 URLSeedScore::URLSeedScore (Configuration & config)
 {
-  char *config_item = "url_seed_score";
+  const char *config_item = "url_seed_score";
 
   StringList sl (config[config_item], "\t \r\n");
 

--- a/hlsearch/ResultMatch.cc
+++ b/hlsearch/ResultMatch.cc
@@ -40,7 +40,7 @@ ResultMatch::~ResultMatch ()
 
 //*****************************************************************************
 // Default-access-methods.  Just dummies when that data is not used.
-char *
+const char *
 ResultMatch::getTitle ()
 {
   return "";
@@ -233,7 +233,7 @@ public:
   getSortFun ();
   virtual void
   setTitle (char *t);
-  virtual char *
+  virtual const char *
   getTitle ();
   TitleMatch ();
   ~
@@ -263,7 +263,7 @@ TitleMatch::setTitle (char *t)
   myTitle = t;
 }
 
-char *
+const char *
 TitleMatch::getTitle ()
 {
   return myTitle;
@@ -274,8 +274,8 @@ TitleMatch::compare (const void *a1, const void *a2)
 {
   ResultMatch *m1 = *((ResultMatch **) a1);
   ResultMatch *m2 = *((ResultMatch **) a2);
-  char *t1 = m1->getTitle ();
-  char *t2 = m2->getTitle ();
+  const char *t1 = m1->getTitle ();
+  const char *t2 = m2->getTitle ();
 
   if (!t1)
     t1 = "";
@@ -295,7 +295,7 @@ ResultMatch::setSortType (const String & sorttype)
 {
   static const struct
   {
-    char *typest;
+    const char *typest;
     SortType type;
   }
   sorttypes[] =

--- a/hlsearch/ResultMatch.h
+++ b/hlsearch/ResultMatch.h
@@ -77,7 +77,7 @@ public:
   // A method for each type of data Display wants to cram in.
   // Will only store the pieces necessary for the
   // search-type as defined in setSortType, the others are dummies.
-  virtual char *getTitle ();
+  virtual const char *getTitle ();
   virtual time_t getTime ();
 
   virtual void setTitle (char *title);

--- a/hlsearch/WeightWord.cc
+++ b/hlsearch/WeightWord.cc
@@ -62,7 +62,7 @@ WeightWord::WeightWord (WeightWord * ww)
 //***************************************************************************
 // WeightWord::WeightWord(char *word, double weight)
 //
-WeightWord::WeightWord (char *word, double weight)
+WeightWord::WeightWord (const char *word, double weight)
 {
   records = 0;
   isExact = 0;
@@ -79,7 +79,7 @@ WeightWord::WeightWord (char *word, double weight)
 //***************************************************************************
 // WeightWord::WeightWord(char *word, double weight, unsigned int f)
 //
-WeightWord::WeightWord (char *word, double weight, unsigned int f)
+WeightWord::WeightWord (const char *word, double weight, unsigned int f)
 {
   records = 0;
 
@@ -110,7 +110,7 @@ WeightWord::~WeightWord ()
 // void WeightWord::set(char *word)
 //
 void
-WeightWord::set (char *word)
+WeightWord::set (const char *word)
 {
 #if 0
   isExact = 0;

--- a/hlsearch/WeightWord.h
+++ b/hlsearch/WeightWord.h
@@ -28,13 +28,13 @@ public:
   // Construction/Destruction
   //
   WeightWord ();
-  WeightWord (char *word, double weight);
-    WeightWord (char *word, double weight, unsigned int flags);
+  WeightWord (const char *word, double weight);
+    WeightWord (const char *word, double weight, unsigned int flags);
     WeightWord (WeightWord *);
 
     virtual ~ WeightWord ();
 
-  void set (char *word);
+  void set (const char *word);
 
   String word;
   double weight;

--- a/hlsearch/hlsearch.cc
+++ b/hlsearch/hlsearch.cc
@@ -54,7 +54,7 @@ void htsearch (Collection *, List &, Parser *);
 
 void setupWords (char *, List &, int, Parser *, String &);
 void createLogicalWords (List &, String &, String &);
-void reportError (char *);
+void reportError (const char *);
 void convertToBoolean (List & words);
 void doFuzzy (WeightWord *, List &, List &);
 void addRequiredWords (List &, StringList &);
@@ -71,7 +71,7 @@ StringList collectionList;      // List of databases to search on
 // Don't use a dictionary structure, as setup time outweights saving.
 struct
 {
-  char *name;
+  const char *name;
   unsigned int flag;
 } colonPrefix[] =
 {
@@ -527,7 +527,7 @@ createLogicalWords (List & searchWords, String & logicalWords, String & wm)
 }
 
 void
-dumpWords (List & words, char *msg = "")
+dumpWords (List & words, const char *msg = "")
 {
   if (debug)
   {
@@ -947,7 +947,7 @@ addRequiredWords (List & searchWords, StringList & requiredWords)
 // we will assume this is the first thing returned by a CGI program.
 //
 void
-reportError (char *msg)
+reportError (const char *msg)
 {
   HtConfiguration *config = HtConfiguration::config ();
   cout << "Content-type: text/html\r\n\r\n";

--- a/hlsearch/parser.cc
+++ b/hlsearch/parser.cc
@@ -50,7 +50,7 @@ int
 Parser::checkSyntax (List * tokenList)
 {
   HtConfiguration *config = HtConfiguration::config ();
-  void reportError (char *);
+  void reportError (const char *);
   // Load boolean_syntax_errors from configuration
   // they should be placed in this order:
   // 0        1               2            3            4
@@ -297,7 +297,7 @@ Parser::match (int t)
 
 //*****************************************************************************
 void
-Parser::setError (char *expected)
+Parser::setError (const char *expected)
 {
   if (valid)
   {

--- a/hlsearch/parser.h
+++ b/hlsearch/parser.h
@@ -55,7 +55,7 @@ protected:
   void term (int);
   void factor (int);
   int match (int);
-  void setError (char *);
+  void setError (const char *);
   void perform_push ();
   void perform_and ();
   void perform_not ();

--- a/hlsearch/parsetest.cc
+++ b/hlsearch/parsetest.cc
@@ -34,7 +34,7 @@
 #include <getopt.h>
 #endif
 
-void reportError (char *msg);
+void reportError (const char *msg);
 void usage ();
 
 int debug = 0;
@@ -170,7 +170,7 @@ usage ()
 // Report an error and die
 //
 void
-reportError (char *msg)
+reportError (const char *msg)
 {
   cout << "parsetest: " << msg << "\n\n";
   exit (1);

--- a/hltools/hldump.cc
+++ b/hltools/hldump.cc
@@ -41,7 +41,7 @@
 int verbose = 0;
 
 void usage ();
-void reportError (char *msg);
+void reportError (const char *msg);
 
 //*****************************************************************************
 // int main(int ac, char **av)
@@ -199,7 +199,7 @@ usage ()
 // Report an error and die
 //
 void
-reportError (char *msg)
+reportError (const char *msg)
 {
   cout << "hldump: " << msg << "\n\n";
   exit (1);

--- a/hltools/hlload.cc
+++ b/hltools/hlload.cc
@@ -42,7 +42,7 @@
 int verbose = 0;
 
 void usage ();
-void reportError (char *msg);
+void reportError (const char *msg);
 
 //*****************************************************************************
 // int main(int ac, char **av)
@@ -198,7 +198,7 @@ usage ()
 // Report an error and die
 //
 void
-reportError (char *msg)
+reportError (const char *msg)
 {
   cout << "hlload: " << msg << "\n\n";
   exit (1);

--- a/hltools/hlmerge.cc
+++ b/hltools/hlmerge.cc
@@ -73,7 +73,7 @@ int stats = 0;
 // Component procedures
 void mergeDB ();
 void usage ();
-void reportError (char *msg);
+void reportError (const char *msg);
 
 //*****************************************************************************
 // int main(int ac, char **av)
@@ -406,7 +406,7 @@ usage ()
 // Report an error and die
 //
 void
-reportError (char *msg)
+reportError (const char *msg)
 {
   cout << "hlmerge: " << msg << "\n\n";
   exit (1);

--- a/hltools/hlstat.cc
+++ b/hltools/hlstat.cc
@@ -39,7 +39,7 @@
 int verbose = 0;
 
 void usage ();
-void reportError (char *msg);
+void reportError (const char *msg);
 
 //*****************************************************************************
 // int main(int ac, char **av)
@@ -195,7 +195,7 @@ usage ()
 // Report an error and die
 //
 void
-reportError (char *msg)
+reportError (const char *msg)
 {
   cout << "hlstat: " << msg << "\n\n";
   exit (1);

--- a/libhtdig/libhtdig_htsearch.cc
+++ b/libhtdig/libhtdig_htsearch.cc
@@ -73,7 +73,7 @@ int htsearch (Collection *, List &, Parser *);
 
 void setupWords (char *, List &, int, Parser *, String &);
 void createLogicalWords (List &, String &, String &);
-void reportError (char *);
+void reportError (const char *);
 void convertToBoolean (List & words);
 void doFuzzy (WeightWord *, List &, List &);
 void addRequiredWords (List &, StringList &);
@@ -1121,7 +1121,7 @@ addRequiredWords (List & searchWords, StringList & requiredWords)
 // we will assume this is the first thing returned by a CGI program.
 //
 void
-reportError_html (char *msg)
+reportError_html (const char *msg)
 {
   HtConfiguration *config = HtConfiguration::config ();
   cout << "Content-type: text/html\r\n\r\n";

--- a/libhtdig/libhtdig_log.cc
+++ b/libhtdig/libhtdig_log.cc
@@ -71,7 +71,7 @@ logEntry (char *msg)
 // Report an error
 
 void
-reportError (char *msg)
+reportError (const char *msg)
 {
   time_t now = time (NULL);
 

--- a/libhtdig/libhtdig_log.h
+++ b/libhtdig/libhtdig_log.h
@@ -31,7 +31,7 @@
 
 int logOpen (char *file);
 void logEntry (char *msg);
-void reportError (char *msg);
+void reportError (const char *msg);
 int logClose (void);
 
 #endif /* LIBHTDIG_LOG_H */

--- a/test/testnet.cc
+++ b/test/testnet.cc
@@ -48,7 +48,7 @@ HtHTTP    *HTTPConnect = NULL;
 
 
 static void usage();
-void reportError(char *msg);
+void reportError(const char *msg);
 Transport::DocStatus Retrieve();
 int Parser(char *ct);
 
@@ -311,7 +311,7 @@ void usage()
 //
 // Report an error and die
 //
-void reportError(char *msg)
+void reportError(const char *msg)
 {
     cout << "testnet: " << msg << "\n\n";
     exit(1);


### PR DESCRIPTION
Changes all possible char* to const char*, avoid casting.