### PR TITLE
Use standard (uint) types

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -261,7 +261,7 @@ AC_TYPE_SIGNAL
 AC_FUNC_STRFTIME
 AC_FUNC_STRPTIME
 AC_FUNC_VPRINTF
-AC_CHECK_FUNCS([alarm btowc bzero ftime getcwd gettimeofday localtime_r memcmp memcpy memmove memset mkstemp munmap pstat_getdynamic raise re_comp regcomp select setlocale strchr strcspn strdup strerror strrchr strstr strtol strtoul timegm])
+AC_CHECK_FUNCS([alarm btowc bzero ftime getcwd gettimeofday localtime_r memcmp memcpy memmove memset mkstemp munmap pstat_getdynamic raise re_comp regcomp rresvport select setlocale strchr strcspn strdup strerror strrchr strstr strtol strtoul timegm])
 AC_REPLACE_FUNCS(snprintf vsnprintf)
 
 # More header checks--here use C++

--- a/db/bt_compare.c
+++ b/db/bt_compare.c
@@ -63,14 +63,14 @@ static const char sccsid[] = "@(#)bt_compare.c  11.2 (Sleepycat) 9/9/99";
  *  Compare a key to a given record.
  *
  * PUBLIC: int CDB___bam_cmp __P((DB *, const DBT *,
- * PUBLIC:    PAGE *, u_int32_t, int (*)(const DBT *, const DBT *)));
+ * PUBLIC:    PAGE *, uint32_t, int (*)(const DBT *, const DBT *)));
  */
 int
 CDB___bam_cmp (dbp, dbt, h, indx, func)
      DB *dbp;
      const DBT *dbt;
      PAGE *h;
-     u_int32_t indx;
+     uint32_t indx;
      int (*func) __P ((const DBT *, const DBT *));
 {
   BINTERNAL *bi;
@@ -154,7 +154,7 @@ CDB___bam_defcmp (a, b)
      const DBT *a, *b;
 {
   size_t len;
-  u_int8_t *p1, *p2;
+  uint8_t *p1, *p2;
 
   /*
    * Returns:
@@ -186,7 +186,7 @@ CDB___bam_defpfx (a, b)
      const DBT *a, *b;
 {
   size_t cnt, len;
-  u_int8_t *p1, *p2;
+  uint8_t *p1, *p2;
 
   cnt = 1;
   len = a->size > b->size ? b->size : a->size;

--- a/db/bt_conv.c
+++ b/db/bt_conv.c
@@ -82,11 +82,11 @@ int
 CDB___bam_mswap (pg)
      PAGE *pg;
 {
-  u_int8_t *p;
+  uint8_t *p;
 
   CDB___db_metaswap (pg);
 
-  p = (u_int8_t *) pg + sizeof (DBMETA);
+  p = (uint8_t *) pg + sizeof (DBMETA);
 
   SWAP32 (p);                   /* maxkey */
   SWAP32 (p);                   /* minkey */

--- a/db/bt_curadj.c
+++ b/db/bt_curadj.c
@@ -57,13 +57,13 @@ CDB___bam_cprint (dbp)
  *  Update the cursors when items are deleted and when already deleted
  *  items are overwritten.  Return the number of relevant cursors found.
  *
- * PUBLIC: int CDB___bam_ca_delete __P((DB *, db_pgno_t, u_int32_t, int));
+ * PUBLIC: int CDB___bam_ca_delete __P((DB *, db_pgno_t, uint32_t, int));
  */
 int
 CDB___bam_ca_delete (dbp, pgno, indx, delete)
      DB *dbp;
      db_pgno_t pgno;
-     u_int32_t indx;
+     uint32_t indx;
      int delete;
 {
   DBC *dbc;
@@ -110,13 +110,13 @@ CDB___bam_ca_delete (dbp, pgno, indx, delete)
  * CDB___bam_ca_di --
  *  Adjust the cursors during a delete or insert.
  *
- * PUBLIC: void CDB___bam_ca_di __P((DB *, db_pgno_t, u_int32_t, int));
+ * PUBLIC: void CDB___bam_ca_di __P((DB *, db_pgno_t, uint32_t, int));
  */
 void
 CDB___bam_ca_di (dbp, pgno, indx, adjust)
      DB *dbp;
      db_pgno_t pgno;
-     u_int32_t indx;
+     uint32_t indx;
      int adjust;
 {
   DBC *dbc;
@@ -156,13 +156,13 @@ CDB___bam_ca_di (dbp, pgno, indx, adjust)
  *  page.
  *
  * PUBLIC: void CDB___bam_ca_dup __P((DB *,
- * PUBLIC:    db_pgno_t, u_int32_t, u_int32_t, db_pgno_t, u_int32_t));
+ * PUBLIC:    db_pgno_t, uint32_t, uint32_t, db_pgno_t, uint32_t));
  */
 void
 CDB___bam_ca_dup (dbp, fpgno, first, fi, tpgno, ti)
      DB *dbp;
      db_pgno_t fpgno, tpgno;
-     u_int32_t first, fi, ti;
+     uint32_t first, fi, ti;
 {
   DBC *dbc;
 
@@ -231,13 +231,13 @@ CDB___bam_ca_rsplit (dbp, fpgno, tpgno)
  *  Adjust the cursors when splitting a page.
  *
  * PUBLIC: void CDB___bam_ca_split __P((DB *,
- * PUBLIC:    db_pgno_t, db_pgno_t, db_pgno_t, u_int32_t, int));
+ * PUBLIC:    db_pgno_t, db_pgno_t, db_pgno_t, uint32_t, int));
  */
 void
 CDB___bam_ca_split (dbp, ppgno, lpgno, rpgno, split_indx, cleft)
      DB *dbp;
      db_pgno_t ppgno, lpgno, rpgno;
-     u_int32_t split_indx;
+     uint32_t split_indx;
      int cleft;
 {
   DBC *dbc;
@@ -297,13 +297,13 @@ CDB___bam_ca_split (dbp, ppgno, lpgno, rpgno, split_indx, cleft)
  *  Adjust the cursors when when doing a replace.
  *
  * PUBLIC: void CDB___bam_ca_repl __P((DB *,
- * PUBLIC:    db_pgno_t, u_int32_t, db_pgno_t, u_int32_t));
+ * PUBLIC:    db_pgno_t, uint32_t, db_pgno_t, uint32_t));
  */
 void
 CDB___bam_ca_repl (dbp, dpgno, dindx, newpgno, newindx)
      DB *dbp;
      db_pgno_t dpgno, newpgno;
-     u_int32_t dindx, newindx;
+     uint32_t dindx, newindx;
 {
   DBC *dbc;
 

--- a/db/bt_cursor.c
+++ b/db/bt_cursor.c
@@ -27,21 +27,21 @@ static const char sccsid[] = "@(#)bt_cursor.c  11.21 (Sleepycat) 11/10/99";
 #include "qam.h"
 
 static int CDB___bam_c_close __P ((DBC *));
-static int CDB___bam_c_del __P ((DBC *, u_int32_t));
+static int CDB___bam_c_del __P ((DBC *, uint32_t));
 static int CDB___bam_c_destroy __P ((DBC *));
 static int CDB___bam_c_first __P ((DBC *));
-static int CDB___bam_c_get __P ((DBC *, DBT *, DBT *, u_int32_t));
+static int CDB___bam_c_get __P ((DBC *, DBT *, DBT *, uint32_t));
 static int CDB___bam_c_getstack __P ((DBC *));
 static int CDB___bam_c_last __P ((DBC *));
 static int CDB___bam_c_next __P ((DBC *, int));
 static int CDB___bam_c_physdel __P ((DBC *));
 static int CDB___bam_c_prev __P ((DBC *));
-static int CDB___bam_c_put __P ((DBC *, DBT *, DBT *, u_int32_t));
+static int CDB___bam_c_put __P ((DBC *, DBT *, DBT *, uint32_t));
 static void CDB___bam_c_reset __P ((BTREE_CURSOR *));
-static int CDB___bam_c_rget __P ((DBC *, DBT *, u_int32_t));
-static int CDB___bam_c_search __P ((DBC *, const DBT *, u_int32_t, int *));
-static int CDB___bam_dsearch __P ((DBC *, DBT *, u_int32_t *));
-static int CDB___bam_dup __P ((DBC *, u_int32_t, int));
+static int CDB___bam_c_rget __P ((DBC *, DBT *, uint32_t));
+static int CDB___bam_c_search __P ((DBC *, const DBT *, uint32_t, int *));
+static int CDB___bam_dsearch __P ((DBC *, DBT *, uint32_t *));
+static int CDB___bam_dup __P ((DBC *, uint32_t, int));
 
 /*
  * Acquire a new page/lock for the cursor.  If we hold a page/lock, discard
@@ -327,7 +327,7 @@ CDB___bam_c_destroy (dbc)
 static int
 CDB___bam_c_del (dbc, flags)
      DBC *dbc;
-     u_int32_t flags;
+     uint32_t flags;
 {
   BTREE_CURSOR *cp;
   DB *dbp;
@@ -457,13 +457,13 @@ static int
 CDB___bam_c_get (dbc_orig, key, data, flags)
      DBC *dbc_orig;
      DBT *key, *data;
-     u_int32_t flags;
+     uint32_t flags;
 {
   BTREE_CURSOR *cp, *orig, start;
   DB *dbp;
   DBC *dbc;
   PAGE *h;
-  u_int32_t tmp_rmw;
+  uint32_t tmp_rmw;
   int exact, ret;
 
   dbp = dbc_orig->dbp;
@@ -740,7 +740,7 @@ static int
 CDB___bam_dsearch (dbc, data, iflagp)
      DBC *dbc;
      DBT *data;
-     u_int32_t *iflagp;         /* Non-NULL if we're doing an insert. */
+     uint32_t *iflagp;         /* Non-NULL if we're doing an insert. */
 {
   BTREE_CURSOR *cp, copy, last;
   DB *dbp;
@@ -836,7 +836,7 @@ static int
 CDB___bam_c_rget (dbc, data, flags)
      DBC *dbc;
      DBT *data;
-     u_int32_t flags;
+     uint32_t flags;
 {
   BTREE_CURSOR *cp;
   DB *dbp;
@@ -884,7 +884,7 @@ static int
 CDB___bam_c_put (dbc_orig, key, data, flags)
      DBC *dbc_orig;
      DBT *key, *data;
-     u_int32_t flags;
+     uint32_t flags;
 {
   BTREE_CURSOR *cp, *orig;
   DB *dbp;
@@ -895,7 +895,7 @@ CDB___bam_c_put (dbc_orig, key, data, flags)
   DBT dbt;
   db_indx_t indx;
   db_pgno_t pgno;
-  u_int32_t iiop;
+  uint32_t iiop;
   int exact, needkey = 0, ret, ret_ignore, stack = 0;
   void *arg;
 
@@ -1532,7 +1532,7 @@ static int
 CDB___bam_c_search (dbc, key, flags, exactp)
      DBC *dbc;
      const DBT *key;
-     u_int32_t flags;
+     uint32_t flags;
      int *exactp;
 {
   BTREE *t;
@@ -1542,7 +1542,7 @@ CDB___bam_c_search (dbc, key, flags, exactp)
   PAGE *h;
   db_recno_t recno;
   db_indx_t indx;
-  u_int32_t sflags;
+  uint32_t sflags;
   int cmp, ret;
 
   dbp = dbc->dbp;
@@ -1717,7 +1717,7 @@ CDB___bam_c_search (dbc, key, flags, exactp)
 static int
 CDB___bam_dup (dbc, indx, last_dup)
      DBC *dbc;
-     u_int32_t indx;
+     uint32_t indx;
      int last_dup;
 {
   BOVERFLOW *bo;

--- a/db/bt_delete.c
+++ b/db/bt_delete.c
@@ -62,19 +62,19 @@ static const char sccsid[] = "@(#)bt_delete.c  11.6 (Sleepycat) 9/9/99";
  * CDB___bam_delete --
  *  Delete the items referenced by a key.
  *
- * PUBLIC: int CDB___bam_delete __P((DB *, DB_TXN *, DBT *, u_int32_t));
+ * PUBLIC: int CDB___bam_delete __P((DB *, DB_TXN *, DBT *, uint32_t));
  */
 int
 CDB___bam_delete (dbp, txn, key, flags)
      DB *dbp;
      DB_TXN *txn;
      DBT *key;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DBC *dbc;
   DBT lkey;
   DBT data;
-  u_int32_t f_init, f_next;
+  uint32_t f_init, f_next;
   int ret, t_ret;
 
   PANIC_CHECK (dbp->dbenv);
@@ -140,19 +140,19 @@ err:                           /* Discard the cursor. */
  * CDB___bam_ditem --
  *  Delete one or more entries from a page.
  *
- * PUBLIC: int CDB___bam_ditem __P((DBC *, PAGE *, u_int32_t));
+ * PUBLIC: int CDB___bam_ditem __P((DBC *, PAGE *, uint32_t));
  */
 int
 CDB___bam_ditem (dbc, h, indx)
      DBC *dbc;
      PAGE *h;
-     u_int32_t indx;
+     uint32_t indx;
 {
   BINTERNAL *bi;
   BKEYDATA *bk;
   BOVERFLOW *bo;
   DB *dbp;
-  u_int32_t nbytes;
+  uint32_t nbytes;
   int ret;
 
   dbp = dbc->dbp;
@@ -196,7 +196,7 @@ CDB___bam_ditem (dbc, h, indx)
        * data item, otherwise the "indx + P_INDX" calculation
        * won't work!
        */
-      if (indx + P_INDX < (u_int32_t) NUM_ENT (h) &&
+      if (indx + P_INDX < (uint32_t) NUM_ENT (h) &&
           h->inp[indx] == h->inp[indx + P_INDX])
         return (CDB___bam_adjindx (dbc, h, indx, indx + O_INDX, 0));
       /*
@@ -250,13 +250,13 @@ CDB___bam_ditem (dbc, h, indx)
  * CDB___bam_adjindx --
  *  Adjust an index on the page.
  *
- * PUBLIC: int CDB___bam_adjindx __P((DBC *, PAGE *, u_int32_t, u_int32_t, int));
+ * PUBLIC: int CDB___bam_adjindx __P((DBC *, PAGE *, uint32_t, uint32_t, int));
  */
 int
 CDB___bam_adjindx (dbc, h, indx, indx_copy, is_insert)
      DBC *dbc;
      PAGE *h;
-     u_int32_t indx, indx_copy;
+     uint32_t indx, indx_copy;
      int is_insert;
 {
   DB *dbp;
@@ -269,7 +269,7 @@ CDB___bam_adjindx (dbc, h, indx, indx_copy, is_insert)
   if (DB_LOGGING (dbc) &&
       (ret = CDB___bam_adj_log (dbp->dbenv, dbc->txn, &LSN (h),
                                 0, dbp->log_fileid, PGNO (h), &LSN (h), indx,
-                                indx_copy, (u_int32_t) is_insert)) != 0)
+                                indx_copy, (uint32_t) is_insert)) != 0)
     return (ret);
 
   if (is_insert)

--- a/db/bt_method.c
+++ b/db/bt_method.c
@@ -24,12 +24,12 @@ static const char sccsid[] = "@(#)bt_method.c  11.8 (Sleepycat) 10/27/99";
 
 static int CDB___bam_set_bt_compare
 __P ((DB *, int (*)(const DBT *, const DBT *)));
-static int CDB___bam_set_bt_maxkey __P ((DB *, u_int32_t));
-static int CDB___bam_set_bt_minkey __P ((DB *, u_int32_t));
+static int CDB___bam_set_bt_maxkey __P ((DB *, uint32_t));
+static int CDB___bam_set_bt_minkey __P ((DB *, uint32_t));
 static int CDB___bam_set_bt_prefix
 __P ((DB *, size_t (*)(const DBT *, const DBT *)));
 static int CDB___ram_set_re_delim __P ((DB *, int));
-static int CDB___ram_set_re_len __P ((DB *, u_int32_t));
+static int CDB___ram_set_re_len __P ((DB *, uint32_t));
 static int CDB___ram_set_re_pad __P ((DB *, int));
 static int CDB___ram_set_re_source __P ((DB *, const char *));
 
@@ -107,14 +107,14 @@ CDB___bam_db_close (dbp)
  * CDB___bam_set_flags --
  *  Set Btree specific flags.
  *
- * PUBLIC: int CDB___bam_set_flags __P((DB *, u_int32_t *flagsp));
+ * PUBLIC: int CDB___bam_set_flags __P((DB *, uint32_t *flagsp));
  */
 int
 CDB___bam_set_flags (dbp, flagsp)
      DB *dbp;
-     u_int32_t *flagsp;
+     uint32_t *flagsp;
 {
-  u_int32_t flags;
+  uint32_t flags;
 
   flags = *flagsp;
   if (LF_ISSET (DB_DUP | DB_DUPSORT | DB_RECNUM | DB_REVSPLITOFF))
@@ -203,7 +203,7 @@ CDB___bam_set_bt_compare (dbp, func)
 static int
 CDB___bam_set_bt_maxkey (dbp, bt_maxkey)
      DB *dbp;
-     u_int32_t bt_maxkey;
+     uint32_t bt_maxkey;
 {
   BTREE *t;
 
@@ -229,7 +229,7 @@ CDB___bam_set_bt_maxkey (dbp, bt_maxkey)
 static int
 CDB___bam_set_bt_minkey (dbp, bt_minkey)
      DB *dbp;
-     u_int32_t bt_minkey;
+     uint32_t bt_minkey;
 {
   BTREE *t;
 
@@ -272,14 +272,14 @@ size_t (*func) __P ((const DBT *, const DBT *));
  * CDB___ram_set_flags --
  *  Set Recno specific flags.
  *
- * PUBLIC: int CDB___ram_set_flags __P((DB *, u_int32_t *flagsp));
+ * PUBLIC: int CDB___ram_set_flags __P((DB *, uint32_t *flagsp));
  */
 int
 CDB___ram_set_flags (dbp, flagsp)
      DB *dbp;
-     u_int32_t *flagsp;
+     uint32_t *flagsp;
 {
-  u_int32_t flags;
+  uint32_t flags;
 
   flags = *flagsp;
   if (LF_ISSET (DB_RENUMBER | DB_SNAPSHOT))
@@ -334,7 +334,7 @@ CDB___ram_set_re_delim (dbp, re_delim)
 static int
 CDB___ram_set_re_len (dbp, re_len)
      DB *dbp;
-     u_int32_t re_len;
+     uint32_t re_len;
 {
   BTREE *t;
   QUEUE *q;

--- a/db/bt_open.c
+++ b/db/bt_open.c
@@ -148,7 +148,7 @@ CDB___bam_metachk (dbp, name, btm)
      BTMETA *btm;
 {
   DB_ENV *dbenv;
-  u_int32_t vers;
+  uint32_t vers;
   int ret;
 
   dbenv = dbp->dbenv;

--- a/db/bt_put.c
+++ b/db/bt_put.c
@@ -57,15 +57,15 @@ static const char sccsid[] = "@(#)bt_put.c  11.20 (Sleepycat) 10/28/99";
 #include "db_page.h"
 #include "btree.h"
 
-static int CDB___bam_ndup __P ((DBC *, PAGE *, u_int32_t));
-static int CDB___bam_ovput __P ((DBC *, PAGE *, u_int32_t, DBT *));
+static int CDB___bam_ndup __P ((DBC *, PAGE *, uint32_t));
+static int CDB___bam_ovput __P ((DBC *, PAGE *, uint32_t, DBT *));
 
 /*
  * CDB___bam_iitem --
  *  Insert an item into the tree.
  *
  * PUBLIC: int CDB___bam_iitem __P((DBC *,
- * PUBLIC:    PAGE **, db_indx_t *, DBT *, DBT *, u_int32_t, u_int32_t));
+ * PUBLIC:    PAGE **, db_indx_t *, DBT *, DBT *, uint32_t, uint32_t));
  */
 int
 CDB___bam_iitem (dbc, hp, indxp, key, data, op, flags)
@@ -73,7 +73,7 @@ CDB___bam_iitem (dbc, hp, indxp, key, data, op, flags)
      PAGE **hp;
      db_indx_t *indxp;
      DBT *key, *data;
-     u_int32_t op, flags;
+     uint32_t op, flags;
 {
   BKEYDATA *bk;
   BTREE *t;
@@ -83,7 +83,7 @@ CDB___bam_iitem (dbc, hp, indxp, key, data, op, flags)
   PAGE *h;
   db_indx_t indx;
   db_pgno_t pgno;
-  u_int32_t data_size, have_bytes, need_bytes, needed;
+  uint32_t data_size, have_bytes, need_bytes, needed;
   int bigkey, bigdata, dupadjust, padrec, replace, ret, was_deleted;
 
   COMPQUIET (bk, NULL);
@@ -489,16 +489,16 @@ done:if (dbp->type == DB_RECNO)
  * CDB___bam_partsize --
  *  Figure out how much space a partial data item is in total.
  *
- * PUBLIC: u_int32_t CDB___bam_partsize __P((u_int32_t, DBT *, PAGE *, u_int32_t));
+ * PUBLIC: uint32_t CDB___bam_partsize __P((uint32_t, DBT *, PAGE *, uint32_t));
  */
-u_int32_t
+uint32_t
 CDB___bam_partsize (op, data, h, indx)
-     u_int32_t op, indx;
+     uint32_t op, indx;
      DBT *data;
      PAGE *h;
 {
   BKEYDATA *bk;
-  u_int32_t nbytes;
+  uint32_t nbytes;
 
   /*
    * If the record doesn't already exist, it's simply the data we're
@@ -539,13 +539,13 @@ CDB___bam_partsize (op, data, h, indx)
  * CDB___bam_build --
  *  Build the real record for a partial put, or short fixed-length record.
  *
- * PUBLIC: int CDB___bam_build __P((DBC *, u_int32_t,
- * PUBLIC:     DBT *, PAGE *, u_int32_t, u_int32_t));
+ * PUBLIC: int CDB___bam_build __P((DBC *, uint32_t,
+ * PUBLIC:     DBT *, PAGE *, uint32_t, uint32_t));
  */
 int
 CDB___bam_build (dbc, op, dbt, h, indx, nbytes)
      DBC *dbc;
-     u_int32_t op, indx, nbytes;
+     uint32_t op, indx, nbytes;
      DBT *dbt;
      PAGE *h;
 {
@@ -554,8 +554,8 @@ CDB___bam_build (dbc, op, dbt, h, indx, nbytes)
   BTREE *t;
   DB *dbp;
   DBT copy;
-  u_int32_t len, tlen;
-  u_int8_t *p;
+  uint32_t len, tlen;
+  uint8_t *p;
   int ret;
 
   COMPQUIET (bo, NULL);
@@ -593,7 +593,7 @@ CDB___bam_build (dbc, op, dbt, h, indx, nbytes)
    */
   if (!F_ISSET (dbt, DB_DBT_PARTIAL) || op != DB_CURRENT)
   {
-    p = (u_int8_t *) dbc->rdata.data + dbt->doff;
+    p = (uint8_t *) dbc->rdata.data + dbt->doff;
     tlen = dbt->doff;
     goto user_copy;
   }
@@ -624,7 +624,7 @@ CDB___bam_build (dbc, op, dbt, h, indx, nbytes)
 
     /* Skip any leading data from the original record. */
     tlen = dbt->doff;
-    p = (u_int8_t *) dbc->rdata.data + dbt->doff;
+    p = (uint8_t *) dbc->rdata.data + dbt->doff;
 
     /*
      * Copy in any trailing data from the original record.
@@ -651,7 +651,7 @@ CDB___bam_build (dbc, op, dbt, h, indx, nbytes)
     memcpy (dbc->rdata.data,
             bk->data, dbt->doff > bk->len ? bk->len : dbt->doff);
     tlen = dbt->doff;
-    p = (u_int8_t *) dbc->rdata.data + dbt->doff;
+    p = (uint8_t *) dbc->rdata.data + dbt->doff;
 
     /* Copy in any trailing data from the original record. */
     len = dbt->doff + dbt->dlen;
@@ -702,7 +702,7 @@ static int
 CDB___bam_ovput (dbc, h, indx, item)
      DBC *dbc;
      PAGE *h;
-     u_int32_t indx;
+     uint32_t indx;
      DBT *item;
 {
   BOVERFLOW bo;
@@ -724,13 +724,13 @@ CDB___bam_ovput (dbc, h, indx, item)
  * CDB___bam_ritem --
  *  Replace an item on a page.
  *
- * PUBLIC: int CDB___bam_ritem __P((DBC *, PAGE *, u_int32_t, DBT *));
+ * PUBLIC: int CDB___bam_ritem __P((DBC *, PAGE *, uint32_t, DBT *));
  */
 int
 CDB___bam_ritem (dbc, h, indx, data)
      DBC *dbc;
      PAGE *h;
-     u_int32_t indx;
+     uint32_t indx;
      DBT *data;
 {
   BKEYDATA *bk;
@@ -738,7 +738,7 @@ CDB___bam_ritem (dbc, h, indx, data)
   DBT orig, repl;
   db_indx_t cnt, lo, ln, min, off, prefix, suffix;
   int32_t nbytes;
-  u_int8_t *p, *t;
+  uint8_t *p, *t;
 
   dbp = dbc->dbp;
 
@@ -765,23 +765,23 @@ CDB___bam_ritem (dbc, h, indx, data)
 
     min -= prefix;
     for (suffix = 0,
-         p = (u_int8_t *) bk->data + bk->len - 1,
-         t = (u_int8_t *) data->data + data->size - 1;
+         p = (uint8_t *) bk->data + bk->len - 1,
+         t = (uint8_t *) data->data + data->size - 1;
          suffix < min && *p == *t; ++suffix, --p, --t)
       ;
 
     /* We only log the parts of the keys that have changed. */
-    orig.data = (u_int8_t *) bk->data + prefix;
+    orig.data = (uint8_t *) bk->data + prefix;
     orig.size = bk->len - (prefix + suffix);
-    repl.data = (u_int8_t *) data->data + prefix;
+    repl.data = (uint8_t *) data->data + prefix;
     repl.size = data->size - (prefix + suffix);
     int ret = 0;
     if ((ret = CDB___bam_repl_log (dbp->dbenv, dbc->txn,
                                    &LSN (h), 0, dbp->log_fileid, PGNO (h),
-                                   &LSN (h), (u_int32_t) indx,
-                                   (u_int32_t) B_DISSET (bk->type), &orig,
-                                   &repl, (u_int32_t) prefix,
-                                   (u_int32_t) suffix)) != 0)
+                                   &LSN (h), (uint32_t) indx,
+                                   (uint32_t) B_DISSET (bk->type), &orig,
+                                   &repl, (uint32_t) prefix,
+                                   (uint32_t) suffix)) != 0)
       return (ret);
   }
 
@@ -789,8 +789,8 @@ CDB___bam_ritem (dbc, h, indx, data)
    * Set references to the first in-use byte on the page and the
    * first byte of the item being replaced.
    */
-  p = (u_int8_t *) h + HOFFSET (h);
-  t = (u_int8_t *) bk;
+  p = (uint8_t *) h + HOFFSET (h);
+  t = (uint8_t *) bk;
 
   /*
    * If the entry is growing in size, shift the beginning of the data
@@ -839,7 +839,7 @@ static int
 CDB___bam_ndup (dbc, h, indx)
      DBC *dbc;
      PAGE *h;
-     u_int32_t indx;
+     uint32_t indx;
 {
   BKEYDATA *bk;
   BOVERFLOW bo;

--- a/db/bt_rec.c
+++ b/db/bt_rec.c
@@ -913,7 +913,7 @@ CDB___bam_repl_recover (dbenv, dbtp, lsnp, redo, info)
   DB_MPOOLFILE *mpf;
   PAGE *pagep;
   int cmp_n, cmp_p, modified, ret;
-  u_int8_t *p;
+  uint8_t *p;
 
   COMPQUIET (info, NULL);
   REC_PRINT (CDB___bam_repl_print);

--- a/db/bt_recno.c
+++ b/db/bt_recno.c
@@ -29,11 +29,11 @@ static const char sccsid[] = "@(#)bt_recno.c  11.9 (Sleepycat) 10/29/99";
 #include "qam.h"
 
 static int CDB___ram_add
-__P ((DBC *, db_recno_t *, DBT *, u_int32_t, u_int32_t));
-static int CDB___ram_delete __P ((DB *, DB_TXN *, DBT *, u_int32_t));
+__P ((DBC *, db_recno_t *, DBT *, uint32_t, uint32_t));
+static int CDB___ram_delete __P ((DB *, DB_TXN *, DBT *, uint32_t));
 static int CDB___ram_fmap __P ((DBC *, db_recno_t));
 static int CDB___ram_i_delete __P ((DBC *));
-static int CDB___ram_put __P ((DB *, DB_TXN *, DBT *, DBT *, u_int32_t));
+static int CDB___ram_put __P ((DB *, DB_TXN *, DBT *, DBT *, uint32_t));
 static int CDB___ram_source __P ((DB *));
 static int CDB___ram_update __P ((DBC *, db_recno_t, int));
 static int CDB___ram_vmap __P ((DBC *, db_recno_t));
@@ -154,7 +154,7 @@ CDB___ram_delete (dbp, txn, key, flags)
      DB *dbp;
      DB_TXN *txn;
      DBT *key;
-     u_int32_t flags;
+     uint32_t flags;
 {
   BTREE_CURSOR *cp;
   DBC *dbc;
@@ -317,7 +317,7 @@ CDB___ram_put (dbp, txn, key, data, flags)
      DB *dbp;
      DB_TXN *txn;
      DBT *key, *data;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DBC *dbc;
   db_recno_t recno;
@@ -370,12 +370,12 @@ CDB___ram_put (dbp, txn, key, data, flags)
  * CDB___ram_c_del --
  *  Recno cursor->c_del function.
  *
- * PUBLIC: int CDB___ram_c_del __P((DBC *, u_int32_t));
+ * PUBLIC: int CDB___ram_c_del __P((DBC *, uint32_t));
  */
 int
 CDB___ram_c_del (dbc, flags)
      DBC *dbc;
-     u_int32_t flags;
+     uint32_t flags;
 {
   BTREE_CURSOR *cp;
   DB *dbp;
@@ -413,13 +413,13 @@ CDB___ram_c_del (dbc, flags)
  * CDB___ram_c_get --
  *  Recno cursor->c_get function.
  *
- * PUBLIC: int CDB___ram_c_get __P((DBC *, DBT *, DBT *, u_int32_t));
+ * PUBLIC: int CDB___ram_c_get __P((DBC *, DBT *, DBT *, uint32_t));
  */
 int
 CDB___ram_c_get (dbc, key, data, flags)
      DBC *dbc;
      DBT *key, *data;
-     u_int32_t flags;
+     uint32_t flags;
 {
   BTREE_CURSOR *cp, copy;
   DB *dbp;
@@ -594,13 +594,13 @@ err:if (stack)
  * CDB___ram_c_put --
  *  Recno cursor->c_put function.
  *
- * PUBLIC: int CDB___ram_c_put __P((DBC *, DBT *, DBT *, u_int32_t));
+ * PUBLIC: int CDB___ram_c_put __P((DBC *, DBT *, DBT *, uint32_t));
  */
 int
 CDB___ram_c_put (dbc, key, data, flags)
      DBC *dbc;
      DBT *key, *data;
-     u_int32_t flags;
+     uint32_t flags;
 {
   BTREE_CURSOR *cp, copy;
   DB *dbp;
@@ -874,7 +874,7 @@ CDB___ram_source (dbp)
 {
   BTREE *t;
   size_t size;
-  u_int32_t bytes, mbytes;
+  uint32_t bytes, mbytes;
   int ret;
 
   t = dbp->bt_internal;
@@ -932,7 +932,7 @@ CDB___ram_source (dbp)
                                &t->re_smap)) != 0)
     return (ret);
   t->re_cmap = t->re_smap;
-  t->re_emap = (u_int8_t *) t->re_smap + (t->re_msize = size);
+  t->re_emap = (uint8_t *) t->re_smap + (t->re_msize = size);
   t->re_irec =
     F_ISSET (dbp, DB_RE_FIXEDLEN) ? CDB___ram_fmap : CDB___ram_vmap;
   return (0);
@@ -955,7 +955,7 @@ CDB___ram_writeback (dbp)
   db_recno_t keyno;
   ssize_t nw;
   int ret, t_ret;
-  u_int8_t delim, *pad;
+  uint8_t delim, *pad;
 
   t = dbp->bt_internal;
 
@@ -1112,8 +1112,8 @@ CDB___ram_fmap (dbc, top)
   DB *dbp;
   DBT data;
   db_recno_t recno;
-  u_int32_t len;
-  u_int8_t *sp, *ep, *p;
+  uint32_t len;
+  uint8_t *sp, *ep, *p;
   int is_modified, ret;
 
   dbp = dbc->dbp;
@@ -1139,8 +1139,8 @@ CDB___ram_fmap (dbc, top)
   data.data = dbc->rdata.data;
   data.size = t->re_len;
 
-  sp = (u_int8_t *) t->re_cmap;
-  ep = (u_int8_t *) t->re_emap;
+  sp = (uint8_t *) t->re_cmap;
+  ep = (uint8_t *) t->re_emap;
   while (recno < top)
   {
     if (sp >= ep)
@@ -1195,7 +1195,7 @@ CDB___ram_vmap (dbc, top)
   BTREE *t;
   DBT data;
   db_recno_t recno;
-  u_int8_t *sp, *ep;
+  uint8_t *sp, *ep;
   int delim, is_modified, ret;
 
   t = dbc->dbp->bt_internal;
@@ -1208,8 +1208,8 @@ CDB___ram_vmap (dbc, top)
 
   memset (&data, 0, sizeof (data));
 
-  sp = (u_int8_t *) t->re_cmap;
-  ep = (u_int8_t *) t->re_emap;
+  sp = (uint8_t *) t->re_cmap;
+  ep = (uint8_t *) t->re_emap;
   while (recno < top)
   {
     if (sp >= ep)
@@ -1230,7 +1230,7 @@ CDB___ram_vmap (dbc, top)
      */
     if (t->re_last >= recno)
     {
-      data.size = sp - (u_int8_t *) data.data;
+      data.size = sp - (uint8_t *) data.data;
       ++recno;
       if ((ret = CDB___ram_add (dbc, &recno, &data, 0, 0)) != 0)
         goto err;
@@ -1255,7 +1255,7 @@ CDB___ram_add (dbc, recnop, data, flags, bi_flags)
      DBC *dbc;
      db_recno_t *recnop;
      DBT *data;
-     u_int32_t flags, bi_flags;
+     uint32_t flags, bi_flags;
 {
   BKEYDATA *bk;
   BTREE_CURSOR *cp;

--- a/db/bt_rsearch.c
+++ b/db/bt_rsearch.c
@@ -55,13 +55,13 @@ static const char sccsid[] = "@(#)bt_rsearch.c  11.8 (Sleepycat) 10/21/99";
  * CDB___bam_rsearch --
  *  Search a btree for a record number.
  *
- * PUBLIC: int CDB___bam_rsearch __P((DBC *, db_recno_t *, u_int32_t, int, int *));
+ * PUBLIC: int CDB___bam_rsearch __P((DBC *, db_recno_t *, uint32_t, int, int *));
  */
 int
 CDB___bam_rsearch (dbc, recnop, flags, stop, exactp)
      DBC *dbc;
      db_recno_t *recnop;
-     u_int32_t flags;
+     uint32_t flags;
      int stop, *exactp;
 {
   BINTERNAL *bi;
@@ -117,7 +117,7 @@ CDB___bam_rsearch (dbc, recnop, flags, stop, exactp)
    * for a write lock.
    */
   if (!stack &&
-      ((LF_ISSET (S_PARENT) && (u_int8_t) (stop + 1) >= h->level) ||
+      ((LF_ISSET (S_PARENT) && (uint8_t) (stop + 1) >= h->level) ||
        (LF_ISSET (S_WRITE) && h->level == LEAFLEVEL)))
   {
     (void) CDB_memp_fput (dbp->mpf, h, 0);
@@ -276,7 +276,7 @@ CDB___bam_rsearch (dbc, recnop, flags, stop, exactp)
        * never unlock it.
        */
       if ((LF_ISSET (S_PARENT) &&
-           (u_int8_t) (stop + 1) >= (u_int8_t) (h->level - 1)) ||
+           (uint8_t) (stop + 1) >= (uint8_t) (h->level - 1)) ||
           (h->level - 1) == LEAFLEVEL)
         stack = 1;
 
@@ -337,7 +337,7 @@ CDB___bam_adjust (dbc, adjust)
           (ret = CDB___bam_cadjust_log (dbp->dbenv,
                                         dbc->txn, &LSN (h), 0,
                                         dbp->log_fileid, PGNO (h), &LSN (h),
-                                        (u_int32_t) epg->indx, adjust,
+                                        (uint32_t) epg->indx, adjust,
                                         1)) != 0)
         return (ret);
 

--- a/db/bt_search.c
+++ b/db/bt_search.c
@@ -63,13 +63,13 @@ static const char sccsid[] = "@(#)bt_search.c  11.8 (Sleepycat) 10/21/99";
  *  Search a btree for a key.
  *
  * PUBLIC: int CDB___bam_search __P((DBC *,
- * PUBLIC:     const DBT *, u_int32_t, int, db_recno_t *, int *));
+ * PUBLIC:     const DBT *, uint32_t, int, db_recno_t *, int *));
  */
 int
 CDB___bam_search (dbc, key, flags, stop, recnop, exactp)
      DBC *dbc;
      const DBT *key;
-     u_int32_t flags;
+     uint32_t flags;
      int stop, *exactp;
      db_recno_t *recnop;
 {
@@ -128,7 +128,7 @@ CDB___bam_search (dbc, key, flags, stop, recnop, exactp)
    * for a write lock.
    */
   if (!stack &&
-      ((LF_ISSET (S_PARENT) && (u_int8_t) (stop + 1) >= h->level) ||
+      ((LF_ISSET (S_PARENT) && (uint8_t) (stop + 1) >= h->level) ||
        (LF_ISSET (S_WRITE) && h->level == LEAFLEVEL)))
   {
     (void) CDB_memp_fput (dbp->mpf, h, 0);
@@ -238,7 +238,7 @@ CDB___bam_search (dbc, key, flags, stop, recnop, exactp)
        * unlock it.
        */
       if ((LF_ISSET (S_PARENT) &&
-           (u_int8_t) (stop + 1) >= (u_int8_t) (h->level - 1)) ||
+           (uint8_t) (stop + 1) >= (uint8_t) (h->level - 1)) ||
           (h->level - 1) == LEAFLEVEL)
         stack = 1;
 

--- a/db/bt_split.c
+++ b/db/bt_split.c
@@ -226,7 +226,7 @@ CDB___bam_root (dbc, cp)
     if ((ret = CDB___bam_split_log (dbp->dbenv, dbc->txn,
                                     &LSN (cp->page), 0, dbp->log_fileid,
                                     PGNO (lp), &LSN (lp), PGNO (rp),
-                                    &LSN (rp), (u_int32_t) NUM_ENT (lp), 0,
+                                    &LSN (rp), (uint32_t) NUM_ENT (lp), 0,
                                     &__lsn, &__a)) != 0)
       goto err;
     LSN (lp) = LSN (rp) = LSN (cp->page);
@@ -389,7 +389,7 @@ CDB___bam_page (dbc, pp, cp)
                                     &LSN (cp->page), 0, dbp->log_fileid,
                                     PGNO (cp->page), &LSN (cp->page),
                                     PGNO (alloc_rp), &LSN (alloc_rp),
-                                    (u_int32_t) NUM_ENT (lp),
+                                    (uint32_t) NUM_ENT (lp),
                                     tp == NULL ? 0 : PGNO (tp),
                                     tp == NULL ? &__lsn : &LSN (tp),
                                     &__a)) != 0)
@@ -413,14 +413,14 @@ CDB___bam_page (dbc, pp, cp)
    */
   save_lsn = alloc_rp->lsn;
   memcpy (alloc_rp, rp, LOFFSET (rp));
-  memcpy ((u_int8_t *) alloc_rp + HOFFSET (rp),
-          (u_int8_t *) rp + HOFFSET (rp), dbp->pgsize - HOFFSET (rp));
+  memcpy ((uint8_t *) alloc_rp + HOFFSET (rp),
+          (uint8_t *) rp + HOFFSET (rp), dbp->pgsize - HOFFSET (rp));
   alloc_rp->lsn = save_lsn;
 
   save_lsn = cp->page->lsn;
   memcpy (cp->page, lp, LOFFSET (lp));
-  memcpy ((u_int8_t *) cp->page + HOFFSET (lp),
-          (u_int8_t *) lp + HOFFSET (lp), dbp->pgsize - HOFFSET (lp));
+  memcpy ((uint8_t *) cp->page + HOFFSET (lp),
+          (uint8_t *) lp + HOFFSET (lp), dbp->pgsize - HOFFSET (lp));
   cp->page->lsn = save_lsn;
 
   /* Fix up the next-page link. */
@@ -689,7 +689,7 @@ CDB___bam_pinsert (dbc, parent, lchild, rchild, space_check)
   RINTERNAL ri;
   db_indx_t off;
   db_recno_t nrecs;
-  u_int32_t n, nbytes, nksize;
+  uint32_t n, nbytes, nksize;
   int ret;
 
   dbp = dbc->dbp;
@@ -875,7 +875,7 @@ CDB___bam_pinsert (dbc, parent, lchild, rchild, space_check)
         (ret = CDB___bam_cadjust_log (dbp->dbenv,
                                       dbc->txn, &LSN (ppage), 0,
                                       dbp->log_fileid, PGNO (ppage),
-                                      &LSN (ppage), (u_int32_t) parent->indx,
+                                      &LSN (ppage), (uint32_t) parent->indx,
                                       -(int32_t) nrecs, (int32_t) 0)) != 0)
       return (ret);
 
@@ -1057,13 +1057,13 @@ sort:splitp = off;
  * CDB___bam_copy --
  *  Copy a set of records from one page to another.
  *
- * PUBLIC: int CDB___bam_copy __P((DB *, PAGE *, PAGE *, u_int32_t, u_int32_t));
+ * PUBLIC: int CDB___bam_copy __P((DB *, PAGE *, PAGE *, uint32_t, uint32_t));
  */
 int
 CDB___bam_copy (dbp, pp, cp, nxt, stop)
      DB *dbp;
      PAGE *pp, *cp;
-     u_int32_t nxt, stop;
+     uint32_t nxt, stop;
 {
   db_indx_t nbytes, off;
 

--- a/db/bt_stat.c
+++ b/db/bt_stat.c
@@ -29,14 +29,14 @@ static int CDB___bam_stat_callback __P ((DB *, PAGE *, void *, int *));
  * CDB___bam_stat --
  *  Gather/print the btree statistics
  *
- * PUBLIC: int CDB___bam_stat __P((DB *, void *, void *(*)(size_t), u_int32_t));
+ * PUBLIC: int CDB___bam_stat __P((DB *, void *, void *(*)(size_t), uint32_t));
  */
 int
 CDB___bam_stat (dbp, spp, db_malloc, flags)
      DB *dbp;
      void *spp;
      void *(*db_malloc) __P ((size_t));
-     u_int32_t flags;
+     uint32_t flags;
 {
   BTMETA *meta;
   BTREE *t;

--- a/db/bt_upgrade.c
+++ b/db/bt_upgrade.c
@@ -74,9 +74,9 @@ CDB___bam_upgrade6 (dbp, swapped, real_name, fhp)
 {
   DB_ENV *dbenv;
   ssize_t n;
-  u_int32_t tmp;
+  uint32_t tmp;
   int ret;
-  u_int8_t buf[256], *p;
+  uint8_t buf[256], *p;
 
   dbenv = dbp->dbenv;
 
@@ -129,7 +129,7 @@ CDB___bam_upgrade6 (dbp, swapped, real_name, fhp)
   tmp = 7;
   if (swapped)
     M_32_SWAP (tmp);
-  memcpy (buf + 16, &tmp, sizeof (u_int32_t));
+  memcpy (buf + 16, &tmp, sizeof (uint32_t));
 
   /*  0-23 done: Bytes 0-24 are unchanged. */
   p = buf + 24;
@@ -151,7 +151,7 @@ CDB___bam_upgrade6 (dbp, swapped, real_name, fhp)
   tmp = 1;
   if (swapped)
     M_32_SWAP (tmp);
-  memcpy (buf + 72, &tmp, sizeof (u_int32_t));
+  memcpy (buf + 72, &tmp, sizeof (uint32_t));
 
   /* Write the metadata page out. */
   if ((ret = CDB___os_seek (fhp, 0, 0, 0, 1, DB_OS_SEEK_SET)) != 0)

--- a/db/bt_verify.c
+++ b/db/bt_verify.c
@@ -27,13 +27,13 @@ static const char revid[] =
 #include "btree.h"
 
 static int __bam_safe_getdata
-__P ((DB *, PAGE *, u_int32_t, int, DBT *, int *));
+__P ((DB *, PAGE *, uint32_t, int, DBT *, int *));
 static int __bam_vrfy_inp
-__P ((DB *, VRFY_DBINFO *, PAGE *, db_pgno_t, db_indx_t *, u_int32_t));
+__P ((DB *, VRFY_DBINFO *, PAGE *, db_pgno_t, db_indx_t *, uint32_t));
 static int __bam_vrfy_treeorder
-__P ((DB *, db_pgno_t, PAGE *, BINTERNAL *, BINTERNAL *, u_int32_t));
+__P ((DB *, db_pgno_t, PAGE *, BINTERNAL *, BINTERNAL *, uint32_t));
 static int __ram_vrfy_inp
-__P ((DB *, VRFY_DBINFO *, PAGE *, db_pgno_t, db_indx_t *, u_int32_t));
+__P ((DB *, VRFY_DBINFO *, PAGE *, db_pgno_t, db_indx_t *, uint32_t));
 
 #define  OKFLAGS  (DB_AGGRESSIVE | DB_NOORDERCHK | DB_SALVAGE)
 
@@ -42,7 +42,7 @@ __P ((DB *, VRFY_DBINFO *, PAGE *, db_pgno_t, db_indx_t *, u_int32_t));
  *  Verify the btree-specific part of a metadata page.
  *
  * PUBLIC: int CDB___bam_vrfy_meta __P((DB *, VRFY_DBINFO *, BTMETA *,
- * PUBLIC:     db_pgno_t, u_int32_t));
+ * PUBLIC:     db_pgno_t, uint32_t));
  */
 int
 CDB___bam_vrfy_meta (dbp, vdp, meta, pgno, flags)
@@ -50,7 +50,7 @@ CDB___bam_vrfy_meta (dbp, vdp, meta, pgno, flags)
      VRFY_DBINFO *vdp;
      BTMETA *meta;
      db_pgno_t pgno;
-     u_int32_t flags;
+     uint32_t flags;
 {
   VRFY_PAGEINFO *pip;
   int isbad, t_ret, ret;
@@ -196,7 +196,7 @@ err:if ((t_ret = CDB___db_vrfy_putpageinfo (vdp, pip)) != 0 && ret == 0)
  *  Verify a recno leaf page.
  *
  * PUBLIC: int CDB___ram_vrfy_leaf __P((DB *, VRFY_DBINFO *, PAGE *, db_pgno_t,
- * PUBLIC:     u_int32_t));
+ * PUBLIC:     uint32_t));
  */
 int
 CDB___ram_vrfy_leaf (dbp, vdp, h, pgno, flags)
@@ -204,13 +204,13 @@ CDB___ram_vrfy_leaf (dbp, vdp, h, pgno, flags)
      VRFY_DBINFO *vdp;
      PAGE *h;
      db_pgno_t pgno;
-     u_int32_t flags;
+     uint32_t flags;
 {
   BKEYDATA *bk;
   VRFY_PAGEINFO *pip;
   db_indx_t i;
   int ret, t_ret, isbad;
-  u_int32_t re_len_guess, len;
+  uint32_t re_len_guess, len;
 
   isbad = 0;
   if ((ret = CDB___db_vrfy_getpageinfo (vdp, pgno, &pip)) != 0)
@@ -308,7 +308,7 @@ err:if ((t_ret = CDB___db_vrfy_putpageinfo (vdp, pip)) != 0 && ret == 0)
  *  Verify a btree leaf or internal page.
  *
  * PUBLIC: int CDB___bam_vrfy __P((DB *, VRFY_DBINFO *, PAGE *, db_pgno_t,
- * PUBLIC:     u_int32_t));
+ * PUBLIC:     uint32_t));
  */
 int
 CDB___bam_vrfy (dbp, vdp, h, pgno, flags)
@@ -316,7 +316,7 @@ CDB___bam_vrfy (dbp, vdp, h, pgno, flags)
      VRFY_DBINFO *vdp;
      PAGE *h;
      db_pgno_t pgno;
-     u_int32_t flags;
+     uint32_t flags;
 {
   VRFY_PAGEINFO *pip;
   int ret, t_ret, isbad;
@@ -415,14 +415,14 @@ __ram_vrfy_inp (dbp, vdp, h, pgno, nentriesp, flags)
      PAGE *h;
      db_pgno_t pgno;
      db_indx_t *nentriesp;
-     u_int32_t flags;
+     uint32_t flags;
 {
   RINTERNAL *ri;
   VRFY_CHILDINFO child;
   VRFY_PAGEINFO *pip;
   int ret, t_ret, isbad;
   db_indx_t himark, i, offset, nentries;
-  u_int8_t *pagelayout, *p;
+  uint8_t *pagelayout, *p;
 
   isbad = 0;
   memset (&child, 0, sizeof (VRFY_CHILDINFO));
@@ -445,7 +445,7 @@ __ram_vrfy_inp (dbp, vdp, h, pgno, nentriesp, flags)
   memset (pagelayout, 0, dbp->pgsize);
   for (i = 0; i < NUM_ENT (h); i++)
   {
-    if ((u_int8_t *) h->inp + i >= (u_int8_t *) h + himark)
+    if ((uint8_t *) h->inp + i >= (uint8_t *) h + himark)
     {
       EPRINT ((dbp->dbenv,
                "Page %lu entries listing %lu overlaps data", pgno, i));
@@ -458,7 +458,7 @@ __ram_vrfy_inp (dbp, vdp, h, pgno, nentriesp, flags)
      * somewhere after the inp array and before the end of the
      * page.
      */
-    if (offset <= ((u_int8_t *) h->inp + i - (u_int8_t *) h) ||
+    if (offset <= ((uint8_t *) h->inp + i - (uint8_t *) h) ||
         offset > dbp->pgsize - RINTERNAL_SIZE)
     {
       isbad = 1;
@@ -529,16 +529,16 @@ __bam_vrfy_inp (dbp, vdp, h, pgno, nentriesp, flags)
      PAGE *h;
      db_pgno_t pgno;
      db_indx_t *nentriesp;
-     u_int32_t flags;
+     uint32_t flags;
 {
   BKEYDATA *bk;
   BOVERFLOW *bo;
   VRFY_CHILDINFO child;
   VRFY_PAGEINFO *pip;
   int isbad, initem, isdupitem, ret, t_ret;
-  u_int32_t himark, offset;     /* These would be db_indx_ts but for algnmt. */
+  uint32_t himark, offset;     /* These would be db_indx_ts but for algnmt. */
   db_indx_t i, endoff, nentries;
-  u_int8_t *pagelayout;
+  uint8_t *pagelayout;
 
   isbad = isdupitem = 0;
   nentries = 0;
@@ -879,7 +879,7 @@ err:if (nentriesp != NULL)
  *  we shouldn't be called if any exist.
  *
  * PUBLIC: int CDB___bam_vrfy_itemorder __P((DB *, VRFY_DBINFO *, PAGE *,
- * PUBLIC:     db_pgno_t, u_int32_t, int, int, u_int32_t));
+ * PUBLIC:     db_pgno_t, uint32_t, int, int, uint32_t));
  */
 int
 CDB___bam_vrfy_itemorder (dbp, vdp, h, pgno, nentries, ovflok, hasdups, flags)
@@ -887,9 +887,9 @@ CDB___bam_vrfy_itemorder (dbp, vdp, h, pgno, nentries, ovflok, hasdups, flags)
      VRFY_DBINFO *vdp;
      PAGE *h;
      db_pgno_t pgno;
-     u_int32_t nentries;
+     uint32_t nentries;
      int ovflok, hasdups;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DBT dbta, dbtb, dup1, dup2, *p1, *p2, *tmp;
   BTREE *bt;
@@ -1194,20 +1194,20 @@ err:if (pip != NULL &&
  *  database containing subdbs).
  *
  * PUBLIC: int CDB___bam_vrfy_structure __P((DB *, VRFY_DBINFO *, db_pgno_t,
- * PUBLIC:     u_int32_t));
+ * PUBLIC:     uint32_t));
  */
 int
 CDB___bam_vrfy_structure (dbp, vdp, meta_pgno, flags)
      DB *dbp;
      VRFY_DBINFO *vdp;
      db_pgno_t meta_pgno;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB *pgset;
   VRFY_PAGEINFO *mip, *rip;
   db_pgno_t root, p;
   int t_ret, ret;
-  u_int32_t nrecs, level, relen, stflags;
+  uint32_t nrecs, level, relen, stflags;
 
   mip = rip = 0;
   pgset = vdp->pgset;
@@ -1308,7 +1308,7 @@ err:if (mip != NULL &&
  *  offpage dup trees, including from hash.
  *
  * PUBLIC: int CDB___bam_vrfy_subtree __P((DB *, VRFY_DBINFO *, db_pgno_t, void *,
- * PUBLIC:     void *, u_int32_t, u_int32_t *, u_int32_t *, u_int32_t *));
+ * PUBLIC:     void *, uint32_t, uint32_t *, uint32_t *, uint32_t *));
  */
 int
 CDB___bam_vrfy_subtree (dbp, vdp, pgno, l, r, flags, levelp, nrecsp, relenp)
@@ -1316,7 +1316,7 @@ CDB___bam_vrfy_subtree (dbp, vdp, pgno, l, r, flags, levelp, nrecsp, relenp)
      VRFY_DBINFO *vdp;
      db_pgno_t pgno;
      void *l, *r;
-     u_int32_t flags, *levelp, *nrecsp, *relenp;
+     uint32_t flags, *levelp, *nrecsp, *relenp;
 {
   BINTERNAL *li, *ri, *lp, *rp;
   DB *pgset;
@@ -1326,7 +1326,7 @@ CDB___bam_vrfy_subtree (dbp, vdp, pgno, l, r, flags, levelp, nrecsp, relenp)
   db_recno_t nrecs, child_nrecs;
   db_indx_t i;
   int ret, t_ret, isbad, toplevel, p;
-  u_int32_t level, child_level, stflags, child_relen, relen;
+  uint32_t level, child_level, stflags, child_relen, relen;
   DBC *cc;
 
   ret = isbad = 0;
@@ -1752,7 +1752,7 @@ __bam_vrfy_treeorder (dbp, pgno, h, lp, rp, flags)
      db_pgno_t pgno;
      PAGE *h;
      BINTERNAL *lp, *rp;
-     u_int32_t flags;
+     uint32_t flags;
 {
   BOVERFLOW *bo;
   BTREE *t;
@@ -1885,28 +1885,28 @@ __bam_vrfy_treeorder (dbp, pgno, h, lp, rp, flags)
  *  Safely dump out anything that looks like a key on an alleged
  *  btree leaf page.
  *
- * PUBLIC: int CDB___bam_salvage __P((DB *, VRFY_DBINFO *, db_pgno_t, u_int32_t,
+ * PUBLIC: int CDB___bam_salvage __P((DB *, VRFY_DBINFO *, db_pgno_t, uint32_t,
  * PUBLIC:     PAGE *, void *, int (*)(void *, const void *), DBT *,
- * PUBLIC:     u_int32_t));
+ * PUBLIC:     uint32_t));
  */
 int
 CDB___bam_salvage (dbp, vdp, pgno, pgtype, h, handle, callback, key, flags)
      DB *dbp;
      VRFY_DBINFO *vdp;
      db_pgno_t pgno;
-     u_int32_t pgtype;
+     uint32_t pgtype;
      PAGE *h;
      void *handle;
      int (*callback) __P ((void *, const void *));
      DBT *key;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DBT dbt, unkdbt;
   BKEYDATA *bk;
   BOVERFLOW *bo;
   db_indx_t i, beg, end;
-  u_int32_t himark;
-  u_int8_t *pgmap;
+  uint32_t himark;
+  uint8_t *pgmap;
   void *ovflbuf;
   int t_ret, ret, err_ret;
 
@@ -2097,7 +2097,7 @@ err:if (pgmap != NULL)
  *  a dup tree, calling CDB___db_salvage_duptree on each child page.
  *
  * PUBLIC: int CDB___bam_salvage_walkdupint __P((DB *, VRFY_DBINFO *, PAGE *,
- * PUBLIC:     DBT *, void *, int (*)(void *, const void *), u_int32_t));
+ * PUBLIC:     DBT *, void *, int (*)(void *, const void *), uint32_t));
  */
 int
 CDB___bam_salvage_walkdupint (dbp, vdp, h, key, handle, callback, flags)
@@ -2107,7 +2107,7 @@ CDB___bam_salvage_walkdupint (dbp, vdp, h, key, handle, callback, flags)
      DBT *key;
      void *handle;
      int (*callback) __P ((void *, const void *));
-     u_int32_t flags;
+     uint32_t flags;
 {
   RINTERNAL *ri;
   BINTERNAL *bi;
@@ -2160,14 +2160,14 @@ CDB___bam_salvage_walkdupint (dbp, vdp, h, key, handle, callback, flags)
  *  for the left branch.
  *
  * PUBLIC: int CDB___bam_meta2pgset __P((DB *, VRFY_DBINFO *, BTMETA *,
- * PUBLIC:     u_int32_t, DB *));
+ * PUBLIC:     uint32_t, DB *));
  */
 int
 CDB___bam_meta2pgset (dbp, vdp, btmeta, flags, pgset)
      DB *dbp;
      VRFY_DBINFO *vdp;
      BTMETA *btmeta;
-     u_int32_t flags;
+     uint32_t flags;
      DB *pgset;
 {
   BINTERNAL *bi;
@@ -2280,7 +2280,7 @@ static int
 __bam_safe_getdata (dbp, h, i, ovflok, dbt, freedbtp)
      DB *dbp;
      PAGE *h;
-     u_int32_t i;
+     uint32_t i;
      int ovflok;
      DBT *dbt;
      int *freedbtp;

--- a/db/btree.h
+++ b/db/btree.h
@@ -194,7 +194,7 @@ struct __cursor
    * be specially adjusted on the next operation.
    */
 #define  C_DELETED  0x0001      /* Record was deleted. */
-  u_int32_t flags;
+  uint32_t flags;
 };
 
 /*
@@ -210,8 +210,8 @@ struct __btree
   db_pgno_t bt_meta;            /* Database meta-data page. */
   db_pgno_t bt_root;            /* Database root page. */
 
-  u_int32_t bt_maxkey;          /* Maximum keys per page. */
-  u_int32_t bt_minkey;          /* Minimum keys per page. */
+  uint32_t bt_maxkey;          /* Maximum keys per page. */
+  uint32_t bt_minkey;          /* Minimum keys per page. */
 
   /* Btree comparison function. */
   int (*bt_compare) __P ((const DBT *, const DBT *));
@@ -221,7 +221,7 @@ struct __btree
   /* Recno access method. */
   int re_pad;                   /* Fixed-length padding byte. */
   int re_delim;                 /* Variable-length delimiting byte. */
-  u_int32_t re_len;             /* Length for fixed-length records. */
+  uint32_t re_len;             /* Length for fixed-length records. */
   char *re_source;              /* Source file name. */
 
   /*
@@ -241,7 +241,7 @@ struct __btree
 
 #define  RECNO_EOF  0x01        /* EOF on backing source file. */
 #define  RECNO_MODIFIED  0x02   /* Tree was modified. */
-  u_int32_t flags;
+  uint32_t flags;
 };
 
 

--- a/db/btree_auto.c
+++ b/db/btree_auto.c
@@ -22,19 +22,19 @@ CDB___bam_pg_alloc_log (dbenv, txnid, ret_lsnp, flags,
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
+     uint32_t flags;
      int32_t fileid;
      DB_LSN *meta_lsn;
      DB_LSN *page_lsn;
      db_pgno_t pgno;
-     u_int32_t ptype;
+     uint32_t ptype;
      db_pgno_t next;
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t rectype, txn_num;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -80,7 +80,7 @@ CDB___bam_pg_alloc_log (dbenv, txnid, ret_lsnp, flags,
   bp += sizeof (ptype);
   memcpy (bp, &next, sizeof (next));
   bp += sizeof (next);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -97,7 +97,7 @@ CDB___bam_pg_alloc_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __bam_pg_alloc_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -134,7 +134,7 @@ CDB___bam_pg_alloc_read (recbuf, argpp)
      __bam_pg_alloc_args **argpp;
 {
   __bam_pg_alloc_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__bam_pg_alloc_args) +
@@ -171,7 +171,7 @@ CDB___bam_pg_free_log (dbenv, txnid, ret_lsnp, flags,
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
+     uint32_t flags;
      int32_t fileid;
      db_pgno_t pgno;
      DB_LSN *meta_lsn;
@@ -180,10 +180,10 @@ CDB___bam_pg_free_log (dbenv, txnid, ret_lsnp, flags,
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t zero;
-  u_int32_t rectype, txn_num;
+  uint32_t zero;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -201,7 +201,7 @@ CDB___bam_pg_free_log (dbenv, txnid, ret_lsnp, flags,
     + sizeof (fileid)
     + sizeof (pgno)
     + sizeof (*meta_lsn)
-    + sizeof (u_int32_t) + (header == NULL ? 0 : header->size)
+    + sizeof (uint32_t) + (header == NULL ? 0 : header->size)
     + sizeof (next);
   if ((ret = CDB___os_malloc (logrec.size, NULL, &logrec.data)) != 0)
     return (ret);
@@ -225,8 +225,8 @@ CDB___bam_pg_free_log (dbenv, txnid, ret_lsnp, flags,
   if (header == NULL)
   {
     zero = 0;
-    memcpy (bp, &zero, sizeof (u_int32_t));
-    bp += sizeof (u_int32_t);
+    memcpy (bp, &zero, sizeof (uint32_t));
+    bp += sizeof (uint32_t);
   }
   else
   {
@@ -237,7 +237,7 @@ CDB___bam_pg_free_log (dbenv, txnid, ret_lsnp, flags,
   }
   memcpy (bp, &next, sizeof (next));
   bp += sizeof (next);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -254,7 +254,7 @@ CDB___bam_pg_free_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __bam_pg_free_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -279,7 +279,7 @@ CDB___bam_pg_free_print (notused1, dbtp, lsnp, notused2, notused3)
   printf ("\theader: ");
   for (i = 0; i < argp->header.size; i++)
   {
-    ch = ((u_int8_t *) argp->header.data)[i];
+    ch = ((uint8_t *) argp->header.data)[i];
     if (isprint (ch) || ch == 0xa)
       putchar (ch);
     else
@@ -298,7 +298,7 @@ CDB___bam_pg_free_read (recbuf, argpp)
      __bam_pg_free_args **argpp;
 {
   __bam_pg_free_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__bam_pg_free_args) +
@@ -320,8 +320,8 @@ CDB___bam_pg_free_read (recbuf, argpp)
   memcpy (&argp->meta_lsn, bp, sizeof (argp->meta_lsn));
   bp += sizeof (argp->meta_lsn);
   memset (&argp->header, 0, sizeof (argp->header));
-  memcpy (&argp->header.size, bp, sizeof (u_int32_t));
-  bp += sizeof (u_int32_t);
+  memcpy (&argp->header.size, bp, sizeof (uint32_t));
+  bp += sizeof (uint32_t);
   argp->header.data = bp;
   bp += argp->header.size;
   memcpy (&argp->next, bp, sizeof (argp->next));
@@ -336,23 +336,23 @@ CDB___bam_split_log (dbenv, txnid, ret_lsnp, flags,
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
+     uint32_t flags;
      int32_t fileid;
      db_pgno_t left;
      DB_LSN *llsn;
      db_pgno_t right;
      DB_LSN *rlsn;
-     u_int32_t indx;
+     uint32_t indx;
      db_pgno_t npgno;
      DB_LSN *nlsn;
      const DBT *pg;
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t zero;
-  u_int32_t rectype, txn_num;
+  uint32_t zero;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -374,7 +374,7 @@ CDB___bam_split_log (dbenv, txnid, ret_lsnp, flags,
     + sizeof (*rlsn)
     + sizeof (indx)
     + sizeof (npgno)
-    + sizeof (*nlsn) + sizeof (u_int32_t) + (pg == NULL ? 0 : pg->size);
+    + sizeof (*nlsn) + sizeof (uint32_t) + (pg == NULL ? 0 : pg->size);
   if ((ret = CDB___os_malloc (logrec.size, NULL, &logrec.data)) != 0)
     return (ret);
 
@@ -413,8 +413,8 @@ CDB___bam_split_log (dbenv, txnid, ret_lsnp, flags,
   if (pg == NULL)
   {
     zero = 0;
-    memcpy (bp, &zero, sizeof (u_int32_t));
-    bp += sizeof (u_int32_t);
+    memcpy (bp, &zero, sizeof (uint32_t));
+    bp += sizeof (uint32_t);
   }
   else
   {
@@ -423,7 +423,7 @@ CDB___bam_split_log (dbenv, txnid, ret_lsnp, flags,
     memcpy (bp, pg->data, pg->size);
     bp += pg->size;
   }
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -440,7 +440,7 @@ CDB___bam_split_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __bam_split_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -472,7 +472,7 @@ CDB___bam_split_print (notused1, dbtp, lsnp, notused2, notused3)
   printf ("\tpg: ");
   for (i = 0; i < argp->pg.size; i++)
   {
-    ch = ((u_int8_t *) argp->pg.data)[i];
+    ch = ((uint8_t *) argp->pg.data)[i];
     if (isprint (ch) || ch == 0xa)
       putchar (ch);
     else
@@ -490,7 +490,7 @@ CDB___bam_split_read (recbuf, argpp)
      __bam_split_args **argpp;
 {
   __bam_split_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__bam_split_args) +
@@ -522,8 +522,8 @@ CDB___bam_split_read (recbuf, argpp)
   memcpy (&argp->nlsn, bp, sizeof (argp->nlsn));
   bp += sizeof (argp->nlsn);
   memset (&argp->pg, 0, sizeof (argp->pg));
-  memcpy (&argp->pg.size, bp, sizeof (u_int32_t));
-  bp += sizeof (u_int32_t);
+  memcpy (&argp->pg.size, bp, sizeof (uint32_t));
+  bp += sizeof (uint32_t);
   argp->pg.data = bp;
   bp += argp->pg.size;
   *argpp = argp;
@@ -536,7 +536,7 @@ CDB___bam_rsplit_log (dbenv, txnid, ret_lsnp, flags,
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
+     uint32_t flags;
      int32_t fileid;
      db_pgno_t pgno;
      const DBT *pgdbt;
@@ -546,10 +546,10 @@ CDB___bam_rsplit_log (dbenv, txnid, ret_lsnp, flags,
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t zero;
-  u_int32_t rectype, txn_num;
+  uint32_t zero;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -566,9 +566,9 @@ CDB___bam_rsplit_log (dbenv, txnid, ret_lsnp, flags,
   logrec.size = sizeof (rectype) + sizeof (txn_num) + sizeof (DB_LSN)
     + sizeof (fileid)
     + sizeof (pgno)
-    + sizeof (u_int32_t) + (pgdbt == NULL ? 0 : pgdbt->size)
+    + sizeof (uint32_t) + (pgdbt == NULL ? 0 : pgdbt->size)
     + sizeof (nrec)
-    + sizeof (u_int32_t) + (rootent == NULL ? 0 : rootent->size)
+    + sizeof (uint32_t) + (rootent == NULL ? 0 : rootent->size)
     + sizeof (*rootlsn);
   if ((ret = CDB___os_malloc (logrec.size, NULL, &logrec.data)) != 0)
     return (ret);
@@ -587,8 +587,8 @@ CDB___bam_rsplit_log (dbenv, txnid, ret_lsnp, flags,
   if (pgdbt == NULL)
   {
     zero = 0;
-    memcpy (bp, &zero, sizeof (u_int32_t));
-    bp += sizeof (u_int32_t);
+    memcpy (bp, &zero, sizeof (uint32_t));
+    bp += sizeof (uint32_t);
   }
   else
   {
@@ -602,8 +602,8 @@ CDB___bam_rsplit_log (dbenv, txnid, ret_lsnp, flags,
   if (rootent == NULL)
   {
     zero = 0;
-    memcpy (bp, &zero, sizeof (u_int32_t));
-    bp += sizeof (u_int32_t);
+    memcpy (bp, &zero, sizeof (uint32_t));
+    bp += sizeof (uint32_t);
   }
   else
   {
@@ -617,7 +617,7 @@ CDB___bam_rsplit_log (dbenv, txnid, ret_lsnp, flags,
   else
     memset (bp, 0, sizeof (*rootlsn));
   bp += sizeof (*rootlsn);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -634,7 +634,7 @@ CDB___bam_rsplit_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __bam_rsplit_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -657,7 +657,7 @@ CDB___bam_rsplit_print (notused1, dbtp, lsnp, notused2, notused3)
   printf ("\tpgdbt: ");
   for (i = 0; i < argp->pgdbt.size; i++)
   {
-    ch = ((u_int8_t *) argp->pgdbt.data)[i];
+    ch = ((uint8_t *) argp->pgdbt.data)[i];
     if (isprint (ch) || ch == 0xa)
       putchar (ch);
     else
@@ -668,7 +668,7 @@ CDB___bam_rsplit_print (notused1, dbtp, lsnp, notused2, notused3)
   printf ("\trootent: ");
   for (i = 0; i < argp->rootent.size; i++)
   {
-    ch = ((u_int8_t *) argp->rootent.data)[i];
+    ch = ((uint8_t *) argp->rootent.data)[i];
     if (isprint (ch) || ch == 0xa)
       putchar (ch);
     else
@@ -688,7 +688,7 @@ CDB___bam_rsplit_read (recbuf, argpp)
      __bam_rsplit_args **argpp;
 {
   __bam_rsplit_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__bam_rsplit_args) +
@@ -708,15 +708,15 @@ CDB___bam_rsplit_read (recbuf, argpp)
   memcpy (&argp->pgno, bp, sizeof (argp->pgno));
   bp += sizeof (argp->pgno);
   memset (&argp->pgdbt, 0, sizeof (argp->pgdbt));
-  memcpy (&argp->pgdbt.size, bp, sizeof (u_int32_t));
-  bp += sizeof (u_int32_t);
+  memcpy (&argp->pgdbt.size, bp, sizeof (uint32_t));
+  bp += sizeof (uint32_t);
   argp->pgdbt.data = bp;
   bp += argp->pgdbt.size;
   memcpy (&argp->nrec, bp, sizeof (argp->nrec));
   bp += sizeof (argp->nrec);
   memset (&argp->rootent, 0, sizeof (argp->rootent));
-  memcpy (&argp->rootent.size, bp, sizeof (u_int32_t));
-  bp += sizeof (u_int32_t);
+  memcpy (&argp->rootent.size, bp, sizeof (uint32_t));
+  bp += sizeof (uint32_t);
   argp->rootent.data = bp;
   bp += argp->rootent.size;
   memcpy (&argp->rootlsn, bp, sizeof (argp->rootlsn));
@@ -731,19 +731,19 @@ CDB___bam_adj_log (dbenv, txnid, ret_lsnp, flags,
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
+     uint32_t flags;
      int32_t fileid;
      db_pgno_t pgno;
      DB_LSN *lsn;
-     u_int32_t indx;
-     u_int32_t indx_copy;
-     u_int32_t is_insert;
+     uint32_t indx;
+     uint32_t indx_copy;
+     uint32_t is_insert;
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t rectype, txn_num;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -786,7 +786,7 @@ CDB___bam_adj_log (dbenv, txnid, ret_lsnp, flags,
   bp += sizeof (indx_copy);
   memcpy (bp, &is_insert, sizeof (is_insert));
   bp += sizeof (is_insert);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -803,7 +803,7 @@ CDB___bam_adj_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __bam_adj_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -839,7 +839,7 @@ CDB___bam_adj_read (recbuf, argpp)
      __bam_adj_args **argpp;
 {
   __bam_adj_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__bam_adj_args) +
@@ -876,19 +876,19 @@ CDB___bam_cadjust_log (dbenv, txnid, ret_lsnp, flags,
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
+     uint32_t flags;
      int32_t fileid;
      db_pgno_t pgno;
      DB_LSN *lsn;
-     u_int32_t indx;
+     uint32_t indx;
      int32_t adjust;
      int32_t total;
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t rectype, txn_num;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -931,7 +931,7 @@ CDB___bam_cadjust_log (dbenv, txnid, ret_lsnp, flags,
   bp += sizeof (adjust);
   memcpy (bp, &total, sizeof (total));
   bp += sizeof (total);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -948,7 +948,7 @@ CDB___bam_cadjust_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __bam_cadjust_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -984,7 +984,7 @@ CDB___bam_cadjust_read (recbuf, argpp)
      __bam_cadjust_args **argpp;
 {
   __bam_cadjust_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__bam_cadjust_args) +
@@ -1020,17 +1020,17 @@ CDB___bam_cdel_log (dbenv, txnid, ret_lsnp, flags, fileid, pgno, lsn, indx)
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
+     uint32_t flags;
      int32_t fileid;
      db_pgno_t pgno;
      DB_LSN *lsn;
-     u_int32_t indx;
+     uint32_t indx;
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t rectype, txn_num;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -1067,7 +1067,7 @@ CDB___bam_cdel_log (dbenv, txnid, ret_lsnp, flags, fileid, pgno, lsn, indx)
   bp += sizeof (*lsn);
   memcpy (bp, &indx, sizeof (indx));
   bp += sizeof (indx);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -1084,7 +1084,7 @@ CDB___bam_cdel_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __bam_cdel_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -1118,7 +1118,7 @@ CDB___bam_cdel_read (recbuf, argpp)
      __bam_cdel_args **argpp;
 {
   __bam_cdel_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__bam_cdel_args) +
@@ -1152,23 +1152,23 @@ CDB___bam_repl_log (dbenv, txnid, ret_lsnp, flags,
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
+     uint32_t flags;
      int32_t fileid;
      db_pgno_t pgno;
      DB_LSN *lsn;
-     u_int32_t indx;
-     u_int32_t isdeleted;
+     uint32_t indx;
+     uint32_t isdeleted;
      const DBT *orig;
      const DBT *repl;
-     u_int32_t prefix;
-     u_int32_t suffix;
+     uint32_t prefix;
+     uint32_t suffix;
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t zero;
-  u_int32_t rectype, txn_num;
+  uint32_t zero;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -1188,8 +1188,8 @@ CDB___bam_repl_log (dbenv, txnid, ret_lsnp, flags,
     + sizeof (*lsn)
     + sizeof (indx)
     + sizeof (isdeleted)
-    + sizeof (u_int32_t) + (orig == NULL ? 0 : orig->size)
-    + sizeof (u_int32_t) + (repl == NULL ? 0 : repl->size)
+    + sizeof (uint32_t) + (orig == NULL ? 0 : orig->size)
+    + sizeof (uint32_t) + (repl == NULL ? 0 : repl->size)
     + sizeof (prefix) + sizeof (suffix);
   if ((ret = CDB___os_malloc (logrec.size, NULL, &logrec.data)) != 0)
     return (ret);
@@ -1217,8 +1217,8 @@ CDB___bam_repl_log (dbenv, txnid, ret_lsnp, flags,
   if (orig == NULL)
   {
     zero = 0;
-    memcpy (bp, &zero, sizeof (u_int32_t));
-    bp += sizeof (u_int32_t);
+    memcpy (bp, &zero, sizeof (uint32_t));
+    bp += sizeof (uint32_t);
   }
   else
   {
@@ -1230,8 +1230,8 @@ CDB___bam_repl_log (dbenv, txnid, ret_lsnp, flags,
   if (repl == NULL)
   {
     zero = 0;
-    memcpy (bp, &zero, sizeof (u_int32_t));
-    bp += sizeof (u_int32_t);
+    memcpy (bp, &zero, sizeof (uint32_t));
+    bp += sizeof (uint32_t);
   }
   else
   {
@@ -1244,7 +1244,7 @@ CDB___bam_repl_log (dbenv, txnid, ret_lsnp, flags,
   bp += sizeof (prefix);
   memcpy (bp, &suffix, sizeof (suffix));
   bp += sizeof (suffix);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -1261,7 +1261,7 @@ CDB___bam_repl_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __bam_repl_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -1288,7 +1288,7 @@ CDB___bam_repl_print (notused1, dbtp, lsnp, notused2, notused3)
   printf ("\torig: ");
   for (i = 0; i < argp->orig.size; i++)
   {
-    ch = ((u_int8_t *) argp->orig.data)[i];
+    ch = ((uint8_t *) argp->orig.data)[i];
     if (isprint (ch) || ch == 0xa)
       putchar (ch);
     else
@@ -1298,7 +1298,7 @@ CDB___bam_repl_print (notused1, dbtp, lsnp, notused2, notused3)
   printf ("\trepl: ");
   for (i = 0; i < argp->repl.size; i++)
   {
-    ch = ((u_int8_t *) argp->repl.data)[i];
+    ch = ((uint8_t *) argp->repl.data)[i];
     if (isprint (ch) || ch == 0xa)
       putchar (ch);
     else
@@ -1318,7 +1318,7 @@ CDB___bam_repl_read (recbuf, argpp)
      __bam_repl_args **argpp;
 {
   __bam_repl_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__bam_repl_args) +
@@ -1344,13 +1344,13 @@ CDB___bam_repl_read (recbuf, argpp)
   memcpy (&argp->isdeleted, bp, sizeof (argp->isdeleted));
   bp += sizeof (argp->isdeleted);
   memset (&argp->orig, 0, sizeof (argp->orig));
-  memcpy (&argp->orig.size, bp, sizeof (u_int32_t));
-  bp += sizeof (u_int32_t);
+  memcpy (&argp->orig.size, bp, sizeof (uint32_t));
+  bp += sizeof (uint32_t);
   argp->orig.data = bp;
   bp += argp->orig.size;
   memset (&argp->repl, 0, sizeof (argp->repl));
-  memcpy (&argp->repl.size, bp, sizeof (u_int32_t));
-  bp += sizeof (u_int32_t);
+  memcpy (&argp->repl.size, bp, sizeof (uint32_t));
+  bp += sizeof (uint32_t);
   argp->repl.data = bp;
   bp += argp->repl.size;
   memcpy (&argp->prefix, bp, sizeof (argp->prefix));
@@ -1367,7 +1367,7 @@ CDB___bam_root_log (dbenv, txnid, ret_lsnp, flags,
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
+     uint32_t flags;
      int32_t fileid;
      db_pgno_t meta_pgno;
      db_pgno_t root_pgno;
@@ -1375,9 +1375,9 @@ CDB___bam_root_log (dbenv, txnid, ret_lsnp, flags,
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t rectype, txn_num;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -1415,7 +1415,7 @@ CDB___bam_root_log (dbenv, txnid, ret_lsnp, flags,
   else
     memset (bp, 0, sizeof (*meta_lsn));
   bp += sizeof (*meta_lsn);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -1432,7 +1432,7 @@ CDB___bam_root_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __bam_root_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -1466,7 +1466,7 @@ CDB___bam_root_read (recbuf, argpp)
      __bam_root_args **argpp;
 {
   __bam_root_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__bam_root_args) +

--- a/db/btree_auto.h
+++ b/db/btree_auto.h
@@ -7,20 +7,20 @@
 
 typedef struct _bam_pg_alloc_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
   int32_t fileid;
   DB_LSN meta_lsn;
   DB_LSN page_lsn;
   db_pgno_t pgno;
-  u_int32_t ptype;
+  uint32_t ptype;
   db_pgno_t next;
 } __bam_pg_alloc_args;
 
 int CDB___bam_pg_alloc_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, int32_t, DB_LSN *, DB_LSN *,
-      db_pgno_t, u_int32_t, db_pgno_t));
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, int32_t, DB_LSN *, DB_LSN *,
+      db_pgno_t, uint32_t, db_pgno_t));
 int CDB___bam_pg_alloc_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___bam_pg_alloc_read __P ((void *, __bam_pg_alloc_args **));
 
@@ -28,7 +28,7 @@ int CDB___bam_pg_alloc_read __P ((void *, __bam_pg_alloc_args **));
 
 typedef struct _bam_pg_free_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
   int32_t fileid;
@@ -39,7 +39,7 @@ typedef struct _bam_pg_free_args
 } __bam_pg_free_args;
 
 int CDB___bam_pg_free_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, int32_t, db_pgno_t, DB_LSN *,
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, int32_t, db_pgno_t, DB_LSN *,
       const DBT *, db_pgno_t));
 int CDB___bam_pg_free_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___bam_pg_free_read __P ((void *, __bam_pg_free_args **));
@@ -48,7 +48,7 @@ int CDB___bam_pg_free_read __P ((void *, __bam_pg_free_args **));
 
 typedef struct _bam_split_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
   int32_t fileid;
@@ -56,15 +56,15 @@ typedef struct _bam_split_args
   DB_LSN llsn;
   db_pgno_t right;
   DB_LSN rlsn;
-  u_int32_t indx;
+  uint32_t indx;
   db_pgno_t npgno;
   DB_LSN nlsn;
   DBT pg;
 } __bam_split_args;
 
 int CDB___bam_split_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, int32_t, db_pgno_t, DB_LSN *,
-      db_pgno_t, DB_LSN *, u_int32_t, db_pgno_t, DB_LSN *, const DBT *));
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, int32_t, db_pgno_t, DB_LSN *,
+      db_pgno_t, DB_LSN *, uint32_t, db_pgno_t, DB_LSN *, const DBT *));
 int CDB___bam_split_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___bam_split_read __P ((void *, __bam_split_args **));
 
@@ -72,7 +72,7 @@ int CDB___bam_split_read __P ((void *, __bam_split_args **));
 
 typedef struct _bam_rsplit_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
   int32_t fileid;
@@ -84,7 +84,7 @@ typedef struct _bam_rsplit_args
 } __bam_rsplit_args;
 
 int CDB___bam_rsplit_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, int32_t, db_pgno_t,
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, int32_t, db_pgno_t,
       const DBT *, db_pgno_t, const DBT *, DB_LSN *));
 int CDB___bam_rsplit_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___bam_rsplit_read __P ((void *, __bam_rsplit_args **));
@@ -93,20 +93,20 @@ int CDB___bam_rsplit_read __P ((void *, __bam_rsplit_args **));
 
 typedef struct _bam_adj_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
   int32_t fileid;
   db_pgno_t pgno;
   DB_LSN lsn;
-  u_int32_t indx;
-  u_int32_t indx_copy;
-  u_int32_t is_insert;
+  uint32_t indx;
+  uint32_t indx_copy;
+  uint32_t is_insert;
 } __bam_adj_args;
 
 int CDB___bam_adj_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, int32_t, db_pgno_t, DB_LSN *,
-      u_int32_t, u_int32_t, u_int32_t));
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, int32_t, db_pgno_t, DB_LSN *,
+      uint32_t, uint32_t, uint32_t));
 int CDB___bam_adj_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___bam_adj_read __P ((void *, __bam_adj_args **));
 
@@ -114,20 +114,20 @@ int CDB___bam_adj_read __P ((void *, __bam_adj_args **));
 
 typedef struct _bam_cadjust_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
   int32_t fileid;
   db_pgno_t pgno;
   DB_LSN lsn;
-  u_int32_t indx;
+  uint32_t indx;
   int32_t adjust;
   int32_t total;
 } __bam_cadjust_args;
 
 int CDB___bam_cadjust_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, int32_t, db_pgno_t, DB_LSN *,
-      u_int32_t, int32_t, int32_t));
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, int32_t, db_pgno_t, DB_LSN *,
+      uint32_t, int32_t, int32_t));
 int CDB___bam_cadjust_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___bam_cadjust_read __P ((void *, __bam_cadjust_args **));
 
@@ -135,18 +135,18 @@ int CDB___bam_cadjust_read __P ((void *, __bam_cadjust_args **));
 
 typedef struct _bam_cdel_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
   int32_t fileid;
   db_pgno_t pgno;
   DB_LSN lsn;
-  u_int32_t indx;
+  uint32_t indx;
 } __bam_cdel_args;
 
 int CDB___bam_cdel_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, int32_t, db_pgno_t, DB_LSN *,
-      u_int32_t));
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, int32_t, db_pgno_t, DB_LSN *,
+      uint32_t));
 int CDB___bam_cdel_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___bam_cdel_read __P ((void *, __bam_cdel_args **));
 
@@ -154,23 +154,23 @@ int CDB___bam_cdel_read __P ((void *, __bam_cdel_args **));
 
 typedef struct _bam_repl_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
   int32_t fileid;
   db_pgno_t pgno;
   DB_LSN lsn;
-  u_int32_t indx;
-  u_int32_t isdeleted;
+  uint32_t indx;
+  uint32_t isdeleted;
   DBT orig;
   DBT repl;
-  u_int32_t prefix;
-  u_int32_t suffix;
+  uint32_t prefix;
+  uint32_t suffix;
 } __bam_repl_args;
 
 int CDB___bam_repl_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, int32_t, db_pgno_t, DB_LSN *,
-      u_int32_t, u_int32_t, const DBT *, const DBT *, u_int32_t, u_int32_t));
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, int32_t, db_pgno_t, DB_LSN *,
+      uint32_t, uint32_t, const DBT *, const DBT *, uint32_t, uint32_t));
 int CDB___bam_repl_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___bam_repl_read __P ((void *, __bam_repl_args **));
 
@@ -178,7 +178,7 @@ int CDB___bam_repl_read __P ((void *, __bam_repl_args **));
 
 typedef struct _bam_root_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
   int32_t fileid;
@@ -188,7 +188,7 @@ typedef struct _bam_root_args
 } __bam_root_args;
 
 int CDB___bam_root_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, int32_t, db_pgno_t, db_pgno_t,
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, int32_t, db_pgno_t, db_pgno_t,
       DB_LSN *));
 int CDB___bam_root_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___bam_root_read __P ((void *, __bam_root_args **));

--- a/db/btree_ext.h
+++ b/db/btree_ext.h
@@ -2,7 +2,7 @@
 #ifndef _btree_ext_h_
 #define _btree_ext_h_
 int CDB___bam_cmp __P ((DB *, const DBT *,
-                        PAGE *, u_int32_t, int (*)(const DBT *,
+                        PAGE *, uint32_t, int (*)(const DBT *,
                                                    const DBT *)));
 int CDB___bam_defcmp __P ((const DBT *, const DBT *));
 size_t CDB___bam_defpfx __P ((const DBT *, const DBT *));
@@ -10,39 +10,39 @@ int CDB___bam_pgin __P ((db_pgno_t, void *, DBT *));
 int CDB___bam_pgout __P ((db_pgno_t, void *, DBT *));
 int CDB___bam_mswap __P ((PAGE *));
 int CDB___bam_cprint __P ((DB *));
-int CDB___bam_ca_delete __P ((DB *, db_pgno_t, u_int32_t, int));
-void CDB___bam_ca_di __P ((DB *, db_pgno_t, u_int32_t, int));
+int CDB___bam_ca_delete __P ((DB *, db_pgno_t, uint32_t, int));
+void CDB___bam_ca_di __P ((DB *, db_pgno_t, uint32_t, int));
 void CDB___bam_ca_dup __P ((DB *,
-                            db_pgno_t, u_int32_t, u_int32_t, db_pgno_t,
-                            u_int32_t));
+                            db_pgno_t, uint32_t, uint32_t, db_pgno_t,
+                            uint32_t));
 void CDB___bam_ca_rsplit __P ((DB *, db_pgno_t, db_pgno_t));
 void CDB___bam_ca_split __P ((DB *,
-                              db_pgno_t, db_pgno_t, db_pgno_t, u_int32_t,
+                              db_pgno_t, db_pgno_t, db_pgno_t, uint32_t,
                               int));
 void CDB___bam_ca_repl
-__P ((DB *, db_pgno_t, u_int32_t, db_pgno_t, u_int32_t));
+__P ((DB *, db_pgno_t, uint32_t, db_pgno_t, uint32_t));
 int CDB___bam_c_init __P ((DBC *));
 int CDB___bam_c_dup __P ((DBC *, DBC *));
-int CDB___bam_delete __P ((DB *, DB_TXN *, DBT *, u_int32_t));
-int CDB___bam_ditem __P ((DBC *, PAGE *, u_int32_t));
-int CDB___bam_adjindx __P ((DBC *, PAGE *, u_int32_t, u_int32_t, int));
+int CDB___bam_delete __P ((DB *, DB_TXN *, DBT *, uint32_t));
+int CDB___bam_ditem __P ((DBC *, PAGE *, uint32_t));
+int CDB___bam_adjindx __P ((DBC *, PAGE *, uint32_t, uint32_t, int));
 int CDB___bam_dpage __P ((DBC *, const DBT *));
 int CDB___bam_dpages __P ((DBC *));
 int CDB___bam_db_create __P ((DB *));
 int CDB___bam_db_close __P ((DB *));
-int CDB___bam_set_flags __P ((DB *, u_int32_t * flagsp));
-int CDB___ram_set_flags __P ((DB *, u_int32_t * flagsp));
+int CDB___bam_set_flags __P ((DB *, uint32_t * flagsp));
+int CDB___ram_set_flags __P ((DB *, uint32_t * flagsp));
 int CDB___bam_open __P ((DB *, const char *, db_pgno_t));
 void CDB___bam_setovflsize __P ((DB *));
 int CDB___bam_metachk __P ((DB *, const char *, BTMETA *));
 int CDB___bam_read_root __P ((DB *, const char *, db_pgno_t));
 int CDB___bam_iitem __P ((DBC *,
-                          PAGE **, db_indx_t *, DBT *, DBT *, u_int32_t,
-                          u_int32_t));
-u_int32_t CDB___bam_partsize __P ((u_int32_t, DBT *, PAGE *, u_int32_t));
-int CDB___bam_build __P ((DBC *, u_int32_t,
-                          DBT *, PAGE *, u_int32_t, u_int32_t));
-int CDB___bam_ritem __P ((DBC *, PAGE *, u_int32_t, DBT *));
+                          PAGE **, db_indx_t *, DBT *, DBT *, uint32_t,
+                          uint32_t));
+uint32_t CDB___bam_partsize __P ((uint32_t, DBT *, PAGE *, uint32_t));
+int CDB___bam_build __P ((DBC *, uint32_t,
+                          DBT *, PAGE *, uint32_t, uint32_t));
+int CDB___bam_ritem __P ((DBC *, PAGE *, uint32_t, DBT *));
 int CDB___bam_pg_alloc_recover __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___bam_pg_free_recover __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___bam_split_recover __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
@@ -54,23 +54,23 @@ int CDB___bam_repl_recover __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___bam_root_recover __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___bam_reclaim __P ((DB *, DB_TXN *));
 int CDB___ram_open __P ((DB *, const char *, db_pgno_t));
-int CDB___ram_c_del __P ((DBC *, u_int32_t));
-int CDB___ram_c_get __P ((DBC *, DBT *, DBT *, u_int32_t));
-int CDB___ram_c_put __P ((DBC *, DBT *, DBT *, u_int32_t));
+int CDB___ram_c_del __P ((DBC *, uint32_t));
+int CDB___ram_c_get __P ((DBC *, DBT *, DBT *, uint32_t));
+int CDB___ram_c_put __P ((DBC *, DBT *, DBT *, uint32_t));
 void CDB___ram_ca __P ((DB *, db_recno_t, ca_recno_arg));
 int CDB___ram_getno __P ((DBC *, const DBT *, db_recno_t *, int));
 int CDB___ram_writeback __P ((DB *));
-int CDB___bam_rsearch __P ((DBC *, db_recno_t *, u_int32_t, int, int *));
+int CDB___bam_rsearch __P ((DBC *, db_recno_t *, uint32_t, int, int *));
 int CDB___bam_adjust __P ((DBC *, int32_t));
 int CDB___bam_nrecs __P ((DBC *, db_recno_t *));
 db_recno_t CDB___bam_total __P ((PAGE *));
 int CDB___bam_search __P ((DBC *,
-                           const DBT *, u_int32_t, int, db_recno_t *, int *));
+                           const DBT *, uint32_t, int, db_recno_t *, int *));
 int CDB___bam_stkrel __P ((DBC *, int));
 int CDB___bam_stkgrow __P ((BTREE_CURSOR *));
 int CDB___bam_split __P ((DBC *, void *));
-int CDB___bam_copy __P ((DB *, PAGE *, PAGE *, u_int32_t, u_int32_t));
-int CDB___bam_stat __P ((DB *, void *, void *(*)(size_t), u_int32_t));
+int CDB___bam_copy __P ((DB *, PAGE *, PAGE *, uint32_t, uint32_t));
+int CDB___bam_stat __P ((DB *, void *, void *(*)(size_t), uint32_t));
 int CDB___bam_traverse __P ((DBC *, db_lockmode_t,
                              db_pgno_t, int (*)(DB *, PAGE *, void *, int *),
                              void *));

--- a/db/common_ext.h
+++ b/db/common_ext.h
@@ -2,9 +2,9 @@
 #ifndef _common_ext_h_
 #define _common_ext_h_
 int CDB___db_byteorder __P ((DB_ENV *, int));
-int CDB___db_fchk __P ((DB_ENV *, const char *, u_int32_t, u_int32_t));
+int CDB___db_fchk __P ((DB_ENV *, const char *, uint32_t, uint32_t));
 int CDB___db_fcchk
-__P ((DB_ENV *, const char *, u_int32_t, u_int32_t, u_int32_t));
+__P ((DB_ENV *, const char *, uint32_t, uint32_t, uint32_t));
 int CDB___db_ferr __P ((const DB_ENV *, const char *, int));
 int CDB___db_pgerr __P ((DB *, db_pgno_t));
 int CDB___db_pgfmt __P ((DB *, db_pgno_t));
@@ -22,11 +22,11 @@ void CDB___db_real_err
 __P ((const DB_ENV *, int, int, int, const char *, va_list));
 #ifdef __STDC__
 int CDB___db_logmsg __P ((DB_ENV *,
-                          DB_TXN *, const char *, u_int32_t, const char *,
+                          DB_TXN *, const char *, uint32_t, const char *,
                           ...));
 #else
 int CDB___db_logmsg ();
 #endif
 int CDB___db_getlong __P ((DB *, const char *, char *, long, long, long *));
-u_int32_t CDB___db_log2 __P ((u_int32_t));
+uint32_t CDB___db_log2 __P ((uint32_t));
 #endif /* _common_ext_h_ */

--- a/db/crdel_auto.c
+++ b/db/crdel_auto.c
@@ -20,16 +20,16 @@ CDB___crdel_fileopen_log (dbenv, txnid, ret_lsnp, flags, name, mode)
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
+     uint32_t flags;
      const DBT *name;
-     u_int32_t mode;
+     uint32_t mode;
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t zero;
-  u_int32_t rectype, txn_num;
+  uint32_t zero;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -44,7 +44,7 @@ CDB___crdel_fileopen_log (dbenv, txnid, ret_lsnp, flags, name, mode)
   else
     lsnp = &txnid->last_lsn;
   logrec.size = sizeof (rectype) + sizeof (txn_num) + sizeof (DB_LSN)
-    + sizeof (u_int32_t) + (name == NULL ? 0 : name->size) + sizeof (mode);
+    + sizeof (uint32_t) + (name == NULL ? 0 : name->size) + sizeof (mode);
   if ((ret = CDB___os_malloc (logrec.size, NULL, &logrec.data)) != 0)
     return (ret);
 
@@ -58,8 +58,8 @@ CDB___crdel_fileopen_log (dbenv, txnid, ret_lsnp, flags, name, mode)
   if (name == NULL)
   {
     zero = 0;
-    memcpy (bp, &zero, sizeof (u_int32_t));
-    bp += sizeof (u_int32_t);
+    memcpy (bp, &zero, sizeof (uint32_t));
+    bp += sizeof (uint32_t);
   }
   else
   {
@@ -70,7 +70,7 @@ CDB___crdel_fileopen_log (dbenv, txnid, ret_lsnp, flags, name, mode)
   }
   memcpy (bp, &mode, sizeof (mode));
   bp += sizeof (mode);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -87,7 +87,7 @@ CDB___crdel_fileopen_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __crdel_fileopen_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -108,7 +108,7 @@ CDB___crdel_fileopen_print (notused1, dbtp, lsnp, notused2, notused3)
   printf ("\tname: ");
   for (i = 0; i < argp->name.size; i++)
   {
-    ch = ((u_int8_t *) argp->name.data)[i];
+    ch = ((uint8_t *) argp->name.data)[i];
     if (isprint (ch) || ch == 0xa)
       putchar (ch);
     else
@@ -127,7 +127,7 @@ CDB___crdel_fileopen_read (recbuf, argpp)
      __crdel_fileopen_args **argpp;
 {
   __crdel_fileopen_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__crdel_fileopen_args) +
@@ -143,8 +143,8 @@ CDB___crdel_fileopen_read (recbuf, argpp)
   memcpy (&argp->prev_lsn, bp, sizeof (DB_LSN));
   bp += sizeof (DB_LSN);
   memset (&argp->name, 0, sizeof (argp->name));
-  memcpy (&argp->name.size, bp, sizeof (u_int32_t));
-  bp += sizeof (u_int32_t);
+  memcpy (&argp->name.size, bp, sizeof (uint32_t));
+  bp += sizeof (uint32_t);
   argp->name.data = bp;
   bp += argp->name.size;
   memcpy (&argp->mode, bp, sizeof (argp->mode));
@@ -159,18 +159,18 @@ CDB___crdel_metasub_log (dbenv, txnid, ret_lsnp, flags,
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
-     u_int32_t fileid;
+     uint32_t flags;
+     uint32_t fileid;
      db_pgno_t pgno;
      const DBT *page;
      DB_LSN *lsn;
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t zero;
-  u_int32_t rectype, txn_num;
+  uint32_t zero;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -187,7 +187,7 @@ CDB___crdel_metasub_log (dbenv, txnid, ret_lsnp, flags,
   logrec.size = sizeof (rectype) + sizeof (txn_num) + sizeof (DB_LSN)
     + sizeof (fileid)
     + sizeof (pgno)
-    + sizeof (u_int32_t) + (page == NULL ? 0 : page->size) + sizeof (*lsn);
+    + sizeof (uint32_t) + (page == NULL ? 0 : page->size) + sizeof (*lsn);
   if ((ret = CDB___os_malloc (logrec.size, NULL, &logrec.data)) != 0)
     return (ret);
 
@@ -205,8 +205,8 @@ CDB___crdel_metasub_log (dbenv, txnid, ret_lsnp, flags,
   if (page == NULL)
   {
     zero = 0;
-    memcpy (bp, &zero, sizeof (u_int32_t));
-    bp += sizeof (u_int32_t);
+    memcpy (bp, &zero, sizeof (uint32_t));
+    bp += sizeof (uint32_t);
   }
   else
   {
@@ -220,7 +220,7 @@ CDB___crdel_metasub_log (dbenv, txnid, ret_lsnp, flags,
   else
     memset (bp, 0, sizeof (*lsn));
   bp += sizeof (*lsn);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -237,7 +237,7 @@ CDB___crdel_metasub_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __crdel_metasub_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -260,7 +260,7 @@ CDB___crdel_metasub_print (notused1, dbtp, lsnp, notused2, notused3)
   printf ("\tpage: ");
   for (i = 0; i < argp->page.size; i++)
   {
-    ch = ((u_int8_t *) argp->page.data)[i];
+    ch = ((uint8_t *) argp->page.data)[i];
     if (isprint (ch) || ch == 0xa)
       putchar (ch);
     else
@@ -280,7 +280,7 @@ CDB___crdel_metasub_read (recbuf, argpp)
      __crdel_metasub_args **argpp;
 {
   __crdel_metasub_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__crdel_metasub_args) +
@@ -300,8 +300,8 @@ CDB___crdel_metasub_read (recbuf, argpp)
   memcpy (&argp->pgno, bp, sizeof (argp->pgno));
   bp += sizeof (argp->pgno);
   memset (&argp->page, 0, sizeof (argp->page));
-  memcpy (&argp->page.size, bp, sizeof (u_int32_t));
-  bp += sizeof (u_int32_t);
+  memcpy (&argp->page.size, bp, sizeof (uint32_t));
+  bp += sizeof (uint32_t);
   argp->page.data = bp;
   bp += argp->page.size;
   memcpy (&argp->lsn, bp, sizeof (argp->lsn));
@@ -316,18 +316,18 @@ CDB___crdel_metapage_log (dbenv, txnid, ret_lsnp, flags,
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
-     u_int32_t fileid;
+     uint32_t flags;
+     uint32_t fileid;
      const DBT *name;
      db_pgno_t pgno;
      const DBT *page;
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t zero;
-  u_int32_t rectype, txn_num;
+  uint32_t zero;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -343,8 +343,8 @@ CDB___crdel_metapage_log (dbenv, txnid, ret_lsnp, flags,
     lsnp = &txnid->last_lsn;
   logrec.size = sizeof (rectype) + sizeof (txn_num) + sizeof (DB_LSN)
     + sizeof (fileid)
-    + sizeof (u_int32_t) + (name == NULL ? 0 : name->size)
-    + sizeof (pgno) + sizeof (u_int32_t) + (page == NULL ? 0 : page->size);
+    + sizeof (uint32_t) + (name == NULL ? 0 : name->size)
+    + sizeof (pgno) + sizeof (uint32_t) + (page == NULL ? 0 : page->size);
   if ((ret = CDB___os_malloc (logrec.size, NULL, &logrec.data)) != 0)
     return (ret);
 
@@ -360,8 +360,8 @@ CDB___crdel_metapage_log (dbenv, txnid, ret_lsnp, flags,
   if (name == NULL)
   {
     zero = 0;
-    memcpy (bp, &zero, sizeof (u_int32_t));
-    bp += sizeof (u_int32_t);
+    memcpy (bp, &zero, sizeof (uint32_t));
+    bp += sizeof (uint32_t);
   }
   else
   {
@@ -375,8 +375,8 @@ CDB___crdel_metapage_log (dbenv, txnid, ret_lsnp, flags,
   if (page == NULL)
   {
     zero = 0;
-    memcpy (bp, &zero, sizeof (u_int32_t));
-    bp += sizeof (u_int32_t);
+    memcpy (bp, &zero, sizeof (uint32_t));
+    bp += sizeof (uint32_t);
   }
   else
   {
@@ -385,7 +385,7 @@ CDB___crdel_metapage_log (dbenv, txnid, ret_lsnp, flags,
     memcpy (bp, page->data, page->size);
     bp += page->size;
   }
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -402,7 +402,7 @@ CDB___crdel_metapage_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __crdel_metapage_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -424,7 +424,7 @@ CDB___crdel_metapage_print (notused1, dbtp, lsnp, notused2, notused3)
   printf ("\tname: ");
   for (i = 0; i < argp->name.size; i++)
   {
-    ch = ((u_int8_t *) argp->name.data)[i];
+    ch = ((uint8_t *) argp->name.data)[i];
     if (isprint (ch) || ch == 0xa)
       putchar (ch);
     else
@@ -435,7 +435,7 @@ CDB___crdel_metapage_print (notused1, dbtp, lsnp, notused2, notused3)
   printf ("\tpage: ");
   for (i = 0; i < argp->page.size; i++)
   {
-    ch = ((u_int8_t *) argp->page.data)[i];
+    ch = ((uint8_t *) argp->page.data)[i];
     if (isprint (ch) || ch == 0xa)
       putchar (ch);
     else
@@ -453,7 +453,7 @@ CDB___crdel_metapage_read (recbuf, argpp)
      __crdel_metapage_args **argpp;
 {
   __crdel_metapage_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__crdel_metapage_args) +
@@ -471,15 +471,15 @@ CDB___crdel_metapage_read (recbuf, argpp)
   memcpy (&argp->fileid, bp, sizeof (argp->fileid));
   bp += sizeof (argp->fileid);
   memset (&argp->name, 0, sizeof (argp->name));
-  memcpy (&argp->name.size, bp, sizeof (u_int32_t));
-  bp += sizeof (u_int32_t);
+  memcpy (&argp->name.size, bp, sizeof (uint32_t));
+  bp += sizeof (uint32_t);
   argp->name.data = bp;
   bp += argp->name.size;
   memcpy (&argp->pgno, bp, sizeof (argp->pgno));
   bp += sizeof (argp->pgno);
   memset (&argp->page, 0, sizeof (argp->page));
-  memcpy (&argp->page.size, bp, sizeof (u_int32_t));
-  bp += sizeof (u_int32_t);
+  memcpy (&argp->page.size, bp, sizeof (uint32_t));
+  bp += sizeof (uint32_t);
   argp->page.data = bp;
   bp += argp->page.size;
   *argpp = argp;
@@ -491,15 +491,15 @@ CDB___crdel_delete_log (dbenv, txnid, ret_lsnp, flags, name)
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
+     uint32_t flags;
      const DBT *name;
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t zero;
-  u_int32_t rectype, txn_num;
+  uint32_t zero;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -514,7 +514,7 @@ CDB___crdel_delete_log (dbenv, txnid, ret_lsnp, flags, name)
   else
     lsnp = &txnid->last_lsn;
   logrec.size = sizeof (rectype) + sizeof (txn_num) + sizeof (DB_LSN)
-    + sizeof (u_int32_t) + (name == NULL ? 0 : name->size);
+    + sizeof (uint32_t) + (name == NULL ? 0 : name->size);
   if ((ret = CDB___os_malloc (logrec.size, NULL, &logrec.data)) != 0)
     return (ret);
 
@@ -528,8 +528,8 @@ CDB___crdel_delete_log (dbenv, txnid, ret_lsnp, flags, name)
   if (name == NULL)
   {
     zero = 0;
-    memcpy (bp, &zero, sizeof (u_int32_t));
-    bp += sizeof (u_int32_t);
+    memcpy (bp, &zero, sizeof (uint32_t));
+    bp += sizeof (uint32_t);
   }
   else
   {
@@ -538,7 +538,7 @@ CDB___crdel_delete_log (dbenv, txnid, ret_lsnp, flags, name)
     memcpy (bp, name->data, name->size);
     bp += name->size;
   }
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -555,7 +555,7 @@ CDB___crdel_delete_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __crdel_delete_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -576,7 +576,7 @@ CDB___crdel_delete_print (notused1, dbtp, lsnp, notused2, notused3)
   printf ("\tname: ");
   for (i = 0; i < argp->name.size; i++)
   {
-    ch = ((u_int8_t *) argp->name.data)[i];
+    ch = ((uint8_t *) argp->name.data)[i];
     if (isprint (ch) || ch == 0xa)
       putchar (ch);
     else
@@ -594,7 +594,7 @@ CDB___crdel_delete_read (recbuf, argpp)
      __crdel_delete_args **argpp;
 {
   __crdel_delete_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__crdel_delete_args) +
@@ -610,8 +610,8 @@ CDB___crdel_delete_read (recbuf, argpp)
   memcpy (&argp->prev_lsn, bp, sizeof (DB_LSN));
   bp += sizeof (DB_LSN);
   memset (&argp->name, 0, sizeof (argp->name));
-  memcpy (&argp->name.size, bp, sizeof (u_int32_t));
-  bp += sizeof (u_int32_t);
+  memcpy (&argp->name.size, bp, sizeof (uint32_t));
+  bp += sizeof (uint32_t);
   argp->name.data = bp;
   bp += argp->name.size;
   *argpp = argp;

--- a/db/crdel_auto.h
+++ b/db/crdel_auto.h
@@ -7,15 +7,15 @@
 
 typedef struct _crdel_fileopen_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
   DBT name;
-  u_int32_t mode;
+  uint32_t mode;
 } __crdel_fileopen_args;
 
 int CDB___crdel_fileopen_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, const DBT *, u_int32_t));
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, const DBT *, uint32_t));
 int CDB___crdel_fileopen_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___crdel_fileopen_read __P ((void *, __crdel_fileopen_args **));
 
@@ -23,17 +23,17 @@ int CDB___crdel_fileopen_read __P ((void *, __crdel_fileopen_args **));
 
 typedef struct _crdel_metasub_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
-  u_int32_t fileid;
+  uint32_t fileid;
   db_pgno_t pgno;
   DBT page;
   DB_LSN lsn;
 } __crdel_metasub_args;
 
 int CDB___crdel_metasub_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, u_int32_t, db_pgno_t,
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, uint32_t, db_pgno_t,
       const DBT *, DB_LSN *));
 int CDB___crdel_metasub_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___crdel_metasub_read __P ((void *, __crdel_metasub_args **));
@@ -42,17 +42,17 @@ int CDB___crdel_metasub_read __P ((void *, __crdel_metasub_args **));
 
 typedef struct _crdel_metapage_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
-  u_int32_t fileid;
+  uint32_t fileid;
   DBT name;
   db_pgno_t pgno;
   DBT page;
 } __crdel_metapage_args;
 
 int CDB___crdel_metapage_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, u_int32_t, const DBT *,
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, uint32_t, const DBT *,
       db_pgno_t, const DBT *));
 int CDB___crdel_metapage_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___crdel_metapage_read __P ((void *, __crdel_metapage_args **));
@@ -61,14 +61,14 @@ int CDB___crdel_metapage_read __P ((void *, __crdel_metapage_args **));
 
 typedef struct _crdel_delete_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
   DBT name;
 } __crdel_delete_args;
 
 int CDB___crdel_delete_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, const DBT *));
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, const DBT *));
 int CDB___crdel_delete_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___crdel_delete_read __P ((void *, __crdel_delete_args **));
 int CDB___crdel_init_print __P ((DB_ENV *));

--- a/db/crdel_rec.c
+++ b/db/crdel_rec.c
@@ -45,7 +45,7 @@ CDB___crdel_fileopen_recover (dbenv, dbtp, lsnp, redo, info)
   DB_FH fh;
   ssize_t nr;
   int do_unlink, ret;
-  u_int32_t b, mb, io;
+  uint32_t b, mb, io;
   char *real_name;
 
   COMPQUIET (info, NULL);
@@ -223,7 +223,7 @@ CDB___crdel_metapage_recover (dbenv, dbtp, lsnp, redo, info)
   DBMETA *meta, ondisk;
   DB_FH fh;
   ssize_t nr;
-  u_int32_t b, io, mb, pagesize;
+  uint32_t b, io, mb, pagesize;
   int is_done, ret;
   char *real_name;
 

--- a/db/db.c
+++ b/db/db.c
@@ -65,15 +65,15 @@ static const char sccsid[] = "@(#)db.c  11.31 (Sleepycat) 11/12/99";
 #include "qam.h"
 
 static int CDB___db_dbopen
-__P ((DB *, const char *, u_int32_t, int, db_pgno_t));
-static int CDB___db_dbenv_setup __P ((DB *, const char *, u_int32_t));
+__P ((DB *, const char *, uint32_t, int, db_pgno_t));
+static int CDB___db_dbenv_setup __P ((DB *, const char *, uint32_t));
 static int CDB___db_file_setup __P ((DB *,
-                                     const char *, u_int32_t, int, db_pgno_t,
+                                     const char *, uint32_t, int, db_pgno_t,
                                      int *));
 static int CDB___db_master_open
-__P ((DB_ENV *, DB_TXN *, const char *, u_int32_t, int, DB **));
+__P ((DB_ENV *, DB_TXN *, const char *, uint32_t, int, DB **));
 static int CDB___db_master_update
-__P ((DB *, const char *, u_int32_t, db_pgno_t *, int, u_int32_t));
+__P ((DB *, const char *, uint32_t, db_pgno_t *, int, uint32_t));
 static int CDB___db_metabegin __P ((DB *, DB_LOCK *));
 static int CDB___db_metaend __P ((DB *,
                                   DB_LOCK *, int, int (*)(DB *, void *),
@@ -91,21 +91,21 @@ static void __db_makecopy __P ((const char *, const char *));
  *  Main library interface to the DB access methods.
  *
  * PUBLIC: int CDB___db_open __P((DB *,
- * PUBLIC:     const char *, const char *, DBTYPE, u_int32_t, int));
+ * PUBLIC:     const char *, const char *, DBTYPE, uint32_t, int));
  */
 int
 CDB___db_open (dbp, name, subdb, type, flags, mode)
      DB *dbp;
      const char *name, *subdb;
      DBTYPE type;
-     u_int32_t flags;
+     uint32_t flags;
      int mode;
 {
   DB_ENV *dbenv;
   DB_LOCK open_lock;
   DB *mdbp;
   db_pgno_t meta_pgno;
-  u_int32_t ok_flags;
+  uint32_t ok_flags;
   int ret, t_ret;
 
   dbenv = dbp->dbenv;
@@ -317,7 +317,7 @@ static int
 CDB___db_dbopen (dbp, name, flags, mode, meta_pgno)
      DB *dbp;
      const char *name;
-     u_int32_t flags;
+     uint32_t flags;
      int mode;
      db_pgno_t meta_pgno;
 {
@@ -380,7 +380,7 @@ CDB___db_master_open (dbenv, txn, name, flags, mode, dbpp)
      DB_ENV *dbenv;
      DB_TXN *txn;
      const char *name;
-     u_int32_t flags;
+     uint32_t flags;
      int mode;
      DB **dbpp;
 {
@@ -417,10 +417,10 @@ static int
 CDB___db_master_update (mdbp, subdb, type, meta_pgnop, is_remove, flags)
      DB *mdbp;
      const char *subdb;
-     u_int32_t type;
+     uint32_t type;
      db_pgno_t *meta_pgnop;     /* !NULL if creating/reading. */
      int is_remove;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DBC *dbc;
   DBT key, data;
@@ -543,7 +543,7 @@ static int
 CDB___db_dbenv_setup (dbp, name, flags)
      DB *dbp;
      const char *name;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB_ENV *dbenv;
   DBT pgcookie;
@@ -665,7 +665,7 @@ static int
 CDB___db_file_setup (dbp, name, flags, mode, meta_pgno, zerop)
      DB *dbp;
      const char *name;
-     u_int32_t flags;
+     uint32_t flags;
      int mode;
      db_pgno_t meta_pgno;
      int *zerop;
@@ -676,7 +676,7 @@ CDB___db_file_setup (dbp, name, flags, mode, meta_pgno, zerop)
   DB_LSN lsn;
   DB_TXN *txn;
   ssize_t nr;
-  u_int32_t magic, oflags;
+  uint32_t magic, oflags;
   int ret, retry_cnt, t_ret;
   char *real_name, mbuf[256];
 
@@ -761,7 +761,7 @@ CDB___db_file_setup (dbp, name, flags, mode, meta_pgno, zerop)
      * from there as necessary, and it saves having two copies.
      */
     if (F_ISSET (dbenv, DB_ENV_LOCKING | DB_ENV_CDB) &&
-        (ret = CDB_lock_id (dbenv, (u_int32_t *) dbp->fileid)) != 0)
+        (ret = CDB_lock_id (dbenv, (uint32_t *) dbp->fileid)) != 0)
       return (ret);
 
     return (0);
@@ -1075,7 +1075,7 @@ CDB___db_set_pgsize (dbp, fhp, name)
      char *name;
 {
   DB_ENV *dbenv;
-  u_int32_t iopsize;
+  uint32_t iopsize;
   int ret;
 
   dbenv = dbp->dbenv;
@@ -1125,12 +1125,12 @@ CDB___db_set_pgsize (dbp, fhp, name)
  * CDB___db_close --
  *  DB destructor.
  *
- * PUBLIC: int CDB___db_close __P((DB *, u_int32_t));
+ * PUBLIC: int CDB___db_close __P((DB *, uint32_t));
  */
 int
 CDB___db_close (dbp, flags)
      DB *dbp;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB_ENV *dbenv;
   DBC *dbc;
@@ -1266,13 +1266,13 @@ CDB___db_refresh (dbp)
  * CDB___db_remove
  *   Remove method for DB.
  *
- * PUBLIC: int CDB___db_remove __P((DB *, const char *, const char *, u_int32_t));
+ * PUBLIC: int CDB___db_remove __P((DB *, const char *, const char *, uint32_t));
  */
 int
 CDB___db_remove (dbp, name, subdb, flags)
      DB *dbp;
      const char *name, *subdb;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DBT namedbt;
   DB_ENV *dbenv;
@@ -1478,7 +1478,7 @@ CDB___db_metabegin (dbp, lockp)
 {
   DB_ENV *dbenv;
   DBT dbplock;
-  u_int32_t locker, lockval;
+  uint32_t locker, lockval;
   int ret;
 
   dbenv = dbp->dbenv;

--- a/db/db.h.in
+++ b/db/db.h.in
@@ -14,6 +14,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#include <stdint.h>
 #include <stdio.h>
 #endif
 
@@ -77,11 +78,11 @@
 #define	DB_VERSION_PATCH	55
 #define	DB_VERSION_STRING	"Sleepycat Software: Berkeley DB 3.0.55: (February 28, 2000)"
 
-typedef	u_int32_t	db_pgno_t;	/* Page number type. */
-typedef	u_int16_t	db_indx_t;	/* Page offset type. */
+typedef	uint32_t	db_pgno_t;	/* Page number type. */
+typedef	uint16_t	db_indx_t;	/* Page offset type. */
 #define	DB_MAX_PAGES	0xffffffff	/* >= # of pages in a file */
 
-typedef	u_int32_t	db_recno_t;	/* Record number type. */
+typedef	uint32_t	db_recno_t;	/* Record number type. */
 #define	DB_MAX_RECORDS	0xffffffff	/* >= # of records in a tree */
 
 /* Forward structure declarations, so applications get type checking. */
@@ -114,17 +115,17 @@ struct __db_cmpr_info;	typedef struct __db_cmpr_info DB_CMPR_INFO;
 /* Key/data structure -- a Data-Base Thang. */
 struct __db_dbt {
 	void	 *data;			/* key/data */
-	u_int32_t size;			/* key/data length */
-	u_int32_t ulen;			/* RO: length of user buffer. */
-	u_int32_t dlen;			/* RO: get/put record length. */
-	u_int32_t doff;			/* RO: get/put record offset. */
+	uint32_t size;			/* key/data length */
+	uint32_t ulen;			/* RO: length of user buffer. */
+	uint32_t dlen;			/* RO: get/put record length. */
+	uint32_t doff;			/* RO: get/put record offset. */
 
 #define	DB_DBT_INTERNAL	0x001		/* Ignore user's malloc (internal). */
 #define	DB_DBT_MALLOC	0x002		/* Return in malloc'd memory. */
 #define	DB_DBT_PARTIAL	0x004		/* Partial put/get. */
 #define	DB_DBT_REALLOC	0x008		/* Return in realloc'd memory. */
 #define	DB_DBT_USERMEM	0x010		/* Return in user's memory. */
-	u_int32_t flags;
+	uint32_t flags;
 };
 
 /*
@@ -132,12 +133,12 @@ struct __db_dbt {
  */
 struct __db_cmpr_info {
     int (*compress)                     /* Compression function */
-	__P((const u_int8_t*, int, u_int8_t**, int*,void *));
+	__P((const uint8_t*, int, uint8_t**, int*,void *));
     int (*uncompress)                   /* Uncompression function */
-	__P((const u_int8_t*, int, u_int8_t*, int,void *));
-    u_int8_t coefficient;	        /* Compression factor is 1<<coefficient  */
-    u_int8_t max_npages;                /* Max number of pages  worst case */
-    u_int8_t zlib_flags;                /* Zlib Compresson Level */
+	__P((const uint8_t*, int, uint8_t*, int,void *));
+    uint8_t coefficient;	        /* Compression factor is 1<<coefficient  */
+    uint8_t max_npages;                /* Max number of pages  worst case */
+    uint8_t zlib_flags;                /* Zlib Compresson Level */
     void         *user_data;            /* Persistent information for compression functions */
 };
 
@@ -243,28 +244,28 @@ struct __db_env {
 #define	DB_VERB_DEADLOCK	0x0002	/* Deadlock detection information. */
 #define	DB_VERB_RECOVERY	0x0004	/* Recovery information. */
 #define	DB_VERB_WAITSFOR	0x0008	/* Dump waits-for table. */
-	u_int32_t	 verbose;	/* Verbose output. */
+	uint32_t	 verbose;	/* Verbose output. */
 
 	/* Locking. */
-	u_int8_t	*lk_conflicts;	/* Two dimensional conflict matrix. */
-	u_int32_t	 lk_modes;	/* Number of lock modes in table. */
-	u_int32_t	 lk_max;	/* Maximum number of locks. */
-	u_int32_t	 lk_detect;	/* Deadlock detect on all conflicts. */
+	uint8_t	*lk_conflicts;	/* Two dimensional conflict matrix. */
+	uint32_t	 lk_modes;	/* Number of lock modes in table. */
+	uint32_t	 lk_max;	/* Maximum number of locks. */
+	uint32_t	 lk_detect;	/* Deadlock detect on all conflicts. */
 
 	/* Logging. */
-	u_int32_t	 lg_bsize;	/* Buffer size. */
-	u_int32_t	 lg_max;	/* Maximum file size. */
+	uint32_t	 lg_bsize;	/* Buffer size. */
+	uint32_t	 lg_max;	/* Maximum file size. */
 
 	/* Memory pool. */
-	u_int32_t	 mp_gbytes;	/* Cachesize: GB. */
-	u_int32_t	 mp_bytes;	/* Cachesize: Bytes. */
+	uint32_t	 mp_gbytes;	/* Cachesize: GB. */
+	uint32_t	 mp_bytes;	/* Cachesize: Bytes. */
 	size_t		 mp_size;	/* DEPRECATED: Cachesize: bytes. */
 	int		 mp_ncache;	/* Number of cache regions. */
 	size_t		 mp_mmapsize;	/* Maximum file size for mmap. */
 	DB_CMPR_INFO   * mp_cmpr_info;  /* Compression info. */
 
 	/* Transactions. */
-	u_int32_t	 tx_max;	/* Maximum number of transactions. */
+	uint32_t	 tx_max;	/* Maximum number of transactions. */
 	int (*tx_recover)		/* Dispatch function for recovery. */
 	    __P((DB_ENV *, DBT *, DB_LSN *, int, void *));
 
@@ -317,12 +318,12 @@ struct __db_env {
 	void	*cj_internal;		/* C++/Java private. */
 
 					/* Methods. */
-	int  (*close) __P((DB_ENV *, u_int32_t));
+	int  (*close) __P((DB_ENV *, uint32_t));
 	void (*err) __P((const DB_ENV *, int, const char *, ...));
 	void (*errx) __P((const DB_ENV *, const char *, ...));
 	int  (*open) __P((DB_ENV *,
-		const char *, char * const *, u_int32_t, int));
-	int  (*remove) __P((DB_ENV *, const char *, char * const *, u_int32_t));
+		const char *, char * const *, uint32_t, int));
+	int  (*remove) __P((DB_ENV *, const char *, char * const *, uint32_t));
 	void (*set_errcall) __P((DB_ENV *, void (*)(const char *, char *)));
 	void (*set_errfile) __P((DB_ENV *, FILE *));
 	void (*set_errpfx) __P((DB_ENV *, const char *));
@@ -333,20 +334,20 @@ struct __db_env {
 	int  (*set_panic) __P((DB_ENV *, int));
 	void (*set_paniccall) __P((DB_ENV *, void (*)(DB_ENV *, int)));
 	int  (*set_region_init) __P((DB_ENV *, int));
-	int  (*set_tas_spins) __P((DB_ENV *, u_int32_t));
-	int  (*set_verbose) __P((DB_ENV *, u_int32_t, int));
+	int  (*set_tas_spins) __P((DB_ENV *, uint32_t));
+	int  (*set_verbose) __P((DB_ENV *, uint32_t, int));
 
-	int  (*set_lg_bsize) __P((DB_ENV *, u_int32_t));
-	int  (*set_lg_max) __P((DB_ENV *, u_int32_t));
+	int  (*set_lg_bsize) __P((DB_ENV *, uint32_t));
+	int  (*set_lg_max) __P((DB_ENV *, uint32_t));
 
-	int  (*set_lk_conflicts) __P((DB_ENV *, u_int8_t *, int));
-	int  (*set_lk_detect) __P((DB_ENV *, u_int32_t));
-	int  (*set_lk_max) __P((DB_ENV *, u_int32_t));
+	int  (*set_lk_conflicts) __P((DB_ENV *, uint8_t *, int));
+	int  (*set_lk_detect) __P((DB_ENV *, uint32_t));
+	int  (*set_lk_max) __P((DB_ENV *, uint32_t));
 
 	int  (*set_mp_mmapsize) __P((DB_ENV *, size_t));
-	int  (*set_cachesize) __P((DB_ENV *, u_int32_t, u_int32_t, int));
+	int  (*set_cachesize) __P((DB_ENV *, uint32_t, uint32_t, int));
 
-	int  (*set_tx_max) __P((DB_ENV *, u_int32_t));
+	int  (*set_tx_max) __P((DB_ENV *, uint32_t));
 	int  (*set_tx_recover) __P((DB_ENV *,
 		int (*)(DB_ENV *, DBT *, DB_LSN *, int, void *)));
 
@@ -358,7 +359,7 @@ struct __db_env {
 	int  (*set_func_free) __P((DB_ENV *, void (*)(void *)));
 	int  (*set_func_fsync) __P((DB_ENV *, int (*)(int)));
 	int  (*set_func_ioinfo) __P((DB_ENV *, int (*)(const char *,
-		int, u_int32_t *, u_int32_t *, u_int32_t *)));
+		int, uint32_t *, uint32_t *, uint32_t *)));
 	int  (*set_func_malloc) __P((DB_ENV *, void *(*)(size_t)));
 	int  (*set_func_map) __P((DB_ENV *,
 		int (*)(char *, size_t, int, int, void **)));
@@ -368,7 +369,7 @@ struct __db_env {
 	int  (*set_func_rename) __P((DB_ENV *,
 		int (*)(const char *, const char *)));
 	int  (*set_func_seek) __P((DB_ENV *,
-		int (*)(int, size_t, db_pgno_t, u_int32_t, int, int)));
+		int (*)(int, size_t, db_pgno_t, uint32_t, int, int)));
 	int  (*set_func_sleep) __P((DB_ENV *, int (*)(u_long, u_long)));
 	int  (*set_func_unlink) __P((DB_ENV *, int (*)(const char *)));
 	int  (*set_func_unmap) __P((DB_ENV *, int (*)(void *, size_t)));
@@ -403,7 +404,7 @@ struct __db_env {
 #define	DB_ENV_TXN		0x01000	/* DB_TXN_NOSYNC set. */
 #define	DB_ENV_TXN_NOSYNC	0x02000	/* DB_TXN_NOSYNC set. */
 #define	DB_ENV_USER_ALLOC	0x04000	/* User allocated the structure. */
-	u_int32_t	 flags;		/* Flags. */
+	uint32_t	 flags;		/* Flags. */
 };
 
 /*******************************************************
@@ -534,7 +535,7 @@ struct __db {
 
 	void	*mutexp;		/* Synchronization for free threading */
 
-	u_int8_t fileid[DB_FILE_ID_LEN];/* File's unique ID for locking. */
+	uint8_t fileid[DB_FILE_ID_LEN];/* File's unique ID for locking. */
 
 #define	DB_LOGFILEID_INVALID	-1
 	int32_t	 log_fileid;		/* File's unique ID for logging. */
@@ -580,48 +581,48 @@ struct __db {
 	void	*xa_internal;		/* XA private. */
 
 					/* Methods. */
-	int  (*close) __P((DB *, u_int32_t));
-	int  (*cursor) __P((DB *, DB_TXN *, DBC **, u_int32_t));
-	int  (*del) __P((DB *, DB_TXN *, DBT *, u_int32_t));
+	int  (*close) __P((DB *, uint32_t));
+	int  (*cursor) __P((DB *, DB_TXN *, DBC **, uint32_t));
+	int  (*del) __P((DB *, DB_TXN *, DBT *, uint32_t));
 	void (*err) __P((DB *, int, const char *, ...));
 	void (*errx) __P((DB *, const char *, ...));
 	int  (*fd) __P((DB *, int *));
-	int  (*get) __P((DB *, DB_TXN *, DBT *, DBT *, u_int32_t));
+	int  (*get) __P((DB *, DB_TXN *, DBT *, DBT *, uint32_t));
 	int  (*get_byteswapped) __P((DB *));
 	DBTYPE
 	     (*get_type) __P((DB *));
-	int  (*join) __P((DB *, DBC **, DBC **, u_int32_t));
+	int  (*join) __P((DB *, DBC **, DBC **, uint32_t));
 	int  (*open) __P((DB *,
-		const char *, const char *, DBTYPE, u_int32_t, int));
-	int  (*put) __P((DB *, DB_TXN *, DBT *, DBT *, u_int32_t));
-	int  (*remove) __P((DB *, const char *, const char *, u_int32_t));
-	int  (*set_cachesize) __P((DB *, u_int32_t, u_int32_t, int));
+		const char *, const char *, DBTYPE, uint32_t, int));
+	int  (*put) __P((DB *, DB_TXN *, DBT *, DBT *, uint32_t));
+	int  (*remove) __P((DB *, const char *, const char *, uint32_t));
+	int  (*set_cachesize) __P((DB *, uint32_t, uint32_t, int));
 	int  (*set_dup_compare) __P((DB *, int (*)(const DBT *, const DBT *)));
 	void (*set_errcall) __P((DB *, void (*)(const char *, char *)));
 	void (*set_errfile) __P((DB *, FILE *));
 	void (*set_errpfx) __P((DB *, const char *));
 	void (*set_feedback) __P((DB *, void (*)(DB *, int, int)));
-	int  (*set_flags) __P((DB *, u_int32_t));
+	int  (*set_flags) __P((DB *, uint32_t));
 	int  (*set_lorder) __P((DB *, int));
 	int  (*set_malloc) __P((DB *, void *(*)(size_t)));
-	int  (*set_pagesize) __P((DB *, u_int32_t));
+	int  (*set_pagesize) __P((DB *, uint32_t));
 	void (*set_paniccall) __P((DB *, void (*)(DB_ENV *, int)));
 	int  (*set_realloc) __P((DB *, void *(*)(void *, size_t)));
-	int  (*stat) __P((DB *, void *, void *(*)(size_t), u_int32_t));
-	int  (*sync) __P((DB *, u_int32_t));
-	int  (*upgrade) __P((DB *, const char *, u_int32_t));
+	int  (*stat) __P((DB *, void *, void *(*)(size_t), uint32_t));
+	int  (*sync) __P((DB *, uint32_t));
+	int  (*upgrade) __P((DB *, const char *, uint32_t));
 
 	int  (*set_bt_compare) __P((DB *, int (*)(const DBT *, const DBT *)));
-	int  (*set_bt_maxkey) __P((DB *, u_int32_t));
-	int  (*set_bt_minkey) __P((DB *, u_int32_t));
+	int  (*set_bt_maxkey) __P((DB *, uint32_t));
+	int  (*set_bt_minkey) __P((DB *, uint32_t));
 	int  (*set_bt_prefix) __P((DB *, size_t (*)(const DBT *, const DBT *)));
 
-	int  (*set_h_ffactor) __P((DB *, u_int32_t));
-	int  (*set_h_hash) __P((DB *, u_int32_t (*)(const void *, u_int32_t)));
-	int  (*set_h_nelem) __P((DB *, u_int32_t));
+	int  (*set_h_ffactor) __P((DB *, uint32_t));
+	int  (*set_h_hash) __P((DB *, uint32_t (*)(const void *, uint32_t)));
+	int  (*set_h_nelem) __P((DB *, uint32_t));
 
 	int  (*set_re_delim) __P((DB *, int));
-	int  (*set_re_len) __P((DB *, u_int32_t));
+	int  (*set_re_len) __P((DB *, uint32_t));
 	int  (*set_re_pad) __P((DB *, int));
 	int  (*set_re_source) __P((DB *, const char *));
 
@@ -629,7 +630,7 @@ struct __db {
 #define	DB_OK_HASH	0x02
 #define	DB_OK_QUEUE	0x04
 #define	DB_OK_RECNO	0x08
-	u_int32_t	am_ok;		/* Legal AM choices. */
+	uint32_t	am_ok;		/* Legal AM choices. */
 
 #define	DB_AM_DISCARD	0x00001		/* Discard any cached pages. */
 #define	DB_AM_DUP	0x00002		/* DB_DUP. */
@@ -648,7 +649,7 @@ struct __db {
 #define	DB_RE_RENUMBER	0x04000		/* DB_RENUMBER. */
 #define	DB_RE_SNAPSHOT	0x08000		/* DB_SNAPSHOT. */
 #define DB_AM_CMPR	0x10000         /* Transparent I/O compression */
-	u_int32_t flags;
+	uint32_t flags;
 };
 
 /*
@@ -657,10 +658,10 @@ struct __db {
  */
 struct __db_ilock {
 	db_pgno_t pgno;			/* Page being locked. */
-	u_int8_t fileid[DB_FILE_ID_LEN];/* File id. */
+	uint8_t fileid[DB_FILE_ID_LEN];/* File id. */
 #define DB_RECORD_LOCK	1
 #define DB_PAGE_LOCK	2
-	u_int8_t type;			/* Record or Page lock */
+	uint8_t type;			/* Record or Page lock */
 };
 
 /*
@@ -670,9 +671,9 @@ struct __db_ilock {
  */
 struct __db_lock_u {
 	size_t		off;		/* Offset of the lock in the region */
-	u_int32_t	ndx;		/* Index of the object referenced by
+	uint32_t	ndx;		/* Index of the object referenced by
 					 * this lock; used for locking. */
-	u_int32_t	gen;		/* Generation number of this lock. */
+	uint32_t	gen;		/* Generation number of this lock. */
 };
 
 /* Cursor description structure. */
@@ -691,8 +692,8 @@ struct __dbc {
 		struct __dbc **tqe_prev;
 	} links;
 
-	u_int32_t lid;			/* Default process' locker id. */
-	u_int32_t locker;		/* Locker for this operation. */
+	uint32_t lid;			/* Default process' locker id. */
+	uint32_t locker;		/* Locker for this operation. */
 	DBT	  lock_dbt;		/* DBT referencing lock. */
 	DB_LOCK_ILOCK lock;		/* Object to be locked. */
 	DB_LOCK	mylock;			/* Lock held on this cursor. */
@@ -701,10 +702,10 @@ struct __dbc {
 	DBT rdata;			/* Returned data. */
 
 	int (*c_close) __P((DBC *));	/* Methods: public. */
-	int (*c_del) __P((DBC *, u_int32_t));
-	int (*c_dup) __P((DBC *, DBC **, u_int32_t));
-	int (*c_get) __P((DBC *, DBT *, DBT *, u_int32_t));
-	int (*c_put) __P((DBC *, DBT *, DBT *, u_int32_t));
+	int (*c_del) __P((DBC *, uint32_t));
+	int (*c_dup) __P((DBC *, DBC **, uint32_t));
+	int (*c_get) __P((DBC *, DBT *, DBT *, uint32_t));
+	int (*c_put) __P((DBC *, DBT *, DBT *, uint32_t));
 
 	int (*c_am_close) __P((DBC *));	/* Methods: private. */
 	int (*c_am_destroy) __P((DBC *));
@@ -716,73 +717,73 @@ struct __dbc {
 #define	DBC_RMW		0x004		/* Acquire write flag in read op. */
 #define	DBC_WRITECURSOR	0x008		/* Cursor may be used to write (CDB). */
 #define	DBC_WRITER	0x010		/* Cursor immediately writing (CDB). */
-	u_int32_t flags;
+	uint32_t flags;
 };
 
 /* Btree/Recno statistics structure. */
 struct __db_bt_stat {
-	u_int32_t bt_metaflags;		/* Metadata flags. */
-	u_int32_t bt_maxkey;		/* Maxkey value. */
-	u_int32_t bt_minkey;		/* Minkey value. */
-	u_int32_t bt_re_len;		/* Fixed-length record length. */
-	u_int32_t bt_re_pad;		/* Fixed-length record pad. */
-	u_int32_t bt_pagesize;		/* Page size. */
-	u_int32_t bt_levels;		/* Tree levels. */
-	u_int32_t bt_nrecs;		/* Number of records. */
-	u_int32_t bt_int_pg;		/* Internal pages. */
-	u_int32_t bt_leaf_pg;		/* Leaf pages. */
-	u_int32_t bt_dup_pg;		/* Duplicate pages. */
-	u_int32_t bt_over_pg;		/* Overflow pages. */
-	u_int32_t bt_free;		/* Pages on the free list. */
-	u_int32_t bt_int_pgfree;	/* Bytes free in internal pages. */
-	u_int32_t bt_leaf_pgfree;	/* Bytes free in leaf pages. */
-	u_int32_t bt_dup_pgfree;	/* Bytes free in duplicate pages. */
-	u_int32_t bt_over_pgfree;	/* Bytes free in overflow pages. */
-	u_int32_t bt_magic;		/* Magic number. */
-	u_int32_t bt_version;		/* Version number. */
+	uint32_t bt_metaflags;		/* Metadata flags. */
+	uint32_t bt_maxkey;		/* Maxkey value. */
+	uint32_t bt_minkey;		/* Minkey value. */
+	uint32_t bt_re_len;		/* Fixed-length record length. */
+	uint32_t bt_re_pad;		/* Fixed-length record pad. */
+	uint32_t bt_pagesize;		/* Page size. */
+	uint32_t bt_levels;		/* Tree levels. */
+	uint32_t bt_nrecs;		/* Number of records. */
+	uint32_t bt_int_pg;		/* Internal pages. */
+	uint32_t bt_leaf_pg;		/* Leaf pages. */
+	uint32_t bt_dup_pg;		/* Duplicate pages. */
+	uint32_t bt_over_pg;		/* Overflow pages. */
+	uint32_t bt_free;		/* Pages on the free list. */
+	uint32_t bt_int_pgfree;	/* Bytes free in internal pages. */
+	uint32_t bt_leaf_pgfree;	/* Bytes free in leaf pages. */
+	uint32_t bt_dup_pgfree;	/* Bytes free in duplicate pages. */
+	uint32_t bt_over_pgfree;	/* Bytes free in overflow pages. */
+	uint32_t bt_magic;		/* Magic number. */
+	uint32_t bt_version;		/* Version number. */
 };
 
 /* Queue statistics structure. */
 struct __db_qam_stat {
-	u_int32_t qs_magic;		/* Magic number. */
-	u_int32_t qs_version;		/* Version number. */
-	u_int32_t qs_metaflags;		/* Metadata flags. */
-	u_int32_t qs_nrecs;		/* Number of records. */
-	u_int32_t qs_pages;		/* Data pages. */
-	u_int32_t qs_pagesize;		/* Page size. */
-	u_int32_t qs_pgfree;		/* Bytes free in data pages. */
-	u_int32_t qs_re_len;		/* Fixed-length record length. */
-	u_int32_t qs_re_pad;		/* Fixed-length record pad. */
-	u_int32_t qs_start;		/* Start offset. */
-	u_int32_t qs_first_recno;	/* First not deleted record. */
-	u_int32_t qs_cur_recno;		/* Last allocated record number. */
+	uint32_t qs_magic;		/* Magic number. */
+	uint32_t qs_version;		/* Version number. */
+	uint32_t qs_metaflags;		/* Metadata flags. */
+	uint32_t qs_nrecs;		/* Number of records. */
+	uint32_t qs_pages;		/* Data pages. */
+	uint32_t qs_pagesize;		/* Page size. */
+	uint32_t qs_pgfree;		/* Bytes free in data pages. */
+	uint32_t qs_re_len;		/* Fixed-length record length. */
+	uint32_t qs_re_pad;		/* Fixed-length record pad. */
+	uint32_t qs_start;		/* Start offset. */
+	uint32_t qs_first_recno;	/* First not deleted record. */
+	uint32_t qs_cur_recno;		/* Last allocated record number. */
 };
 
 /* Hash statistics structure. */
 struct __db_h_stat {
-	u_int32_t hash_magic;		/* Magic number. */
-	u_int32_t hash_version;		/* Version number. */
-	u_int32_t hash_metaflags;	/* Metadata flags. */
-	u_int32_t hash_pagesize;	/* Page size. */
-	u_int32_t hash_nelem;		/* Original nelem specified. */
-	u_int32_t hash_ffactor;		/* Fill factor specified at create. */
-	u_int32_t hash_nrecs;		/* Number of records. */
-	u_int32_t hash_buckets;		/* Number of hash buckets. */
-	u_int32_t hash_free;		/* Pages on the free list. */
-	u_int32_t hash_bfree;		/* Bytes free on bucket pages. */
-	u_int32_t hash_bigpages;	/* Number of big key/data pages. */
-	u_int32_t hash_big_bfree;	/* Bytes free on big item pages. */
-	u_int32_t hash_overflows;	/* Number of overflow pages. */
-	u_int32_t hash_ovfl_free;	/* Bytes free on ovfl pages. */
-	u_int32_t hash_dup;		/* Number of dup pages. */
-	u_int32_t hash_dup_free;	/* Bytes free on duplicate pages. */
+	uint32_t hash_magic;		/* Magic number. */
+	uint32_t hash_version;		/* Version number. */
+	uint32_t hash_metaflags;	/* Metadata flags. */
+	uint32_t hash_pagesize;	/* Page size. */
+	uint32_t hash_nelem;		/* Original nelem specified. */
+	uint32_t hash_ffactor;		/* Fill factor specified at create. */
+	uint32_t hash_nrecs;		/* Number of records. */
+	uint32_t hash_buckets;		/* Number of hash buckets. */
+	uint32_t hash_free;		/* Pages on the free list. */
+	uint32_t hash_bfree;		/* Bytes free on bucket pages. */
+	uint32_t hash_bigpages;	/* Number of big key/data pages. */
+	uint32_t hash_big_bfree;	/* Bytes free on big item pages. */
+	uint32_t hash_overflows;	/* Number of overflow pages. */
+	uint32_t hash_ovfl_free;	/* Bytes free on ovfl pages. */
+	uint32_t hash_dup;		/* Number of dup pages. */
+	uint32_t hash_dup_free;	/* Bytes free on duplicate pages. */
 };
 
 #if defined(__cplusplus)
 extern "C" {
 #endif
-int   CDB_db_create __P((DB **, DB_ENV *, u_int32_t));
-int   CDB_db_env_create __P((DB_ENV **, u_int32_t));
+int   CDB_db_create __P((DB **, DB_ENV *, uint32_t));
+int   CDB_db_env_create __P((DB_ENV **, uint32_t));
 char *CDB_db_strerror __P((int));
 char *CDB_db_version __P((int *, int *, int *));
 
@@ -857,7 +858,7 @@ typedef enum {
 struct __db_lockreq {
 	db_lockop_t	 op;		/* Operation. */
 	db_lockmode_t	 mode;		/* Requested mode. */
-	u_int32_t	 locker;	/* Locker identity. */
+	uint32_t	 locker;	/* Locker identity. */
 	DBT		*obj;		/* Object being locked. */
 	DB_LOCK		 lock;		/* Lock returned. */
 };
@@ -868,38 +869,38 @@ struct __db_lockreq {
  * Standard Read/Write (or exclusive/shared) locks.
  */
 #define	DB_LOCK_RW_N	3
-extern const u_int8_t CDB_db_rw_conflicts[];
+extern const uint8_t CDB_db_rw_conflicts[];
 
 /* Multi-granularity locking. */
 #define	DB_LOCK_RIW_N	6
-extern const u_int8_t CDB_db_riw_conflicts[];
+extern const uint8_t CDB_db_riw_conflicts[];
 
 struct __db_lock_stat {
-	u_int32_t st_lastid;		/* Last allocated locker ID. */
-	u_int32_t st_maxlocks;		/* Maximum number of locks in table. */
-	u_int32_t st_nmodes;		/* Number of lock modes. */
-	u_int32_t st_nlockers;		/* Number of lockers. */
-	u_int32_t st_maxnlockers;	/* Maximum number of lockers. */
-	u_int32_t st_nconflicts;	/* Number of lock conflicts. */
-	u_int32_t st_nrequests;		/* Number of lock gets. */
-	u_int32_t st_nreleases;		/* Number of lock puts. */
-	u_int32_t st_ndeadlocks;	/* Number of lock deadlocks. */
-	u_int32_t st_region_wait;	/* Region lock granted after wait. */
-	u_int32_t st_region_nowait;	/* Region lock granted without wait. */
-	u_int32_t st_regsize;		/* Region size. */
+	uint32_t st_lastid;		/* Last allocated locker ID. */
+	uint32_t st_maxlocks;		/* Maximum number of locks in table. */
+	uint32_t st_nmodes;		/* Number of lock modes. */
+	uint32_t st_nlockers;		/* Number of lockers. */
+	uint32_t st_maxnlockers;	/* Maximum number of lockers. */
+	uint32_t st_nconflicts;	/* Number of lock conflicts. */
+	uint32_t st_nrequests;		/* Number of lock gets. */
+	uint32_t st_nreleases;		/* Number of lock puts. */
+	uint32_t st_ndeadlocks;	/* Number of lock deadlocks. */
+	uint32_t st_region_wait;	/* Region lock granted after wait. */
+	uint32_t st_region_nowait;	/* Region lock granted without wait. */
+	uint32_t st_regsize;		/* Region size. */
 };
 
 #if defined(__cplusplus)
 extern "C" {
 #endif
-int	  CDB_lock_detect __P((DB_ENV *, u_int32_t, u_int32_t, int *));
+int	  CDB_lock_detect __P((DB_ENV *, uint32_t, uint32_t, int *));
 int	  CDB_lock_get __P((DB_ENV *,
-	    u_int32_t, u_int32_t, const DBT *, db_lockmode_t, DB_LOCK *));
-int	  CDB_lock_id __P((DB_ENV *, u_int32_t *));
+	    uint32_t, uint32_t, const DBT *, db_lockmode_t, DB_LOCK *));
+int	  CDB_lock_id __P((DB_ENV *, uint32_t *));
 int	  CDB_lock_put __P((DB_ENV *, DB_LOCK *));
 int	  CDB_lock_stat __P((DB_ENV *, DB_LOCK_STAT **, void *(*)(size_t)));
 int	  CDB_lock_vec __P((DB_ENV *,
-	    u_int32_t, u_int32_t, DB_LOCKREQ *, int, DB_LOCKREQ **));
+	    uint32_t, uint32_t, DB_LOCKREQ *, int, DB_LOCKREQ **));
 #if defined(__cplusplus)
 }
 #endif
@@ -922,40 +923,40 @@ int	  CDB_lock_vec __P((DB_ENV *,
  * offset is reached.
  */
 struct __db_lsn {
-	u_int32_t	file;		/* File ID. */
-	u_int32_t	offset;		/* File offset. */
+	uint32_t	file;		/* File ID. */
+	uint32_t	offset;		/* File offset. */
 };
 
 /* Log statistics structure. */
 struct __db_log_stat {
-	u_int32_t st_magic;		/* Log file magic number. */
-	u_int32_t st_version;		/* Log file version number. */
+	uint32_t st_magic;		/* Log file magic number. */
+	uint32_t st_version;		/* Log file version number. */
 	int st_mode;			/* Log file mode. */
-	u_int32_t st_lg_bsize;		/* Log buffer size. */
-	u_int32_t st_lg_max;		/* Maximum log file size. */
-	u_int32_t st_w_bytes;		/* Bytes to log. */
-	u_int32_t st_w_mbytes;		/* Megabytes to log. */
-	u_int32_t st_wc_bytes;		/* Bytes to log since checkpoint. */
-	u_int32_t st_wc_mbytes;		/* Megabytes to log since checkpoint. */
-	u_int32_t st_wcount;		/* Total writes to the log. */
-	u_int32_t st_wcount_fill;	/* Overflow writes to the log. */
-	u_int32_t st_scount;		/* Total syncs to the log. */
-	u_int32_t st_region_wait;	/* Region lock granted after wait. */
-	u_int32_t st_region_nowait;	/* Region lock granted without wait. */
-	u_int32_t st_cur_file;		/* Current log file number. */
-	u_int32_t st_cur_offset;	/* Current log file offset. */
-	u_int32_t st_regsize;		/* Region size. */
+	uint32_t st_lg_bsize;		/* Log buffer size. */
+	uint32_t st_lg_max;		/* Maximum log file size. */
+	uint32_t st_w_bytes;		/* Bytes to log. */
+	uint32_t st_w_mbytes;		/* Megabytes to log. */
+	uint32_t st_wc_bytes;		/* Bytes to log since checkpoint. */
+	uint32_t st_wc_mbytes;		/* Megabytes to log since checkpoint. */
+	uint32_t st_wcount;		/* Total writes to the log. */
+	uint32_t st_wcount_fill;	/* Overflow writes to the log. */
+	uint32_t st_scount;		/* Total syncs to the log. */
+	uint32_t st_region_wait;	/* Region lock granted after wait. */
+	uint32_t st_region_nowait;	/* Region lock granted without wait. */
+	uint32_t st_cur_file;		/* Current log file number. */
+	uint32_t st_cur_offset;	/* Current log file offset. */
+	uint32_t st_regsize;		/* Region size. */
 };
 
 #if defined(__cplusplus)
 extern "C" {
 #endif
-int	 CDB_log_archive __P((DB_ENV *, char **[], u_int32_t, void *(*)(size_t)));
+int	 CDB_log_archive __P((DB_ENV *, char **[], uint32_t, void *(*)(size_t)));
 int	 CDB_log_compare __P((const DB_LSN *, const DB_LSN *));
 int	 CDB_log_file __P((DB_ENV *, const DB_LSN *, char *, size_t));
 int	 CDB_log_flush __P((DB_ENV *, const DB_LSN *));
-int	 CDB_log_get __P((DB_ENV *, DB_LSN *, DBT *, u_int32_t));
-int	 CDB_log_put __P((DB_ENV *, DB_LSN *, const DBT *, u_int32_t));
+int	 CDB_log_get __P((DB_ENV *, DB_LSN *, DBT *, uint32_t));
+int	 CDB_log_put __P((DB_ENV *, DB_LSN *, const DBT *, uint32_t));
 int	 CDB_log_register __P((DB_ENV *, DB *, const char *, int32_t *));
 int	 CDB_log_stat __P((DB_ENV *, DB_LOG_STAT **, void *(*)(size_t)));
 int	 CDB_log_unregister __P((DB_ENV *, int32_t));
@@ -979,47 +980,47 @@ int	 CDB_log_unregister __P((DB_ENV *, int32_t));
 
 /* Mpool statistics structure. */
 struct __db_mpool_stat {
-	u_int32_t st_cache_hit;		/* Pages found in the cache. */
-	u_int32_t st_cache_miss;	/* Pages not found in the cache. */
-	u_int32_t st_map;		/* Pages from mapped files. */
-	u_int32_t st_page_create;	/* Pages created in the cache. */
-	u_int32_t st_page_in;		/* Pages read in. */
-	u_int32_t st_page_out;		/* Pages written out. */
-	u_int32_t st_ro_evict;		/* Clean pages forced from the cache. */
-	u_int32_t st_rw_evict;		/* Dirty pages forced from the cache. */
-	u_int32_t st_hash_buckets;	/* Number of hash buckets. */
-	u_int32_t st_hash_searches;	/* Total hash chain searches. */
-	u_int32_t st_hash_longest;	/* Longest hash chain searched. */
-	u_int32_t st_hash_examined;	/* Total hash entries searched. */
-	u_int32_t st_page_clean;	/* Clean pages. */
-	u_int32_t st_page_dirty;	/* Dirty pages. */
-	u_int32_t st_page_trickle;	/* Pages written by CDB_memp_trickle. */
-	u_int32_t st_region_wait;	/* Region lock granted after wait. */
-	u_int32_t st_region_nowait;	/* Region lock granted without wait. */
-	u_int32_t st_regsize;		/* Region size. */
-	u_int32_t st_gbytes;		/* Cache size: GB. */
-	u_int32_t st_bytes;		/* Cache size: B. */
+	uint32_t st_cache_hit;		/* Pages found in the cache. */
+	uint32_t st_cache_miss;	/* Pages not found in the cache. */
+	uint32_t st_map;		/* Pages from mapped files. */
+	uint32_t st_page_create;	/* Pages created in the cache. */
+	uint32_t st_page_in;		/* Pages read in. */
+	uint32_t st_page_out;		/* Pages written out. */
+	uint32_t st_ro_evict;		/* Clean pages forced from the cache. */
+	uint32_t st_rw_evict;		/* Dirty pages forced from the cache. */
+	uint32_t st_hash_buckets;	/* Number of hash buckets. */
+	uint32_t st_hash_searches;	/* Total hash chain searches. */
+	uint32_t st_hash_longest;	/* Longest hash chain searched. */
+	uint32_t st_hash_examined;	/* Total hash entries searched. */
+	uint32_t st_page_clean;	/* Clean pages. */
+	uint32_t st_page_dirty;	/* Dirty pages. */
+	uint32_t st_page_trickle;	/* Pages written by CDB_memp_trickle. */
+	uint32_t st_region_wait;	/* Region lock granted after wait. */
+	uint32_t st_region_nowait;	/* Region lock granted without wait. */
+	uint32_t st_regsize;		/* Region size. */
+	uint32_t st_gbytes;		/* Cache size: GB. */
+	uint32_t st_bytes;		/* Cache size: B. */
 };
 
 /* Mpool file open information structure. */
 struct __db_mpool_finfo {
 	int	   ftype;		/* File type. */
 	DBT	  *pgcookie;		/* Byte-string passed to pgin/pgout. */
-	u_int8_t  *fileid;		/* Unique file ID. */
+	uint8_t  *fileid;		/* Unique file ID. */
 	int32_t	   lsn_offset;		/* LSN offset in page. */
-	u_int32_t  clear_len;		/* Cleared length on created pages. */
+	uint32_t  clear_len;		/* Cleared length on created pages. */
 };
 
 /* Mpool file statistics structure. */
 struct __db_mpool_fstat {
 	char *file_name;		/* File name. */
 	size_t st_pagesize;		/* Page size. */
-	u_int32_t st_cache_hit;		/* Pages found in the cache. */
-	u_int32_t st_cache_miss;	/* Pages not found in the cache. */
-	u_int32_t st_map;		/* Pages from mapped files. */
-	u_int32_t st_page_create;	/* Pages created in the cache. */
-	u_int32_t st_page_in;		/* Pages read in. */
-	u_int32_t st_page_out;		/* Pages written out. */
+	uint32_t st_cache_hit;		/* Pages found in the cache. */
+	uint32_t st_cache_miss;	/* Pages not found in the cache. */
+	uint32_t st_map;		/* Pages from mapped files. */
+	uint32_t st_page_create;	/* Pages created in the cache. */
+	uint32_t st_page_in;		/* Pages read in. */
+	uint32_t st_page_out;		/* Pages written out. */
 };
 
 
@@ -1036,11 +1037,11 @@ extern "C" {
 extern "C" {
 #endif
 int	CDB_memp_fclose __P((DB_MPOOLFILE *));
-int	CDB_memp_fget __P((DB_MPOOLFILE *, db_pgno_t *, u_int32_t, void *));
+int	CDB_memp_fget __P((DB_MPOOLFILE *, db_pgno_t *, uint32_t, void *));
 int	CDB_memp_fopen __P((DB_ENV *, const char *,
-	    u_int32_t, int, size_t, DB_MPOOL_FINFO *, DB_MPOOLFILE **));
-int	CDB_memp_fput __P((DB_MPOOLFILE *, void *, u_int32_t));
-int	CDB_memp_fset __P((DB_MPOOLFILE *, void *, u_int32_t));
+	    uint32_t, int, size_t, DB_MPOOL_FINFO *, DB_MPOOLFILE **));
+int	CDB_memp_fput __P((DB_MPOOLFILE *, void *, uint32_t));
+int	CDB_memp_fset __P((DB_MPOOLFILE *, void *, uint32_t));
 int	CDB_memp_fsync __P((DB_MPOOLFILE *));
 int	CDB_memp_register __P((DB_ENV *, int,
 	    int (*)(db_pgno_t, void *, DBT *),
@@ -1069,8 +1070,8 @@ int	CDB_memp_trickle __P((DB_ENV *, int, int *));
 
 /* Transaction statistics structure. */
 struct __db_txn_active {
-	u_int32_t	txnid;		/* Transaction ID */
-	u_int32_t	parentid;	/* Transaction ID of parent */
+	uint32_t	txnid;		/* Transaction ID */
+	uint32_t	parentid;	/* Transaction ID of parent */
 	DB_LSN		lsn;		/* Lsn of the begin record */
 };
 
@@ -1078,28 +1079,28 @@ struct __db_txn_stat {
 	DB_LSN	  st_last_ckp;		/* lsn of the last checkpoint */
 	DB_LSN	  st_pending_ckp;	/* last checkpoint did not finish */
 	time_t	  st_time_ckp;		/* time of last checkpoint */
-	u_int32_t st_last_txnid;	/* last transaction id given out */
-	u_int32_t st_maxtxns;		/* maximum txns possible */
-	u_int32_t st_naborts;		/* number of aborted transactions */
-	u_int32_t st_nbegins;		/* number of begun transactions */
-	u_int32_t st_ncommits;		/* number of committed transactions */
-	u_int32_t st_nactive;		/* number of active transactions */
-	u_int32_t st_maxnactive;	/* maximum active transactions */
+	uint32_t st_last_txnid;	/* last transaction id given out */
+	uint32_t st_maxtxns;		/* maximum txns possible */
+	uint32_t st_naborts;		/* number of aborted transactions */
+	uint32_t st_nbegins;		/* number of begun transactions */
+	uint32_t st_ncommits;		/* number of committed transactions */
+	uint32_t st_nactive;		/* number of active transactions */
+	uint32_t st_maxnactive;	/* maximum active transactions */
 	DB_TXN_ACTIVE
 		 *st_txnarray;		/* array of active transactions */
-	u_int32_t st_region_wait;	/* Region lock granted after wait. */
-	u_int32_t st_region_nowait;	/* Region lock granted without wait. */
-	u_int32_t st_regsize;		/* Region size. */
+	uint32_t st_region_wait;	/* Region lock granted after wait. */
+	uint32_t st_region_nowait;	/* Region lock granted without wait. */
+	uint32_t st_regsize;		/* Region size. */
 };
 
 #if defined(__cplusplus)
 extern "C" {
 #endif
 int	  CDB_txn_abort __P((DB_TXN *));
-int	  CDB_txn_begin __P((DB_ENV *, DB_TXN *, DB_TXN **, u_int32_t));
-int	  CDB_txn_checkpoint __P((DB_ENV *, u_int32_t, u_int32_t));
-int	  CDB_txn_commit __P((DB_TXN *, u_int32_t));
-u_int32_t CDB_txn_id __P((DB_TXN *));
+int	  CDB_txn_begin __P((DB_ENV *, DB_TXN *, DB_TXN **, uint32_t));
+int	  CDB_txn_checkpoint __P((DB_ENV *, uint32_t, uint32_t));
+int	  CDB_txn_commit __P((DB_TXN *, uint32_t));
+uint32_t CDB_txn_id __P((DB_TXN *));
 int	  CDB_txn_prepare __P((DB_TXN *));
 int	  CDB_txn_stat __P((DB_ENV *, DB_TXN_STAT **, void *(*)(size_t)));
 #if defined(__cplusplus)

--- a/db/db.h.win32
+++ b/db/db.h.win32
@@ -30,11 +30,11 @@
 
 #define snprintf _snprintf
 #define vsnprintf _vsnprintf
-typedef unsigned char u_int8_t;
+typedef unsigned char uint8_t;
 typedef short int16_t;
-typedef unsigned short u_int16_t;
+typedef unsigned short uint16_t;
 typedef int int32_t;
-typedef unsigned int u_int32_t;
+typedef unsigned int uint32_t;
 typedef long int64_t;
 typedef unsigned long u_int64_t;
 typedef int32_t register_t;
@@ -109,11 +109,11 @@ typedef unsigned long ssize_t;
 #define	DB_VERSION_PATCH	55
 #define	DB_VERSION_STRING	"Sleepycat Software: Berkeley DB 3.0.55: (February 28, 2000)"
 
-typedef	u_int32_t	db_pgno_t;	/* Page number type. */
-typedef	u_int16_t	db_indx_t;	/* Page offset type. */
+typedef	uint32_t	db_pgno_t;	/* Page number type. */
+typedef	uint16_t	db_indx_t;	/* Page offset type. */
 #define	DB_MAX_PAGES	0xffffffff	/* >= # of pages in a file */
 
-typedef	u_int32_t	db_recno_t;	/* Record number type. */
+typedef	uint32_t	db_recno_t;	/* Record number type. */
 #define	DB_MAX_RECORDS	0xffffffff	/* >= # of records in a tree */
 
 /* Forward structure declarations, so applications get type checking. */
@@ -146,17 +146,17 @@ struct __db_cmpr_info;	typedef struct __db_cmpr_info DB_CMPR_INFO;
 /* Key/data structure -- a Data-Base Thang. */
 struct __db_dbt {
 	void	 *data;			/* key/data */
-	u_int32_t size;			/* key/data length */
-	u_int32_t ulen;			/* RO: length of user buffer. */
-	u_int32_t dlen;			/* RO: get/put record length. */
-	u_int32_t doff;			/* RO: get/put record offset. */
+	uint32_t size;			/* key/data length */
+	uint32_t ulen;			/* RO: length of user buffer. */
+	uint32_t dlen;			/* RO: get/put record length. */
+	uint32_t doff;			/* RO: get/put record offset. */
 
 #define	DB_DBT_INTERNAL	0x001		/* Ignore user's malloc (internal). */
 #define	DB_DBT_MALLOC	0x002		/* Return in malloc'd memory. */
 #define	DB_DBT_PARTIAL	0x004		/* Partial put/get. */
 #define	DB_DBT_REALLOC	0x008		/* Return in realloc'd memory. */
 #define	DB_DBT_USERMEM	0x010		/* Return in user's memory. */
-	u_int32_t flags;
+	uint32_t flags;
 };
 
 /*
@@ -164,12 +164,12 @@ struct __db_dbt {
  */
 struct __db_cmpr_info {
     int (*compress)                     /* Compression function */
-	__P((const u_int8_t*, int, u_int8_t**, int*,void *));
+	__P((const uint8_t*, int, uint8_t**, int*,void *));
     int (*uncompress)                   /* Uncompression function */
-	__P((const u_int8_t*, int, u_int8_t*, int,void *));
-    u_int8_t coefficient;	        /* Compression factor is 1<<coefficient  */
-    u_int8_t max_npages;                /* Max number of pages  worst case */
-    u_int8_t zlib_flags;                /* Zlib Compresson Level */
+	__P((const uint8_t*, int, uint8_t*, int,void *));
+    uint8_t coefficient;	        /* Compression factor is 1<<coefficient  */
+    uint8_t max_npages;                /* Max number of pages  worst case */
+    uint8_t zlib_flags;                /* Zlib Compresson Level */
     void         *user_data;            /* Persistent information for compression functions */
 };
 
@@ -275,28 +275,28 @@ struct __db_env {
 #define	DB_VERB_DEADLOCK	0x0002	/* Deadlock detection information. */
 #define	DB_VERB_RECOVERY	0x0004	/* Recovery information. */
 #define	DB_VERB_WAITSFOR	0x0008	/* Dump waits-for table. */
-	u_int32_t	 verbose;	/* Verbose output. */
+	uint32_t	 verbose;	/* Verbose output. */
 
 	/* Locking. */
-	u_int8_t	*lk_conflicts;	/* Two dimensional conflict matrix. */
-	u_int32_t	 lk_modes;	/* Number of lock modes in table. */
-	u_int32_t	 lk_max;	/* Maximum number of locks. */
-	u_int32_t	 lk_detect;	/* Deadlock detect on all conflicts. */
+	uint8_t	*lk_conflicts;	/* Two dimensional conflict matrix. */
+	uint32_t	 lk_modes;	/* Number of lock modes in table. */
+	uint32_t	 lk_max;	/* Maximum number of locks. */
+	uint32_t	 lk_detect;	/* Deadlock detect on all conflicts. */
 
 	/* Logging. */
-	u_int32_t	 lg_bsize;	/* Buffer size. */
-	u_int32_t	 lg_max;	/* Maximum file size. */
+	uint32_t	 lg_bsize;	/* Buffer size. */
+	uint32_t	 lg_max;	/* Maximum file size. */
 
 	/* Memory pool. */
-	u_int32_t	 mp_gbytes;	/* Cachesize: GB. */
-	u_int32_t	 mp_bytes;	/* Cachesize: Bytes. */
+	uint32_t	 mp_gbytes;	/* Cachesize: GB. */
+	uint32_t	 mp_bytes;	/* Cachesize: Bytes. */
 	size_t		 mp_size;	/* DEPRECATED: Cachesize: bytes. */
 	int		 mp_ncache;	/* Number of cache regions. */
 	size_t		 mp_mmapsize;	/* Maximum file size for mmap. */
 	DB_CMPR_INFO   * mp_cmpr_info;  /* Compression info. */
 
 	/* Transactions. */
-	u_int32_t	 tx_max;	/* Maximum number of transactions. */
+	uint32_t	 tx_max;	/* Maximum number of transactions. */
 	int (*tx_recover)		/* Dispatch function for recovery. */
 	    __P((DB_ENV *, DBT *, DB_LSN *, int, void *));
 
@@ -349,12 +349,12 @@ struct __db_env {
 	void	*cj_internal;		/* C++/Java private. */
 
 					/* Methods. */
-	int  (*close) __P((DB_ENV *, u_int32_t));
+	int  (*close) __P((DB_ENV *, uint32_t));
 	void (*err) __P((const DB_ENV *, int, const char *, ...));
 	void (*errx) __P((const DB_ENV *, const char *, ...));
 	int  (*open) __P((DB_ENV *,
-		const char *, char * const *, u_int32_t, int));
-	int  (*remove) __P((DB_ENV *, const char *, char * const *, u_int32_t));
+		const char *, char * const *, uint32_t, int));
+	int  (*remove) __P((DB_ENV *, const char *, char * const *, uint32_t));
 	void (*set_errcall) __P((DB_ENV *, void (*)(const char *, char *)));
 	void (*set_errfile) __P((DB_ENV *, FILE *));
 	void (*set_errpfx) __P((DB_ENV *, const char *));
@@ -365,20 +365,20 @@ struct __db_env {
 	int  (*set_panic) __P((DB_ENV *, int));
 	void (*set_paniccall) __P((DB_ENV *, void (*)(DB_ENV *, int)));
 	int  (*set_region_init) __P((DB_ENV *, int));
-	int  (*set_tas_spins) __P((DB_ENV *, u_int32_t));
-	int  (*set_verbose) __P((DB_ENV *, u_int32_t, int));
+	int  (*set_tas_spins) __P((DB_ENV *, uint32_t));
+	int  (*set_verbose) __P((DB_ENV *, uint32_t, int));
 
-	int  (*set_lg_bsize) __P((DB_ENV *, u_int32_t));
-	int  (*set_lg_max) __P((DB_ENV *, u_int32_t));
+	int  (*set_lg_bsize) __P((DB_ENV *, uint32_t));
+	int  (*set_lg_max) __P((DB_ENV *, uint32_t));
 
-	int  (*set_lk_conflicts) __P((DB_ENV *, u_int8_t *, int));
-	int  (*set_lk_detect) __P((DB_ENV *, u_int32_t));
-	int  (*set_lk_max) __P((DB_ENV *, u_int32_t));
+	int  (*set_lk_conflicts) __P((DB_ENV *, uint8_t *, int));
+	int  (*set_lk_detect) __P((DB_ENV *, uint32_t));
+	int  (*set_lk_max) __P((DB_ENV *, uint32_t));
 
 	int  (*set_mp_mmapsize) __P((DB_ENV *, size_t));
-	int  (*set_cachesize) __P((DB_ENV *, u_int32_t, u_int32_t, int));
+	int  (*set_cachesize) __P((DB_ENV *, uint32_t, uint32_t, int));
 
-	int  (*set_tx_max) __P((DB_ENV *, u_int32_t));
+	int  (*set_tx_max) __P((DB_ENV *, uint32_t));
 	int  (*set_tx_recover) __P((DB_ENV *,
 		int (*)(DB_ENV *, DBT *, DB_LSN *, int, void *)));
 
@@ -390,7 +390,7 @@ struct __db_env {
 	int  (*set_func_free) __P((DB_ENV *, void (*)(void *)));
 	int  (*set_func_fsync) __P((DB_ENV *, int (*)(int)));
 	int  (*set_func_ioinfo) __P((DB_ENV *, int (*)(const char *,
-		int, u_int32_t *, u_int32_t *, u_int32_t *)));
+		int, uint32_t *, uint32_t *, uint32_t *)));
 	int  (*set_func_malloc) __P((DB_ENV *, void *(*)(size_t)));
 	int  (*set_func_map) __P((DB_ENV *,
 		int (*)(char *, size_t, int, int, void **)));
@@ -400,7 +400,7 @@ struct __db_env {
 	int  (*set_func_rename) __P((DB_ENV *,
 		int (*)(const char *, const char *)));
 	int  (*set_func_seek) __P((DB_ENV *,
-		int (*)(int, size_t, db_pgno_t, u_int32_t, int, int)));
+		int (*)(int, size_t, db_pgno_t, uint32_t, int, int)));
 	int  (*set_func_sleep) __P((DB_ENV *, int (*)(u_long, u_long)));
 	int  (*set_func_unlink) __P((DB_ENV *, int (*)(const char *)));
 	int  (*set_func_unmap) __P((DB_ENV *, int (*)(void *, size_t)));
@@ -435,7 +435,7 @@ struct __db_env {
 #define	DB_ENV_TXN		0x01000	/* DB_TXN_NOSYNC set. */
 #define	DB_ENV_TXN_NOSYNC	0x02000	/* DB_TXN_NOSYNC set. */
 #define	DB_ENV_USER_ALLOC	0x04000	/* User allocated the structure. */
-	u_int32_t	 flags;		/* Flags. */
+	uint32_t	 flags;		/* Flags. */
 };
 
 /*******************************************************
@@ -566,7 +566,7 @@ struct __db {
 
 	void	*mutexp;		/* Synchronization for free threading */
 
-	u_int8_t fileid[DB_FILE_ID_LEN];/* File's unique ID for locking. */
+	uint8_t fileid[DB_FILE_ID_LEN];/* File's unique ID for locking. */
 
 #define	DB_LOGFILEID_INVALID	-1
 	int32_t	 log_fileid;		/* File's unique ID for logging. */
@@ -612,48 +612,48 @@ struct __db {
 	void	*xa_internal;		/* XA private. */
 
 					/* Methods. */
-	int  (*close) __P((DB *, u_int32_t));
-	int  (*cursor) __P((DB *, DB_TXN *, DBC **, u_int32_t));
-	int  (*del) __P((DB *, DB_TXN *, DBT *, u_int32_t));
+	int  (*close) __P((DB *, uint32_t));
+	int  (*cursor) __P((DB *, DB_TXN *, DBC **, uint32_t));
+	int  (*del) __P((DB *, DB_TXN *, DBT *, uint32_t));
 	void (*err) __P((DB *, int, const char *, ...));
 	void (*errx) __P((DB *, const char *, ...));
 	int  (*fd) __P((DB *, int *));
-	int  (*get) __P((DB *, DB_TXN *, DBT *, DBT *, u_int32_t));
+	int  (*get) __P((DB *, DB_TXN *, DBT *, DBT *, uint32_t));
 	int  (*get_byteswapped) __P((DB *));
 	DBTYPE
 	     (*get_type) __P((DB *));
-	int  (*join) __P((DB *, DBC **, DBC **, u_int32_t));
+	int  (*join) __P((DB *, DBC **, DBC **, uint32_t));
 	int  (*open) __P((DB *,
-		const char *, const char *, DBTYPE, u_int32_t, int));
-	int  (*put) __P((DB *, DB_TXN *, DBT *, DBT *, u_int32_t));
-	int  (*remove) __P((DB *, const char *, const char *, u_int32_t));
-	int  (*set_cachesize) __P((DB *, u_int32_t, u_int32_t, int));
+		const char *, const char *, DBTYPE, uint32_t, int));
+	int  (*put) __P((DB *, DB_TXN *, DBT *, DBT *, uint32_t));
+	int  (*remove) __P((DB *, const char *, const char *, uint32_t));
+	int  (*set_cachesize) __P((DB *, uint32_t, uint32_t, int));
 	int  (*set_dup_compare) __P((DB *, int (*)(const DBT *, const DBT *)));
 	void (*set_errcall) __P((DB *, void (*)(const char *, char *)));
 	void (*set_errfile) __P((DB *, FILE *));
 	void (*set_errpfx) __P((DB *, const char *));
 	void (*set_feedback) __P((DB *, void (*)(DB *, int, int)));
-	int  (*set_flags) __P((DB *, u_int32_t));
+	int  (*set_flags) __P((DB *, uint32_t));
 	int  (*set_lorder) __P((DB *, int));
 	int  (*set_malloc) __P((DB *, void *(*)(size_t)));
-	int  (*set_pagesize) __P((DB *, u_int32_t));
+	int  (*set_pagesize) __P((DB *, uint32_t));
 	void (*set_paniccall) __P((DB *, void (*)(DB_ENV *, int)));
 	int  (*set_realloc) __P((DB *, void *(*)(void *, size_t)));
-	int  (*stat) __P((DB *, void *, void *(*)(size_t), u_int32_t));
-	int  (*sync) __P((DB *, u_int32_t));
-	int  (*upgrade) __P((DB *, const char *, u_int32_t));
+	int  (*stat) __P((DB *, void *, void *(*)(size_t), uint32_t));
+	int  (*sync) __P((DB *, uint32_t));
+	int  (*upgrade) __P((DB *, const char *, uint32_t));
 
 	int  (*set_bt_compare) __P((DB *, int (*)(const DBT *, const DBT *)));
-	int  (*set_bt_maxkey) __P((DB *, u_int32_t));
-	int  (*set_bt_minkey) __P((DB *, u_int32_t));
+	int  (*set_bt_maxkey) __P((DB *, uint32_t));
+	int  (*set_bt_minkey) __P((DB *, uint32_t));
 	int  (*set_bt_prefix) __P((DB *, size_t (*)(const DBT *, const DBT *)));
 
-	int  (*set_h_ffactor) __P((DB *, u_int32_t));
-	int  (*set_h_hash) __P((DB *, u_int32_t (*)(const void *, u_int32_t)));
-	int  (*set_h_nelem) __P((DB *, u_int32_t));
+	int  (*set_h_ffactor) __P((DB *, uint32_t));
+	int  (*set_h_hash) __P((DB *, uint32_t (*)(const void *, uint32_t)));
+	int  (*set_h_nelem) __P((DB *, uint32_t));
 
 	int  (*set_re_delim) __P((DB *, int));
-	int  (*set_re_len) __P((DB *, u_int32_t));
+	int  (*set_re_len) __P((DB *, uint32_t));
 	int  (*set_re_pad) __P((DB *, int));
 	int  (*set_re_source) __P((DB *, const char *));
 
@@ -661,7 +661,7 @@ struct __db {
 #define	DB_OK_HASH	0x02
 #define	DB_OK_QUEUE	0x04
 #define	DB_OK_RECNO	0x08
-	u_int32_t	am_ok;		/* Legal AM choices. */
+	uint32_t	am_ok;		/* Legal AM choices. */
 
 #define	DB_AM_DISCARD	0x00001		/* Discard any cached pages. */
 #define	DB_AM_DUP	0x00002		/* DB_DUP. */
@@ -680,7 +680,7 @@ struct __db {
 #define	DB_RE_RENUMBER	0x04000		/* DB_RENUMBER. */
 #define	DB_RE_SNAPSHOT	0x08000		/* DB_SNAPSHOT. */
 #define DB_AM_CMPR	0x10000         /* Transparent I/O compression */
-	u_int32_t flags;
+	uint32_t flags;
 };
 
 /*
@@ -689,10 +689,10 @@ struct __db {
  */
 struct __db_ilock {
 	db_pgno_t pgno;			/* Page being locked. */
-	u_int8_t fileid[DB_FILE_ID_LEN];/* File id. */
+	uint8_t fileid[DB_FILE_ID_LEN];/* File id. */
 #define DB_RECORD_LOCK	1
 #define DB_PAGE_LOCK	2
-	u_int8_t type;			/* Record or Page lock */
+	uint8_t type;			/* Record or Page lock */
 };
 
 /*
@@ -702,9 +702,9 @@ struct __db_ilock {
  */
 struct __db_lock_u {
 	size_t		off;		/* Offset of the lock in the region */
-	u_int32_t	ndx;		/* Index of the object referenced by
+	uint32_t	ndx;		/* Index of the object referenced by
 					 * this lock; used for locking. */
-	u_int32_t	gen;		/* Generation number of this lock. */
+	uint32_t	gen;		/* Generation number of this lock. */
 };
 
 /* Cursor description structure. */
@@ -723,8 +723,8 @@ struct __dbc {
 		struct __dbc **tqe_prev;
 	} links;
 
-	u_int32_t lid;			/* Default process' locker id. */
-	u_int32_t locker;		/* Locker for this operation. */
+	uint32_t lid;			/* Default process' locker id. */
+	uint32_t locker;		/* Locker for this operation. */
 	DBT	  lock_dbt;		/* DBT referencing lock. */
 	DB_LOCK_ILOCK lock;		/* Object to be locked. */
 	DB_LOCK	mylock;			/* Lock held on this cursor. */
@@ -733,10 +733,10 @@ struct __dbc {
 	DBT rdata;			/* Returned data. */
 
 	int (*c_close) __P((DBC *));	/* Methods: public. */
-	int (*c_del) __P((DBC *, u_int32_t));
-	int (*c_dup) __P((DBC *, DBC **, u_int32_t));
-	int (*c_get) __P((DBC *, DBT *, DBT *, u_int32_t));
-	int (*c_put) __P((DBC *, DBT *, DBT *, u_int32_t));
+	int (*c_del) __P((DBC *, uint32_t));
+	int (*c_dup) __P((DBC *, DBC **, uint32_t));
+	int (*c_get) __P((DBC *, DBT *, DBT *, uint32_t));
+	int (*c_put) __P((DBC *, DBT *, DBT *, uint32_t));
 
 	int (*c_am_close) __P((DBC *));	/* Methods: private. */
 	int (*c_am_destroy) __P((DBC *));
@@ -748,73 +748,73 @@ struct __dbc {
 #define	DBC_RMW		0x004		/* Acquire write flag in read op. */
 #define	DBC_WRITECURSOR	0x008		/* Cursor may be used to write (CDB). */
 #define	DBC_WRITER	0x010		/* Cursor immediately writing (CDB). */
-	u_int32_t flags;
+	uint32_t flags;
 };
 
 /* Btree/Recno statistics structure. */
 struct __db_bt_stat {
-	u_int32_t bt_metaflags;		/* Metadata flags. */
-	u_int32_t bt_maxkey;		/* Maxkey value. */
-	u_int32_t bt_minkey;		/* Minkey value. */
-	u_int32_t bt_re_len;		/* Fixed-length record length. */
-	u_int32_t bt_re_pad;		/* Fixed-length record pad. */
-	u_int32_t bt_pagesize;		/* Page size. */
-	u_int32_t bt_levels;		/* Tree levels. */
-	u_int32_t bt_nrecs;		/* Number of records. */
-	u_int32_t bt_int_pg;		/* Internal pages. */
-	u_int32_t bt_leaf_pg;		/* Leaf pages. */
-	u_int32_t bt_dup_pg;		/* Duplicate pages. */
-	u_int32_t bt_over_pg;		/* Overflow pages. */
-	u_int32_t bt_free;		/* Pages on the free list. */
-	u_int32_t bt_int_pgfree;	/* Bytes free in internal pages. */
-	u_int32_t bt_leaf_pgfree;	/* Bytes free in leaf pages. */
-	u_int32_t bt_dup_pgfree;	/* Bytes free in duplicate pages. */
-	u_int32_t bt_over_pgfree;	/* Bytes free in overflow pages. */
-	u_int32_t bt_magic;		/* Magic number. */
-	u_int32_t bt_version;		/* Version number. */
+	uint32_t bt_metaflags;		/* Metadata flags. */
+	uint32_t bt_maxkey;		/* Maxkey value. */
+	uint32_t bt_minkey;		/* Minkey value. */
+	uint32_t bt_re_len;		/* Fixed-length record length. */
+	uint32_t bt_re_pad;		/* Fixed-length record pad. */
+	uint32_t bt_pagesize;		/* Page size. */
+	uint32_t bt_levels;		/* Tree levels. */
+	uint32_t bt_nrecs;		/* Number of records. */
+	uint32_t bt_int_pg;		/* Internal pages. */
+	uint32_t bt_leaf_pg;		/* Leaf pages. */
+	uint32_t bt_dup_pg;		/* Duplicate pages. */
+	uint32_t bt_over_pg;		/* Overflow pages. */
+	uint32_t bt_free;		/* Pages on the free list. */
+	uint32_t bt_int_pgfree;	/* Bytes free in internal pages. */
+	uint32_t bt_leaf_pgfree;	/* Bytes free in leaf pages. */
+	uint32_t bt_dup_pgfree;	/* Bytes free in duplicate pages. */
+	uint32_t bt_over_pgfree;	/* Bytes free in overflow pages. */
+	uint32_t bt_magic;		/* Magic number. */
+	uint32_t bt_version;		/* Version number. */
 };
 
 /* Queue statistics structure. */
 struct __db_qam_stat {
-	u_int32_t qs_magic;		/* Magic number. */
-	u_int32_t qs_version;		/* Version number. */
-	u_int32_t qs_metaflags;		/* Metadata flags. */
-	u_int32_t qs_nrecs;		/* Number of records. */
-	u_int32_t qs_pages;		/* Data pages. */
-	u_int32_t qs_pagesize;		/* Page size. */
-	u_int32_t qs_pgfree;		/* Bytes free in data pages. */
-	u_int32_t qs_re_len;		/* Fixed-length record length. */
-	u_int32_t qs_re_pad;		/* Fixed-length record pad. */
-	u_int32_t qs_start;		/* Start offset. */
-	u_int32_t qs_first_recno;	/* First not deleted record. */
-	u_int32_t qs_cur_recno;		/* Last allocated record number. */
+	uint32_t qs_magic;		/* Magic number. */
+	uint32_t qs_version;		/* Version number. */
+	uint32_t qs_metaflags;		/* Metadata flags. */
+	uint32_t qs_nrecs;		/* Number of records. */
+	uint32_t qs_pages;		/* Data pages. */
+	uint32_t qs_pagesize;		/* Page size. */
+	uint32_t qs_pgfree;		/* Bytes free in data pages. */
+	uint32_t qs_re_len;		/* Fixed-length record length. */
+	uint32_t qs_re_pad;		/* Fixed-length record pad. */
+	uint32_t qs_start;		/* Start offset. */
+	uint32_t qs_first_recno;	/* First not deleted record. */
+	uint32_t qs_cur_recno;		/* Last allocated record number. */
 };
 
 /* Hash statistics structure. */
 struct __db_h_stat {
-	u_int32_t hash_magic;		/* Magic number. */
-	u_int32_t hash_version;		/* Version number. */
-	u_int32_t hash_metaflags;	/* Metadata flags. */
-	u_int32_t hash_pagesize;	/* Page size. */
-	u_int32_t hash_nelem;		/* Original nelem specified. */
-	u_int32_t hash_ffactor;		/* Fill factor specified at create. */
-	u_int32_t hash_nrecs;		/* Number of records. */
-	u_int32_t hash_buckets;		/* Number of hash buckets. */
-	u_int32_t hash_free;		/* Pages on the free list. */
-	u_int32_t hash_bfree;		/* Bytes free on bucket pages. */
-	u_int32_t hash_bigpages;	/* Number of big key/data pages. */
-	u_int32_t hash_big_bfree;	/* Bytes free on big item pages. */
-	u_int32_t hash_overflows;	/* Number of overflow pages. */
-	u_int32_t hash_ovfl_free;	/* Bytes free on ovfl pages. */
-	u_int32_t hash_dup;		/* Number of dup pages. */
-	u_int32_t hash_dup_free;	/* Bytes free on duplicate pages. */
+	uint32_t hash_magic;		/* Magic number. */
+	uint32_t hash_version;		/* Version number. */
+	uint32_t hash_metaflags;	/* Metadata flags. */
+	uint32_t hash_pagesize;	/* Page size. */
+	uint32_t hash_nelem;		/* Original nelem specified. */
+	uint32_t hash_ffactor;		/* Fill factor specified at create. */
+	uint32_t hash_nrecs;		/* Number of records. */
+	uint32_t hash_buckets;		/* Number of hash buckets. */
+	uint32_t hash_free;		/* Pages on the free list. */
+	uint32_t hash_bfree;		/* Bytes free on bucket pages. */
+	uint32_t hash_bigpages;	/* Number of big key/data pages. */
+	uint32_t hash_big_bfree;	/* Bytes free on big item pages. */
+	uint32_t hash_overflows;	/* Number of overflow pages. */
+	uint32_t hash_ovfl_free;	/* Bytes free on ovfl pages. */
+	uint32_t hash_dup;		/* Number of dup pages. */
+	uint32_t hash_dup_free;	/* Bytes free on duplicate pages. */
 };
 
 #if defined(__cplusplus)
 extern "C" {
 #endif
-int   CDB_db_create __P((DB **, DB_ENV *, u_int32_t));
-int   CDB_db_env_create __P((DB_ENV **, u_int32_t));
+int   CDB_db_create __P((DB **, DB_ENV *, uint32_t));
+int   CDB_db_env_create __P((DB_ENV **, uint32_t));
 char *CDB_db_strerror __P((int));
 char *CDB_db_version __P((int *, int *, int *));
 
@@ -889,7 +889,7 @@ typedef enum {
 struct __db_lockreq {
 	db_lockop_t	 op;		/* Operation. */
 	db_lockmode_t	 mode;		/* Requested mode. */
-	u_int32_t	 locker;	/* Locker identity. */
+	uint32_t	 locker;	/* Locker identity. */
 	DBT		*obj;		/* Object being locked. */
 	DB_LOCK		 lock;		/* Lock returned. */
 };
@@ -900,38 +900,38 @@ struct __db_lockreq {
  * Standard Read/Write (or exclusive/shared) locks.
  */
 #define	DB_LOCK_RW_N	3
-extern const u_int8_t CDB_db_rw_conflicts[];
+extern const uint8_t CDB_db_rw_conflicts[];
 
 /* Multi-granularity locking. */
 #define	DB_LOCK_RIW_N	6
-extern const u_int8_t CDB_db_riw_conflicts[];
+extern const uint8_t CDB_db_riw_conflicts[];
 
 struct __db_lock_stat {
-	u_int32_t st_lastid;		/* Last allocated locker ID. */
-	u_int32_t st_maxlocks;		/* Maximum number of locks in table. */
-	u_int32_t st_nmodes;		/* Number of lock modes. */
-	u_int32_t st_nlockers;		/* Number of lockers. */
-	u_int32_t st_maxnlockers;	/* Maximum number of lockers. */
-	u_int32_t st_nconflicts;	/* Number of lock conflicts. */
-	u_int32_t st_nrequests;		/* Number of lock gets. */
-	u_int32_t st_nreleases;		/* Number of lock puts. */
-	u_int32_t st_ndeadlocks;	/* Number of lock deadlocks. */
-	u_int32_t st_region_wait;	/* Region lock granted after wait. */
-	u_int32_t st_region_nowait;	/* Region lock granted without wait. */
-	u_int32_t st_regsize;		/* Region size. */
+	uint32_t st_lastid;		/* Last allocated locker ID. */
+	uint32_t st_maxlocks;		/* Maximum number of locks in table. */
+	uint32_t st_nmodes;		/* Number of lock modes. */
+	uint32_t st_nlockers;		/* Number of lockers. */
+	uint32_t st_maxnlockers;	/* Maximum number of lockers. */
+	uint32_t st_nconflicts;	/* Number of lock conflicts. */
+	uint32_t st_nrequests;		/* Number of lock gets. */
+	uint32_t st_nreleases;		/* Number of lock puts. */
+	uint32_t st_ndeadlocks;	/* Number of lock deadlocks. */
+	uint32_t st_region_wait;	/* Region lock granted after wait. */
+	uint32_t st_region_nowait;	/* Region lock granted without wait. */
+	uint32_t st_regsize;		/* Region size. */
 };
 
 #if defined(__cplusplus)
 extern "C" {
 #endif
-int	  CDB_lock_detect __P((DB_ENV *, u_int32_t, u_int32_t, int *));
+int	  CDB_lock_detect __P((DB_ENV *, uint32_t, uint32_t, int *));
 int	  CDB_lock_get __P((DB_ENV *,
-	    u_int32_t, u_int32_t, const DBT *, db_lockmode_t, DB_LOCK *));
-int	  CDB_lock_id __P((DB_ENV *, u_int32_t *));
+	    uint32_t, uint32_t, const DBT *, db_lockmode_t, DB_LOCK *));
+int	  CDB_lock_id __P((DB_ENV *, uint32_t *));
 int	  CDB_lock_put __P((DB_ENV *, DB_LOCK *));
 int	  CDB_lock_stat __P((DB_ENV *, DB_LOCK_STAT **, void *(*)(size_t)));
 int	  CDB_lock_vec __P((DB_ENV *,
-	    u_int32_t, u_int32_t, DB_LOCKREQ *, int, DB_LOCKREQ **));
+	    uint32_t, uint32_t, DB_LOCKREQ *, int, DB_LOCKREQ **));
 #if defined(__cplusplus)
 }
 #endif
@@ -954,40 +954,40 @@ int	  CDB_lock_vec __P((DB_ENV *,
  * offset is reached.
  */
 struct __db_lsn {
-	u_int32_t	file;		/* File ID. */
-	u_int32_t	offset;		/* File offset. */
+	uint32_t	file;		/* File ID. */
+	uint32_t	offset;		/* File offset. */
 };
 
 /* Log statistics structure. */
 struct __db_log_stat {
-	u_int32_t st_magic;		/* Log file magic number. */
-	u_int32_t st_version;		/* Log file version number. */
+	uint32_t st_magic;		/* Log file magic number. */
+	uint32_t st_version;		/* Log file version number. */
 	int st_mode;			/* Log file mode. */
-	u_int32_t st_lg_bsize;		/* Log buffer size. */
-	u_int32_t st_lg_max;		/* Maximum log file size. */
-	u_int32_t st_w_bytes;		/* Bytes to log. */
-	u_int32_t st_w_mbytes;		/* Megabytes to log. */
-	u_int32_t st_wc_bytes;		/* Bytes to log since checkpoint. */
-	u_int32_t st_wc_mbytes;		/* Megabytes to log since checkpoint. */
-	u_int32_t st_wcount;		/* Total writes to the log. */
-	u_int32_t st_wcount_fill;	/* Overflow writes to the log. */
-	u_int32_t st_scount;		/* Total syncs to the log. */
-	u_int32_t st_region_wait;	/* Region lock granted after wait. */
-	u_int32_t st_region_nowait;	/* Region lock granted without wait. */
-	u_int32_t st_cur_file;		/* Current log file number. */
-	u_int32_t st_cur_offset;	/* Current log file offset. */
-	u_int32_t st_regsize;		/* Region size. */
+	uint32_t st_lg_bsize;		/* Log buffer size. */
+	uint32_t st_lg_max;		/* Maximum log file size. */
+	uint32_t st_w_bytes;		/* Bytes to log. */
+	uint32_t st_w_mbytes;		/* Megabytes to log. */
+	uint32_t st_wc_bytes;		/* Bytes to log since checkpoint. */
+	uint32_t st_wc_mbytes;		/* Megabytes to log since checkpoint. */
+	uint32_t st_wcount;		/* Total writes to the log. */
+	uint32_t st_wcount_fill;	/* Overflow writes to the log. */
+	uint32_t st_scount;		/* Total syncs to the log. */
+	uint32_t st_region_wait;	/* Region lock granted after wait. */
+	uint32_t st_region_nowait;	/* Region lock granted without wait. */
+	uint32_t st_cur_file;		/* Current log file number. */
+	uint32_t st_cur_offset;	/* Current log file offset. */
+	uint32_t st_regsize;		/* Region size. */
 };
 
 #if defined(__cplusplus)
 extern "C" {
 #endif
-int	 CDB_log_archive __P((DB_ENV *, char **[], u_int32_t, void *(*)(size_t)));
+int	 CDB_log_archive __P((DB_ENV *, char **[], uint32_t, void *(*)(size_t)));
 int	 CDB_log_compare __P((const DB_LSN *, const DB_LSN *));
 int	 CDB_log_file __P((DB_ENV *, const DB_LSN *, char *, size_t));
 int	 CDB_log_flush __P((DB_ENV *, const DB_LSN *));
-int	 CDB_log_get __P((DB_ENV *, DB_LSN *, DBT *, u_int32_t));
-int	 CDB_log_put __P((DB_ENV *, DB_LSN *, const DBT *, u_int32_t));
+int	 CDB_log_get __P((DB_ENV *, DB_LSN *, DBT *, uint32_t));
+int	 CDB_log_put __P((DB_ENV *, DB_LSN *, const DBT *, uint32_t));
 int	 CDB_log_register __P((DB_ENV *, DB *, const char *, int32_t *));
 int	 CDB_log_stat __P((DB_ENV *, DB_LOG_STAT **, void *(*)(size_t)));
 int	 CDB_log_unregister __P((DB_ENV *, int32_t));
@@ -1011,47 +1011,47 @@ int	 CDB_log_unregister __P((DB_ENV *, int32_t));
 
 /* Mpool statistics structure. */
 struct __db_mpool_stat {
-	u_int32_t st_cache_hit;		/* Pages found in the cache. */
-	u_int32_t st_cache_miss;	/* Pages not found in the cache. */
-	u_int32_t st_map;		/* Pages from mapped files. */
-	u_int32_t st_page_create;	/* Pages created in the cache. */
-	u_int32_t st_page_in;		/* Pages read in. */
-	u_int32_t st_page_out;		/* Pages written out. */
-	u_int32_t st_ro_evict;		/* Clean pages forced from the cache. */
-	u_int32_t st_rw_evict;		/* Dirty pages forced from the cache. */
-	u_int32_t st_hash_buckets;	/* Number of hash buckets. */
-	u_int32_t st_hash_searches;	/* Total hash chain searches. */
-	u_int32_t st_hash_longest;	/* Longest hash chain searched. */
-	u_int32_t st_hash_examined;	/* Total hash entries searched. */
-	u_int32_t st_page_clean;	/* Clean pages. */
-	u_int32_t st_page_dirty;	/* Dirty pages. */
-	u_int32_t st_page_trickle;	/* Pages written by CDB_memp_trickle. */
-	u_int32_t st_region_wait;	/* Region lock granted after wait. */
-	u_int32_t st_region_nowait;	/* Region lock granted without wait. */
-	u_int32_t st_regsize;		/* Region size. */
-	u_int32_t st_gbytes;		/* Cache size: GB. */
-	u_int32_t st_bytes;		/* Cache size: B. */
+	uint32_t st_cache_hit;		/* Pages found in the cache. */
+	uint32_t st_cache_miss;	/* Pages not found in the cache. */
+	uint32_t st_map;		/* Pages from mapped files. */
+	uint32_t st_page_create;	/* Pages created in the cache. */
+	uint32_t st_page_in;		/* Pages read in. */
+	uint32_t st_page_out;		/* Pages written out. */
+	uint32_t st_ro_evict;		/* Clean pages forced from the cache. */
+	uint32_t st_rw_evict;		/* Dirty pages forced from the cache. */
+	uint32_t st_hash_buckets;	/* Number of hash buckets. */
+	uint32_t st_hash_searches;	/* Total hash chain searches. */
+	uint32_t st_hash_longest;	/* Longest hash chain searched. */
+	uint32_t st_hash_examined;	/* Total hash entries searched. */
+	uint32_t st_page_clean;	/* Clean pages. */
+	uint32_t st_page_dirty;	/* Dirty pages. */
+	uint32_t st_page_trickle;	/* Pages written by CDB_memp_trickle. */
+	uint32_t st_region_wait;	/* Region lock granted after wait. */
+	uint32_t st_region_nowait;	/* Region lock granted without wait. */
+	uint32_t st_regsize;		/* Region size. */
+	uint32_t st_gbytes;		/* Cache size: GB. */
+	uint32_t st_bytes;		/* Cache size: B. */
 };
 
 /* Mpool file open information structure. */
 struct __db_mpool_finfo {
 	int	   ftype;		/* File type. */
 	DBT	  *pgcookie;		/* Byte-string passed to pgin/pgout. */
-	u_int8_t  *fileid;		/* Unique file ID. */
+	uint8_t  *fileid;		/* Unique file ID. */
 	int32_t	   lsn_offset;		/* LSN offset in page. */
-	u_int32_t  clear_len;		/* Cleared length on created pages. */
+	uint32_t  clear_len;		/* Cleared length on created pages. */
 };
 
 /* Mpool file statistics structure. */
 struct __db_mpool_fstat {
 	char *file_name;		/* File name. */
 	size_t st_pagesize;		/* Page size. */
-	u_int32_t st_cache_hit;		/* Pages found in the cache. */
-	u_int32_t st_cache_miss;	/* Pages not found in the cache. */
-	u_int32_t st_map;		/* Pages from mapped files. */
-	u_int32_t st_page_create;	/* Pages created in the cache. */
-	u_int32_t st_page_in;		/* Pages read in. */
-	u_int32_t st_page_out;		/* Pages written out. */
+	uint32_t st_cache_hit;		/* Pages found in the cache. */
+	uint32_t st_cache_miss;	/* Pages not found in the cache. */
+	uint32_t st_map;		/* Pages from mapped files. */
+	uint32_t st_page_create;	/* Pages created in the cache. */
+	uint32_t st_page_in;		/* Pages read in. */
+	uint32_t st_page_out;		/* Pages written out. */
 };
 
 
@@ -1068,11 +1068,11 @@ extern "C" {
 extern "C" {
 #endif
 int	CDB_memp_fclose __P((DB_MPOOLFILE *));
-int	CDB_memp_fget __P((DB_MPOOLFILE *, db_pgno_t *, u_int32_t, void *));
+int	CDB_memp_fget __P((DB_MPOOLFILE *, db_pgno_t *, uint32_t, void *));
 int	CDB_memp_fopen __P((DB_ENV *, const char *,
-	    u_int32_t, int, size_t, DB_MPOOL_FINFO *, DB_MPOOLFILE **));
-int	CDB_memp_fput __P((DB_MPOOLFILE *, void *, u_int32_t));
-int	CDB_memp_fset __P((DB_MPOOLFILE *, void *, u_int32_t));
+	    uint32_t, int, size_t, DB_MPOOL_FINFO *, DB_MPOOLFILE **));
+int	CDB_memp_fput __P((DB_MPOOLFILE *, void *, uint32_t));
+int	CDB_memp_fset __P((DB_MPOOLFILE *, void *, uint32_t));
 int	CDB_memp_fsync __P((DB_MPOOLFILE *));
 int	CDB_memp_register __P((DB_ENV *, int,
 	    int (*)(db_pgno_t, void *, DBT *),
@@ -1101,8 +1101,8 @@ int	CDB_memp_trickle __P((DB_ENV *, int, int *));
 
 /* Transaction statistics structure. */
 struct __db_txn_active {
-	u_int32_t	txnid;		/* Transaction ID */
-	u_int32_t	parentid;	/* Transaction ID of parent */
+	uint32_t	txnid;		/* Transaction ID */
+	uint32_t	parentid;	/* Transaction ID of parent */
 	DB_LSN		lsn;		/* Lsn of the begin record */
 };
 
@@ -1110,28 +1110,28 @@ struct __db_txn_stat {
 	DB_LSN	  st_last_ckp;		/* lsn of the last checkpoint */
 	DB_LSN	  st_pending_ckp;	/* last checkpoint did not finish */
 	time_t	  st_time_ckp;		/* time of last checkpoint */
-	u_int32_t st_last_txnid;	/* last transaction id given out */
-	u_int32_t st_maxtxns;		/* maximum txns possible */
-	u_int32_t st_naborts;		/* number of aborted transactions */
-	u_int32_t st_nbegins;		/* number of begun transactions */
-	u_int32_t st_ncommits;		/* number of committed transactions */
-	u_int32_t st_nactive;		/* number of active transactions */
-	u_int32_t st_maxnactive;	/* maximum active transactions */
+	uint32_t st_last_txnid;	/* last transaction id given out */
+	uint32_t st_maxtxns;		/* maximum txns possible */
+	uint32_t st_naborts;		/* number of aborted transactions */
+	uint32_t st_nbegins;		/* number of begun transactions */
+	uint32_t st_ncommits;		/* number of committed transactions */
+	uint32_t st_nactive;		/* number of active transactions */
+	uint32_t st_maxnactive;	/* maximum active transactions */
 	DB_TXN_ACTIVE
 		 *st_txnarray;		/* array of active transactions */
-	u_int32_t st_region_wait;	/* Region lock granted after wait. */
-	u_int32_t st_region_nowait;	/* Region lock granted without wait. */
-	u_int32_t st_regsize;		/* Region size. */
+	uint32_t st_region_wait;	/* Region lock granted after wait. */
+	uint32_t st_region_nowait;	/* Region lock granted without wait. */
+	uint32_t st_regsize;		/* Region size. */
 };
 
 #if defined(__cplusplus)
 extern "C" {
 #endif
 int	  CDB_txn_abort __P((DB_TXN *));
-int	  CDB_txn_begin __P((DB_ENV *, DB_TXN *, DB_TXN **, u_int32_t));
-int	  CDB_txn_checkpoint __P((DB_ENV *, u_int32_t, u_int32_t));
-int	  CDB_txn_commit __P((DB_TXN *, u_int32_t));
-u_int32_t CDB_txn_id __P((DB_TXN *));
+int	  CDB_txn_begin __P((DB_ENV *, DB_TXN *, DB_TXN **, uint32_t));
+int	  CDB_txn_checkpoint __P((DB_ENV *, uint32_t, uint32_t));
+int	  CDB_txn_commit __P((DB_TXN *, uint32_t));
+uint32_t CDB_txn_id __P((DB_TXN *));
 int	  CDB_txn_prepare __P((DB_TXN *));
 int	  CDB_txn_stat __P((DB_ENV *, DB_TXN_STAT **, void *(*)(size_t)));
 #if defined(__cplusplus)

--- a/db/db_am.c
+++ b/db/db_am.c
@@ -40,18 +40,18 @@ static int CDB___db_c_close __P ((DBC *));
  * CDB___db_cursor --
  *  Allocate and return a cursor.
  *
- * PUBLIC: int CDB___db_cursor __P((DB *, DB_TXN *, DBC **, u_int32_t));
+ * PUBLIC: int CDB___db_cursor __P((DB *, DB_TXN *, DBC **, uint32_t));
  */
 int
 CDB___db_cursor (dbp, txn, dbcp, flags)
      DB *dbp;
      DB_TXN *txn;
      DBC **dbcp;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DBC *dbc, *adbc;
   db_lockmode_t mode;
-  u_int32_t op;
+  uint32_t op;
   int ret;
 
   PANIC_CHECK (dbp->dbenv);
@@ -245,13 +245,13 @@ CDB___db_c_close (dbc)
  * CDB___db_c_dup --
  *  Duplicate a cursor
  *
- * PUBLIC: int CDB___db_c_dup __P((DBC *, DBC **, u_int32_t));
+ * PUBLIC: int CDB___db_c_dup __P((DBC *, DBC **, uint32_t));
  */
 int
 CDB___db_c_dup (orig_dbc, dbcp, flags)
      DBC *orig_dbc;
      DBC **dbcp;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB *dbp;
   DBC *dbc;
@@ -425,14 +425,14 @@ CDB___db_fd (dbp, fdp)
  * CDB___db_get --
  *  Return a key/data pair.
  *
- * PUBLIC: int CDB___db_get __P((DB *, DB_TXN *, DBT *, DBT *, u_int32_t));
+ * PUBLIC: int CDB___db_get __P((DB *, DB_TXN *, DBT *, DBT *, uint32_t));
  */
 int
 CDB___db_get (dbp, txn, key, data, flags)
      DB *dbp;
      DB_TXN *txn;
      DBT *key, *data;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DBC *dbc;
   int ret, t_ret;
@@ -479,14 +479,14 @@ CDB___db_get (dbp, txn, key, data, flags)
  * CDB___db_put --
  *  Store a key/data pair.
  *
- * PUBLIC: int CDB___db_put __P((DB *, DB_TXN *, DBT *, DBT *, u_int32_t));
+ * PUBLIC: int CDB___db_put __P((DB *, DB_TXN *, DBT *, DBT *, uint32_t));
  */
 int
 CDB___db_put (dbp, txn, key, data, flags)
      DB *dbp;
      DB_TXN *txn;
      DBT *key, *data;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DBC *dbc;
   DBT tdata;
@@ -542,12 +542,12 @@ CDB___db_put (dbp, txn, key, data, flags)
  * CDB___db_sync --
  *  Flush the database cache.
  *
- * PUBLIC: int CDB___db_sync __P((DB *, u_int32_t));
+ * PUBLIC: int CDB___db_sync __P((DB *, uint32_t));
  */
 int
 CDB___db_sync (dbp, flags)
      DB *dbp;
-     u_int32_t flags;
+     uint32_t flags;
 {
   int ret, t_ret;
 

--- a/db/db_auto.c
+++ b/db/db_auto.c
@@ -21,11 +21,11 @@ CDB___db_addrem_log (dbenv, txnid, ret_lsnp, flags,
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
-     u_int32_t opcode;
+     uint32_t flags;
+     uint32_t opcode;
      int32_t fileid;
      db_pgno_t pgno;
-     u_int32_t indx;
+     uint32_t indx;
      size_t nbytes;
      const DBT *hdr;
      const DBT *dbt;
@@ -33,10 +33,10 @@ CDB___db_addrem_log (dbenv, txnid, ret_lsnp, flags,
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t zero;
-  u_int32_t rectype, txn_num;
+  uint32_t zero;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -56,8 +56,8 @@ CDB___db_addrem_log (dbenv, txnid, ret_lsnp, flags,
     + sizeof (pgno)
     + sizeof (indx)
     + sizeof (nbytes)
-    + sizeof (u_int32_t) + (hdr == NULL ? 0 : hdr->size)
-    + sizeof (u_int32_t) + (dbt == NULL ? 0 : dbt->size) + sizeof (*pagelsn);
+    + sizeof (uint32_t) + (hdr == NULL ? 0 : hdr->size)
+    + sizeof (uint32_t) + (dbt == NULL ? 0 : dbt->size) + sizeof (*pagelsn);
   if ((ret = CDB___os_malloc (logrec.size, NULL, &logrec.data)) != 0)
     return (ret);
 
@@ -81,8 +81,8 @@ CDB___db_addrem_log (dbenv, txnid, ret_lsnp, flags,
   if (hdr == NULL)
   {
     zero = 0;
-    memcpy (bp, &zero, sizeof (u_int32_t));
-    bp += sizeof (u_int32_t);
+    memcpy (bp, &zero, sizeof (uint32_t));
+    bp += sizeof (uint32_t);
   }
   else
   {
@@ -94,8 +94,8 @@ CDB___db_addrem_log (dbenv, txnid, ret_lsnp, flags,
   if (dbt == NULL)
   {
     zero = 0;
-    memcpy (bp, &zero, sizeof (u_int32_t));
-    bp += sizeof (u_int32_t);
+    memcpy (bp, &zero, sizeof (uint32_t));
+    bp += sizeof (uint32_t);
   }
   else
   {
@@ -109,7 +109,7 @@ CDB___db_addrem_log (dbenv, txnid, ret_lsnp, flags,
   else
     memset (bp, 0, sizeof (*pagelsn));
   bp += sizeof (*pagelsn);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -126,7 +126,7 @@ CDB___db_addrem_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __db_addrem_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -152,7 +152,7 @@ CDB___db_addrem_print (notused1, dbtp, lsnp, notused2, notused3)
   printf ("\thdr: ");
   for (i = 0; i < argp->hdr.size; i++)
   {
-    ch = ((u_int8_t *) argp->hdr.data)[i];
+    ch = ((uint8_t *) argp->hdr.data)[i];
     if (isprint (ch) || ch == 0xa)
       putchar (ch);
     else
@@ -162,7 +162,7 @@ CDB___db_addrem_print (notused1, dbtp, lsnp, notused2, notused3)
   printf ("\tdbt: ");
   for (i = 0; i < argp->dbt.size; i++)
   {
-    ch = ((u_int8_t *) argp->dbt.data)[i];
+    ch = ((uint8_t *) argp->dbt.data)[i];
     if (isprint (ch) || ch == 0xa)
       putchar (ch);
     else
@@ -182,7 +182,7 @@ CDB___db_addrem_read (recbuf, argpp)
      __db_addrem_args **argpp;
 {
   __db_addrem_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__db_addrem_args) +
@@ -208,13 +208,13 @@ CDB___db_addrem_read (recbuf, argpp)
   memcpy (&argp->nbytes, bp, sizeof (argp->nbytes));
   bp += sizeof (argp->nbytes);
   memset (&argp->hdr, 0, sizeof (argp->hdr));
-  memcpy (&argp->hdr.size, bp, sizeof (u_int32_t));
-  bp += sizeof (u_int32_t);
+  memcpy (&argp->hdr.size, bp, sizeof (uint32_t));
+  bp += sizeof (uint32_t);
   argp->hdr.data = bp;
   bp += argp->hdr.size;
   memset (&argp->dbt, 0, sizeof (argp->dbt));
-  memcpy (&argp->dbt.size, bp, sizeof (u_int32_t));
-  bp += sizeof (u_int32_t);
+  memcpy (&argp->dbt.size, bp, sizeof (uint32_t));
+  bp += sizeof (uint32_t);
   argp->dbt.data = bp;
   bp += argp->dbt.size;
   memcpy (&argp->pagelsn, bp, sizeof (argp->pagelsn));
@@ -229,8 +229,8 @@ CDB___db_split_log (dbenv, txnid, ret_lsnp, flags,
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
-     u_int32_t opcode;
+     uint32_t flags;
+     uint32_t opcode;
      int32_t fileid;
      db_pgno_t pgno;
      const DBT *pageimage;
@@ -238,10 +238,10 @@ CDB___db_split_log (dbenv, txnid, ret_lsnp, flags,
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t zero;
-  u_int32_t rectype, txn_num;
+  uint32_t zero;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -259,7 +259,7 @@ CDB___db_split_log (dbenv, txnid, ret_lsnp, flags,
     + sizeof (opcode)
     + sizeof (fileid)
     + sizeof (pgno)
-    + sizeof (u_int32_t) + (pageimage == NULL ? 0 : pageimage->size)
+    + sizeof (uint32_t) + (pageimage == NULL ? 0 : pageimage->size)
     + sizeof (*pagelsn);
   if ((ret = CDB___os_malloc (logrec.size, NULL, &logrec.data)) != 0)
     return (ret);
@@ -280,8 +280,8 @@ CDB___db_split_log (dbenv, txnid, ret_lsnp, flags,
   if (pageimage == NULL)
   {
     zero = 0;
-    memcpy (bp, &zero, sizeof (u_int32_t));
-    bp += sizeof (u_int32_t);
+    memcpy (bp, &zero, sizeof (uint32_t));
+    bp += sizeof (uint32_t);
   }
   else
   {
@@ -295,7 +295,7 @@ CDB___db_split_log (dbenv, txnid, ret_lsnp, flags,
   else
     memset (bp, 0, sizeof (*pagelsn));
   bp += sizeof (*pagelsn);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -312,7 +312,7 @@ CDB___db_split_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __db_split_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -336,7 +336,7 @@ CDB___db_split_print (notused1, dbtp, lsnp, notused2, notused3)
   printf ("\tpageimage: ");
   for (i = 0; i < argp->pageimage.size; i++)
   {
-    ch = ((u_int8_t *) argp->pageimage.data)[i];
+    ch = ((uint8_t *) argp->pageimage.data)[i];
     if (isprint (ch) || ch == 0xa)
       putchar (ch);
     else
@@ -356,7 +356,7 @@ CDB___db_split_read (recbuf, argpp)
      __db_split_args **argpp;
 {
   __db_split_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__db_split_args) +
@@ -378,8 +378,8 @@ CDB___db_split_read (recbuf, argpp)
   memcpy (&argp->pgno, bp, sizeof (argp->pgno));
   bp += sizeof (argp->pgno);
   memset (&argp->pageimage, 0, sizeof (argp->pageimage));
-  memcpy (&argp->pageimage.size, bp, sizeof (u_int32_t));
-  bp += sizeof (u_int32_t);
+  memcpy (&argp->pageimage.size, bp, sizeof (uint32_t));
+  bp += sizeof (uint32_t);
   argp->pageimage.data = bp;
   bp += argp->pageimage.size;
   memcpy (&argp->pagelsn, bp, sizeof (argp->pagelsn));
@@ -395,8 +395,8 @@ CDB___db_big_log (dbenv, txnid, ret_lsnp, flags,
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
-     u_int32_t opcode;
+     uint32_t flags;
+     uint32_t opcode;
      int32_t fileid;
      db_pgno_t pgno;
      db_pgno_t prev_pgno;
@@ -408,10 +408,10 @@ CDB___db_big_log (dbenv, txnid, ret_lsnp, flags,
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t zero;
-  u_int32_t rectype, txn_num;
+  uint32_t zero;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -431,7 +431,7 @@ CDB___db_big_log (dbenv, txnid, ret_lsnp, flags,
     + sizeof (pgno)
     + sizeof (prev_pgno)
     + sizeof (next_pgno)
-    + sizeof (u_int32_t) + (dbt == NULL ? 0 : dbt->size)
+    + sizeof (uint32_t) + (dbt == NULL ? 0 : dbt->size)
     + sizeof (*pagelsn) + sizeof (*prevlsn) + sizeof (*nextlsn);
   if ((ret = CDB___os_malloc (logrec.size, NULL, &logrec.data)) != 0)
     return (ret);
@@ -456,8 +456,8 @@ CDB___db_big_log (dbenv, txnid, ret_lsnp, flags,
   if (dbt == NULL)
   {
     zero = 0;
-    memcpy (bp, &zero, sizeof (u_int32_t));
-    bp += sizeof (u_int32_t);
+    memcpy (bp, &zero, sizeof (uint32_t));
+    bp += sizeof (uint32_t);
   }
   else
   {
@@ -481,7 +481,7 @@ CDB___db_big_log (dbenv, txnid, ret_lsnp, flags,
   else
     memset (bp, 0, sizeof (*nextlsn));
   bp += sizeof (*nextlsn);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -498,7 +498,7 @@ CDB___db_big_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __db_big_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -524,7 +524,7 @@ CDB___db_big_print (notused1, dbtp, lsnp, notused2, notused3)
   printf ("\tdbt: ");
   for (i = 0; i < argp->dbt.size; i++)
   {
-    ch = ((u_int8_t *) argp->dbt.data)[i];
+    ch = ((uint8_t *) argp->dbt.data)[i];
     if (isprint (ch) || ch == 0xa)
       putchar (ch);
     else
@@ -548,7 +548,7 @@ CDB___db_big_read (recbuf, argpp)
      __db_big_args **argpp;
 {
   __db_big_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__db_big_args) +
@@ -574,8 +574,8 @@ CDB___db_big_read (recbuf, argpp)
   memcpy (&argp->next_pgno, bp, sizeof (argp->next_pgno));
   bp += sizeof (argp->next_pgno);
   memset (&argp->dbt, 0, sizeof (argp->dbt));
-  memcpy (&argp->dbt.size, bp, sizeof (u_int32_t));
-  bp += sizeof (u_int32_t);
+  memcpy (&argp->dbt.size, bp, sizeof (uint32_t));
+  bp += sizeof (uint32_t);
   argp->dbt.data = bp;
   bp += argp->dbt.size;
   memcpy (&argp->pagelsn, bp, sizeof (argp->pagelsn));
@@ -593,7 +593,7 @@ CDB___db_ovref_log (dbenv, txnid, ret_lsnp, flags, fileid, pgno, adjust, lsn)
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
+     uint32_t flags;
      int32_t fileid;
      db_pgno_t pgno;
      int32_t adjust;
@@ -601,9 +601,9 @@ CDB___db_ovref_log (dbenv, txnid, ret_lsnp, flags, fileid, pgno, adjust, lsn)
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t rectype, txn_num;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -640,7 +640,7 @@ CDB___db_ovref_log (dbenv, txnid, ret_lsnp, flags, fileid, pgno, adjust, lsn)
   else
     memset (bp, 0, sizeof (*lsn));
   bp += sizeof (*lsn);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -657,7 +657,7 @@ CDB___db_ovref_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __db_ovref_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -691,7 +691,7 @@ CDB___db_ovref_read (recbuf, argpp)
      __db_ovref_args **argpp;
 {
   __db_ovref_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__db_ovref_args) +
@@ -725,8 +725,8 @@ CDB___db_relink_log (dbenv, txnid, ret_lsnp, flags,
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
-     u_int32_t opcode;
+     uint32_t flags;
+     uint32_t opcode;
      int32_t fileid;
      db_pgno_t pgno;
      DB_LSN *lsn;
@@ -737,9 +737,9 @@ CDB___db_relink_log (dbenv, txnid, ret_lsnp, flags,
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t rectype, txn_num;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -794,7 +794,7 @@ CDB___db_relink_log (dbenv, txnid, ret_lsnp, flags,
   else
     memset (bp, 0, sizeof (*lsn_next));
   bp += sizeof (*lsn_next);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -811,7 +811,7 @@ CDB___db_relink_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __db_relink_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -851,7 +851,7 @@ CDB___db_relink_read (recbuf, argpp)
      __db_relink_args **argpp;
 {
   __db_relink_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__db_relink_args) +
@@ -892,7 +892,7 @@ CDB___db_addpage_log (dbenv, txnid, ret_lsnp, flags,
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
+     uint32_t flags;
      int32_t fileid;
      db_pgno_t pgno;
      DB_LSN *lsn;
@@ -901,9 +901,9 @@ CDB___db_addpage_log (dbenv, txnid, ret_lsnp, flags,
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t rectype, txn_num;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -946,7 +946,7 @@ CDB___db_addpage_log (dbenv, txnid, ret_lsnp, flags,
   else
     memset (bp, 0, sizeof (*nextlsn));
   bp += sizeof (*nextlsn);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -963,7 +963,7 @@ CDB___db_addpage_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __db_addpage_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -999,7 +999,7 @@ CDB___db_addpage_read (recbuf, argpp)
      __db_addpage_args **argpp;
 {
   __db_addpage_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__db_addpage_args) +
@@ -1034,19 +1034,19 @@ CDB___db_debug_log (dbenv, txnid, ret_lsnp, flags,
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
+     uint32_t flags;
      const DBT *op;
      int32_t fileid;
      const DBT *key;
      const DBT *data;
-     u_int32_t arg_flags;
+     uint32_t arg_flags;
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t zero;
-  u_int32_t rectype, txn_num;
+  uint32_t zero;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -1061,10 +1061,10 @@ CDB___db_debug_log (dbenv, txnid, ret_lsnp, flags,
   else
     lsnp = &txnid->last_lsn;
   logrec.size = sizeof (rectype) + sizeof (txn_num) + sizeof (DB_LSN)
-    + sizeof (u_int32_t) + (op == NULL ? 0 : op->size)
+    + sizeof (uint32_t) + (op == NULL ? 0 : op->size)
     + sizeof (fileid)
-    + sizeof (u_int32_t) + (key == NULL ? 0 : key->size)
-    + sizeof (u_int32_t) + (data == NULL ? 0 : data->size)
+    + sizeof (uint32_t) + (key == NULL ? 0 : key->size)
+    + sizeof (uint32_t) + (data == NULL ? 0 : data->size)
     + sizeof (arg_flags);
   if ((ret = CDB___os_malloc (logrec.size, NULL, &logrec.data)) != 0)
     return (ret);
@@ -1079,8 +1079,8 @@ CDB___db_debug_log (dbenv, txnid, ret_lsnp, flags,
   if (op == NULL)
   {
     zero = 0;
-    memcpy (bp, &zero, sizeof (u_int32_t));
-    bp += sizeof (u_int32_t);
+    memcpy (bp, &zero, sizeof (uint32_t));
+    bp += sizeof (uint32_t);
   }
   else
   {
@@ -1094,8 +1094,8 @@ CDB___db_debug_log (dbenv, txnid, ret_lsnp, flags,
   if (key == NULL)
   {
     zero = 0;
-    memcpy (bp, &zero, sizeof (u_int32_t));
-    bp += sizeof (u_int32_t);
+    memcpy (bp, &zero, sizeof (uint32_t));
+    bp += sizeof (uint32_t);
   }
   else
   {
@@ -1107,8 +1107,8 @@ CDB___db_debug_log (dbenv, txnid, ret_lsnp, flags,
   if (data == NULL)
   {
     zero = 0;
-    memcpy (bp, &zero, sizeof (u_int32_t));
-    bp += sizeof (u_int32_t);
+    memcpy (bp, &zero, sizeof (uint32_t));
+    bp += sizeof (uint32_t);
   }
   else
   {
@@ -1119,7 +1119,7 @@ CDB___db_debug_log (dbenv, txnid, ret_lsnp, flags,
   }
   memcpy (bp, &arg_flags, sizeof (arg_flags));
   bp += sizeof (arg_flags);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -1136,7 +1136,7 @@ CDB___db_debug_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __db_debug_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -1157,7 +1157,7 @@ CDB___db_debug_print (notused1, dbtp, lsnp, notused2, notused3)
   printf ("\top: ");
   for (i = 0; i < argp->op.size; i++)
   {
-    ch = ((u_int8_t *) argp->op.data)[i];
+    ch = ((uint8_t *) argp->op.data)[i];
     if (isprint (ch) || ch == 0xa)
       putchar (ch);
     else
@@ -1168,7 +1168,7 @@ CDB___db_debug_print (notused1, dbtp, lsnp, notused2, notused3)
   printf ("\tkey: ");
   for (i = 0; i < argp->key.size; i++)
   {
-    ch = ((u_int8_t *) argp->key.data)[i];
+    ch = ((uint8_t *) argp->key.data)[i];
     if (isprint (ch) || ch == 0xa)
       putchar (ch);
     else
@@ -1178,7 +1178,7 @@ CDB___db_debug_print (notused1, dbtp, lsnp, notused2, notused3)
   printf ("\tdata: ");
   for (i = 0; i < argp->data.size; i++)
   {
-    ch = ((u_int8_t *) argp->data.data)[i];
+    ch = ((uint8_t *) argp->data.data)[i];
     if (isprint (ch) || ch == 0xa)
       putchar (ch);
     else
@@ -1197,7 +1197,7 @@ CDB___db_debug_read (recbuf, argpp)
      __db_debug_args **argpp;
 {
   __db_debug_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__db_debug_args) +
@@ -1213,20 +1213,20 @@ CDB___db_debug_read (recbuf, argpp)
   memcpy (&argp->prev_lsn, bp, sizeof (DB_LSN));
   bp += sizeof (DB_LSN);
   memset (&argp->op, 0, sizeof (argp->op));
-  memcpy (&argp->op.size, bp, sizeof (u_int32_t));
-  bp += sizeof (u_int32_t);
+  memcpy (&argp->op.size, bp, sizeof (uint32_t));
+  bp += sizeof (uint32_t);
   argp->op.data = bp;
   bp += argp->op.size;
   memcpy (&argp->fileid, bp, sizeof (argp->fileid));
   bp += sizeof (argp->fileid);
   memset (&argp->key, 0, sizeof (argp->key));
-  memcpy (&argp->key.size, bp, sizeof (u_int32_t));
-  bp += sizeof (u_int32_t);
+  memcpy (&argp->key.size, bp, sizeof (uint32_t));
+  bp += sizeof (uint32_t);
   argp->key.data = bp;
   bp += argp->key.size;
   memset (&argp->data, 0, sizeof (argp->data));
-  memcpy (&argp->data.size, bp, sizeof (u_int32_t));
-  bp += sizeof (u_int32_t);
+  memcpy (&argp->data.size, bp, sizeof (uint32_t));
+  bp += sizeof (uint32_t);
   argp->data.data = bp;
   bp += argp->data.size;
   memcpy (&argp->arg_flags, bp, sizeof (argp->arg_flags));
@@ -1240,16 +1240,16 @@ CDB___db_noop_log (dbenv, txnid, ret_lsnp, flags, fileid, pgno, prevlsn)
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
+     uint32_t flags;
      int32_t fileid;
      db_pgno_t pgno;
      DB_LSN *prevlsn;
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t rectype, txn_num;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -1284,7 +1284,7 @@ CDB___db_noop_log (dbenv, txnid, ret_lsnp, flags, fileid, pgno, prevlsn)
   else
     memset (bp, 0, sizeof (*prevlsn));
   bp += sizeof (*prevlsn);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -1301,7 +1301,7 @@ CDB___db_noop_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __db_noop_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -1334,7 +1334,7 @@ CDB___db_noop_read (recbuf, argpp)
      __db_noop_args **argpp;
 {
   __db_noop_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__db_noop_args) +

--- a/db/db_auto.h
+++ b/db/db_auto.h
@@ -7,13 +7,13 @@
 
 typedef struct _db_addrem_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
-  u_int32_t opcode;
+  uint32_t opcode;
   int32_t fileid;
   db_pgno_t pgno;
-  u_int32_t indx;
+  uint32_t indx;
   size_t nbytes;
   DBT hdr;
   DBT dbt;
@@ -21,8 +21,8 @@ typedef struct _db_addrem_args
 } __db_addrem_args;
 
 int CDB___db_addrem_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, u_int32_t, int32_t, db_pgno_t,
-      u_int32_t, size_t, const DBT *, const DBT *, DB_LSN *));
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, uint32_t, int32_t, db_pgno_t,
+      uint32_t, size_t, const DBT *, const DBT *, DB_LSN *));
 int CDB___db_addrem_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___db_addrem_read __P ((void *, __db_addrem_args **));
 
@@ -30,10 +30,10 @@ int CDB___db_addrem_read __P ((void *, __db_addrem_args **));
 
 typedef struct _db_split_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
-  u_int32_t opcode;
+  uint32_t opcode;
   int32_t fileid;
   db_pgno_t pgno;
   DBT pageimage;
@@ -41,7 +41,7 @@ typedef struct _db_split_args
 } __db_split_args;
 
 int CDB___db_split_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, u_int32_t, int32_t, db_pgno_t,
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, uint32_t, int32_t, db_pgno_t,
       const DBT *, DB_LSN *));
 int CDB___db_split_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___db_split_read __P ((void *, __db_split_args **));
@@ -50,10 +50,10 @@ int CDB___db_split_read __P ((void *, __db_split_args **));
 
 typedef struct _db_big_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
-  u_int32_t opcode;
+  uint32_t opcode;
   int32_t fileid;
   db_pgno_t pgno;
   db_pgno_t prev_pgno;
@@ -65,7 +65,7 @@ typedef struct _db_big_args
 } __db_big_args;
 
 int CDB___db_big_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, u_int32_t, int32_t, db_pgno_t,
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, uint32_t, int32_t, db_pgno_t,
       db_pgno_t, db_pgno_t, const DBT *, DB_LSN *, DB_LSN *, DB_LSN *));
 int CDB___db_big_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___db_big_read __P ((void *, __db_big_args **));
@@ -74,7 +74,7 @@ int CDB___db_big_read __P ((void *, __db_big_args **));
 
 typedef struct _db_ovref_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
   int32_t fileid;
@@ -84,7 +84,7 @@ typedef struct _db_ovref_args
 } __db_ovref_args;
 
 int CDB___db_ovref_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, int32_t, db_pgno_t, int32_t,
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, int32_t, db_pgno_t, int32_t,
       DB_LSN *));
 int CDB___db_ovref_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___db_ovref_read __P ((void *, __db_ovref_args **));
@@ -93,10 +93,10 @@ int CDB___db_ovref_read __P ((void *, __db_ovref_args **));
 
 typedef struct _db_relink_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
-  u_int32_t opcode;
+  uint32_t opcode;
   int32_t fileid;
   db_pgno_t pgno;
   DB_LSN lsn;
@@ -107,7 +107,7 @@ typedef struct _db_relink_args
 } __db_relink_args;
 
 int CDB___db_relink_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, u_int32_t, int32_t, db_pgno_t,
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, uint32_t, int32_t, db_pgno_t,
       DB_LSN *, db_pgno_t, DB_LSN *, db_pgno_t, DB_LSN *));
 int CDB___db_relink_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___db_relink_read __P ((void *, __db_relink_args **));
@@ -116,7 +116,7 @@ int CDB___db_relink_read __P ((void *, __db_relink_args **));
 
 typedef struct _db_addpage_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
   int32_t fileid;
@@ -127,7 +127,7 @@ typedef struct _db_addpage_args
 } __db_addpage_args;
 
 int CDB___db_addpage_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, int32_t, db_pgno_t, DB_LSN *,
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, int32_t, db_pgno_t, DB_LSN *,
       db_pgno_t, DB_LSN *));
 int CDB___db_addpage_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___db_addpage_read __P ((void *, __db_addpage_args **));
@@ -136,19 +136,19 @@ int CDB___db_addpage_read __P ((void *, __db_addpage_args **));
 
 typedef struct _db_debug_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
   DBT op;
   int32_t fileid;
   DBT key;
   DBT data;
-  u_int32_t arg_flags;
+  uint32_t arg_flags;
 } __db_debug_args;
 
 int CDB___db_debug_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, const DBT *, int32_t,
-      const DBT *, const DBT *, u_int32_t));
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, const DBT *, int32_t,
+      const DBT *, const DBT *, uint32_t));
 int CDB___db_debug_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___db_debug_read __P ((void *, __db_debug_args **));
 
@@ -156,7 +156,7 @@ int CDB___db_debug_read __P ((void *, __db_debug_args **));
 
 typedef struct _db_noop_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
   int32_t fileid;
@@ -165,7 +165,7 @@ typedef struct _db_noop_args
 } __db_noop_args;
 
 int CDB___db_noop_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, int32_t, db_pgno_t, DB_LSN *));
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, int32_t, db_pgno_t, DB_LSN *));
 int CDB___db_noop_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___db_noop_read __P ((void *, __db_noop_args **));
 int CDB___db_init_print __P ((DB_ENV *));

--- a/db/db_cam.c
+++ b/db/db_cam.c
@@ -28,7 +28,7 @@ static const char revid[] =
 #include "db_ext.h"
 
 static int __db_c_cleanup __P ((DBC *, DBC *, int));
-static int __db_c_idup __P ((DBC *, DBC **, u_int32_t));
+static int __db_c_idup __P ((DBC *, DBC **, uint32_t));
 static int __db_wrlock_err __P ((DB_ENV *));
 
 #define  LOCKING_INIT(dbp, dbc)          \
@@ -197,13 +197,13 @@ CDB___db_c_destroy (dbc)
  * CDB___db_c_count --
  *  Return a count of duplicate data items.
  *
- * PUBLIC: int CDB___db_c_count __P((DBC *, db_recno_t *, u_int32_t));
+ * PUBLIC: int CDB___db_c_count __P((DBC *, db_recno_t *, uint32_t));
  */
 int
 CDB___db_c_count (dbc, recnop, flags)
      DBC *dbc;
      db_recno_t *recnop;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB *dbp;
   int ret;
@@ -252,12 +252,12 @@ CDB___db_c_count (dbc, recnop, flags)
  * CDB___db_c_del --
  *  Delete using a cursor.
  *
- * PUBLIC: int CDB___db_c_del __P((DBC *, u_int32_t));
+ * PUBLIC: int CDB___db_c_del __P((DBC *, uint32_t));
  */
 int
 CDB___db_c_del (dbc, flags)
      DBC *dbc;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB *dbp;
   DBC *opd;
@@ -305,13 +305,13 @@ CDB___db_c_del (dbc, flags)
  * CDB___db_c_dup --
  *  Duplicate a cursor
  *
- * PUBLIC: int CDB___db_c_dup __P((DBC *, DBC **, u_int32_t));
+ * PUBLIC: int CDB___db_c_dup __P((DBC *, DBC **, uint32_t));
  */
 int
 CDB___db_c_dup (dbc_orig, dbcp, flags)
      DBC *dbc_orig;
      DBC **dbcp;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB_ENV *dbenv;
   DB *dbp;
@@ -387,7 +387,7 @@ err:if (dbc_n != NULL)
 static int
 __db_c_idup (dbc_orig, dbcp, flags)
      DBC *dbc_orig, **dbcp;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB *dbp;
   DBC *dbc_n;
@@ -450,20 +450,20 @@ err:(void) dbc_n->c_close (dbc_n);
  * CDB___db_c_get --
  *  Get using a cursor.
  *
- * PUBLIC: int CDB___db_c_get __P((DBC *, DBT *, DBT *, u_int32_t));
+ * PUBLIC: int CDB___db_c_get __P((DBC *, DBT *, DBT *, uint32_t));
  */
 int
 CDB___db_c_get (dbc_arg, key, data, flags)
      DBC *dbc_arg;
      DBT *key, *data;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB *dbp;
   DBC *dbc, *dbc_n, *opd;
   DBC_INTERNAL *cp, *cp_n;
   db_pgno_t pgno;
-  u_int32_t tmp_flags, tmp_rmw;
-  u_int8_t type;
+  uint32_t tmp_flags, tmp_rmw;
+  uint8_t type;
   int ret, t_ret;
 
   /*
@@ -694,18 +694,18 @@ err:                           /* Don't pass DB_DBT_ISSET back to application le
  * CDB___db_c_put --
  *  Put using a cursor.
  *
- * PUBLIC: int CDB___db_c_put __P((DBC *, DBT *, DBT *, u_int32_t));
+ * PUBLIC: int CDB___db_c_put __P((DBC *, DBT *, DBT *, uint32_t));
  */
 int
 CDB___db_c_put (dbc_arg, key, data, flags)
      DBC *dbc_arg;
      DBT *key, *data;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB *dbp;
   DBC *dbc_n, *opd;
   db_pgno_t pgno;
-  u_int32_t tmp_flags;
+  uint32_t tmp_flags;
   int ret, t_ret;
 
   /*
@@ -804,12 +804,12 @@ err:                           /* Cleanup and cursor resolution. */
 /*
  * CDB___db_duperr()
  *  Error message: we don't currently support sorted duplicate duplicates.
- * PUBLIC: int CDB___db_duperr __P((DB *, u_int32_t));
+ * PUBLIC: int CDB___db_duperr __P((DB *, uint32_t));
  */
 int
 CDB___db_duperr (dbp, flags)
      DB *dbp;
-     u_int32_t flags;
+     uint32_t flags;
 {
   if (flags != DB_NODUPDATA)
     CDB___db_err (dbp->dbenv,

--- a/db/db_conv.c
+++ b/db/db_conv.c
@@ -146,9 +146,9 @@ void
 CDB___db_metaswap (pg)
      PAGE *pg;
 {
-  u_int8_t *p;
+  uint8_t *p;
 
-  p = (u_int8_t *) pg;
+  p = (uint8_t *) pg;
 
   /* Swap the meta-data information. */
   SWAP32 (p);                   /* lsn.file */
@@ -180,7 +180,7 @@ CDB___db_byteswap (pg, h, pagesize, pgin)
   BOVERFLOW *bo;
   RINTERNAL *ri;
   db_indx_t i, len, tmp;
-  u_int8_t *p, *end;
+  uint8_t *p, *end;
 
   COMPQUIET (pg, 0);
 

--- a/db/db_dispatch.c
+++ b/db/db_dispatch.c
@@ -79,10 +79,10 @@ CDB___db_dispatch (dbenv, db, lsnp, redo, info)
      int redo;                  /* Redo this op (or undo it). */
      void *info;
 {
-  u_int32_t rectype, txnid;
+  uint32_t rectype, txnid;
 
   memcpy (&rectype, db->data, sizeof (rectype));
-  memcpy (&txnid, (u_int8_t *) db->data + sizeof (rectype), sizeof (txnid));
+  memcpy (&txnid, (uint8_t *) db->data + sizeof (rectype), sizeof (txnid));
 
   switch (redo)
   {
@@ -132,15 +132,15 @@ CDB___db_dispatch (dbenv, db, lsnp, redo, info)
  * CDB___db_add_recovery --
  *
  * PUBLIC: int CDB___db_add_recovery __P((DB_ENV *,
- * PUBLIC:    int (*)(DB_ENV *, DBT *, DB_LSN *, int, void *), u_int32_t));
+ * PUBLIC:    int (*)(DB_ENV *, DBT *, DB_LSN *, int, void *), uint32_t));
  */
 int
 CDB___db_add_recovery (dbenv, func, ndx)
      DB_ENV *dbenv;
      int (*func) __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
-     u_int32_t ndx;
+     uint32_t ndx;
 {
-  u_int32_t i;
+  uint32_t i;
   int ret;
 
   /* Check if we have to grow the table. */
@@ -187,12 +187,12 @@ CDB___db_txnlist_init (retp)
  * CDB___db_txnlist_add --
  *  Add an element to our transaction linked list.
  *
- * PUBLIC: int CDB___db_txnlist_add __P((void *, u_int32_t));
+ * PUBLIC: int CDB___db_txnlist_add __P((void *, uint32_t));
  */
 int
 CDB___db_txnlist_add (listp, txnid)
      void *listp;
-     u_int32_t txnid;
+     uint32_t txnid;
 {
   DB_TXNHEAD *hp;
   DB_TXNLIST *elp;
@@ -220,14 +220,14 @@ CDB___db_txnlist_add (listp, txnid)
  * to have been deleted.  If you never do any operations on a file, then
  * we assume it's OK to appear deleted.
  *
- * PUBLIC: int CDB___db_txnlist_close __P((void *, u_int32_t, u_int32_t));
+ * PUBLIC: int CDB___db_txnlist_close __P((void *, uint32_t, uint32_t));
  */
 
 int
 CDB___db_txnlist_close (listp, lid, count)
      void *listp;
-     u_int32_t lid;
-     u_int32_t count;
+     uint32_t lid;
+     uint32_t count;
 {
   DB_TXNHEAD *hp;
   DB_TXNLIST *p;
@@ -254,13 +254,13 @@ CDB___db_txnlist_close (listp, lid, count)
  * just encountered a file that is missing.  The lid is the log fileid
  * and is only meaningful if deleted is not equal to 0.
  *
- * PUBLIC: int CDB___db_txnlist_delete __P((void *, char *, u_int32_t, int));
+ * PUBLIC: int CDB___db_txnlist_delete __P((void *, char *, uint32_t, int));
  */
 int
 CDB___db_txnlist_delete (listp, name, lid, deleted)
      void *listp;
      char *name;
-     u_int32_t lid;
+     uint32_t lid;
      int deleted;
 {
   DB_TXNHEAD *hp;
@@ -345,12 +345,12 @@ CDB___db_txnlist_end (dbenv, listp)
  *  Checks to see if a txnid with the current generation is in the
  *  txnid list.
  *
- * PUBLIC: int CDB___db_txnlist_find __P((void *, u_int32_t));
+ * PUBLIC: int CDB___db_txnlist_find __P((void *, uint32_t));
  */
 int
 CDB___db_txnlist_find (listp, txnid)
      void *listp;
-     u_int32_t txnid;
+     uint32_t txnid;
 {
   DB_TXNHEAD *hp;
   DB_TXNLIST *p;

--- a/db/db_dispatch.h
+++ b/db/db_dispatch.h
@@ -51,7 +51,7 @@ typedef struct __db_txnlist DB_TXNLIST;
 struct __db_txnhead
 {
   LIST_HEAD (__db_headlink, __db_txnlist) head;
-  u_int32_t maxid;
+  uint32_t maxid;
   int32_t generation;
 };
 
@@ -65,16 +65,16 @@ struct __db_txnlist
   {
     struct
     {
-      u_int32_t txnid;
+      uint32_t txnid;
       int32_t generation;
     } t;
     struct
     {
 #define TXNLIST_FLAG_DELETED  0x1
 #define  TXNLIST_FLAG_CLOSED  0x2
-      u_int32_t flags;
-      u_int32_t fileid;
-      u_int32_t count;
+      uint32_t flags;
+      uint32_t fileid;
+      uint32_t count;
       char *fname;
     } d;
   } u;

--- a/db/db_dup.c
+++ b/db/db_dup.c
@@ -26,7 +26,7 @@ static const char sccsid[] = "@(#)db_dup.c  11.11 (Sleepycat) 11/3/99";
 #include "db_am.h"
 
 static int CDB___db_addpage __P ((DBC *, PAGE **, db_indx_t *));
-static int CDB___db_dsplit __P ((DBC *, PAGE **, db_indx_t *, u_int32_t));
+static int CDB___db_dsplit __P ((DBC *, PAGE **, db_indx_t *, uint32_t));
 
 /*
  * CDB___db_dput --
@@ -96,7 +96,7 @@ CDB___db_dput (dbc, dbt, pp, indxp)
    * the location to insert.
    */
   if ((ret = CDB___db_pitem (dbc,
-                             pagep, (u_int32_t) * indxp, isize, hdr_dbtp,
+                             pagep, (uint32_t) * indxp, isize, hdr_dbtp,
                              data_dbtp)) != 0)
     return (ret);
 
@@ -108,13 +108,13 @@ CDB___db_dput (dbc, dbt, pp, indxp)
  * CDB___db_drem --
  *  Remove a duplicate at the given index on the given page.
  *
- * PUBLIC: int CDB___db_drem __P((DBC *, PAGE **, u_int32_t));
+ * PUBLIC: int CDB___db_drem __P((DBC *, PAGE **, uint32_t));
  */
 int
 CDB___db_drem (dbc, pp, indx)
      DBC *dbc;
      PAGE **pp;
-     u_int32_t indx;
+     uint32_t indx;
 {
   PAGE *pagep;
   int ret;
@@ -215,7 +215,7 @@ CDB___db_dsplit (dbc, hp, indxp, size)
      DBC *dbc;
      PAGE **hp;
      db_indx_t *indxp;
-     u_int32_t size;
+     uint32_t size;
 {
   PAGE *h, *np, *tp;
   BKEYDATA *bk;
@@ -326,7 +326,7 @@ CDB___db_dsplit (dbc, hp, indxp, size)
       s = BOVERFLOW_SIZE;
 
     np->inp[nindex++] = HOFFSET (np) -= s;
-    memcpy ((u_int8_t *) np + HOFFSET (np), bk, s);
+    memcpy ((uint8_t *) np + HOFFSET (np), bk, s);
     NUM_ENT (np)++;
   }
 
@@ -343,7 +343,7 @@ CDB___db_dsplit (dbc, hp, indxp, size)
       s = BOVERFLOW_SIZE;
 
     tp->inp[nindex++] = HOFFSET (tp) -= s;
-    memcpy ((u_int8_t *) tp + HOFFSET (tp), bk, s);
+    memcpy ((uint8_t *) tp + HOFFSET (tp), bk, s);
     NUM_ENT (tp)++;
   }
 
@@ -354,8 +354,8 @@ CDB___db_dsplit (dbc, hp, indxp, size)
    * about half a page.
    */
   memcpy (h, tp, LOFFSET (tp));
-  memcpy ((u_int8_t *) h + HOFFSET (tp),
-          (u_int8_t *) tp + HOFFSET (tp), pgsize - HOFFSET (tp));
+  memcpy ((uint8_t *) h + HOFFSET (tp),
+          (uint8_t *) tp + HOFFSET (tp), pgsize - HOFFSET (tp));
   CDB___os_free (tp, pgsize);
 
   if (DB_LOGGING (dbc))
@@ -406,19 +406,19 @@ CDB___db_dsplit (dbc, hp, indxp, size)
  * CDB___db_ditem --
  *  Remove an item from a page.
  *
- * PUBLIC:  int CDB___db_ditem __P((DBC *, PAGE *, u_int32_t, u_int32_t));
+ * PUBLIC:  int CDB___db_ditem __P((DBC *, PAGE *, uint32_t, uint32_t));
  */
 int
 CDB___db_ditem (dbc, pagep, indx, nbytes)
      DBC *dbc;
      PAGE *pagep;
-     u_int32_t indx, nbytes;
+     uint32_t indx, nbytes;
 {
   DB *dbp;
   DBT ldbt;
   db_indx_t cnt, offset;
   int ret;
-  u_int8_t *from;
+  uint8_t *from;
 
   dbp = dbc->dbp;
   if (DB_LOGGING (dbc))
@@ -428,7 +428,7 @@ CDB___db_ditem (dbc, pagep, indx, nbytes)
     if ((ret = CDB___db_addrem_log (dbp->dbenv, dbc->txn,
                                     &LSN (pagep), 0, DB_REM_DUP,
                                     dbp->log_fileid, PGNO (pagep),
-                                    (u_int32_t) indx, nbytes, &ldbt, NULL,
+                                    (uint32_t) indx, nbytes, &ldbt, NULL,
                                     &LSN (pagep))) != 0)
       return (ret);
   }
@@ -448,7 +448,7 @@ CDB___db_ditem (dbc, pagep, indx, nbytes)
    * Pack the remaining key/data items at the end of the page.  Use
    * memmove(3), the regions may overlap.
    */
-  from = (u_int8_t *) pagep + HOFFSET (pagep);
+  from = (uint8_t *) pagep + HOFFSET (pagep);
   memmove (from + nbytes, from, pagep->inp[indx] - HOFFSET (pagep));
   HOFFSET (pagep) += nbytes;
 
@@ -472,21 +472,21 @@ CDB___db_ditem (dbc, pagep, indx, nbytes)
  *  Put an item on a page.
  *
  * PUBLIC: int CDB___db_pitem
- * PUBLIC:     __P((DBC *, PAGE *, u_int32_t, u_int32_t, DBT *, DBT *));
+ * PUBLIC:     __P((DBC *, PAGE *, uint32_t, uint32_t, DBT *, DBT *));
  */
 int
 CDB___db_pitem (dbc, pagep, indx, nbytes, hdr, data)
      DBC *dbc;
      PAGE *pagep;
-     u_int32_t indx;
-     u_int32_t nbytes;
+     uint32_t indx;
+     uint32_t nbytes;
      DBT *hdr, *data;
 {
   DB *dbp;
   BKEYDATA bk;
   DBT thdr;
   int ret;
-  u_int8_t *p;
+  uint8_t *p;
 
   /*
    * Put a single item onto a page.  The logic figuring out where to
@@ -510,7 +510,7 @@ CDB___db_pitem (dbc, pagep, indx, nbytes, hdr, data)
     if ((ret = CDB___db_addrem_log (dbp->dbenv, dbc->txn,
                                     &LSN (pagep), 0, DB_ADD_DUP,
                                     dbp->log_fileid, PGNO (pagep),
-                                    (u_int32_t) indx, nbytes, hdr, data,
+                                    (uint32_t) indx, nbytes, hdr, data,
                                     &LSN (pagep))) != 0)
       return (ret);
 
@@ -544,12 +544,12 @@ CDB___db_pitem (dbc, pagep, indx, nbytes, hdr, data)
  * CDB___db_relink --
  *  Relink around a deleted page.
  *
- * PUBLIC: int CDB___db_relink __P((DBC *, u_int32_t, PAGE *, PAGE **, int));
+ * PUBLIC: int CDB___db_relink __P((DBC *, uint32_t, PAGE *, PAGE **, int));
  */
 int
 CDB___db_relink (dbc, add_rem, pagep, new_next, needlock)
      DBC *dbc;
-     u_int32_t add_rem;
+     uint32_t add_rem;
      PAGE *pagep, **new_next;
      int needlock;
 {

--- a/db/db_err.c
+++ b/db/db_err.c
@@ -51,13 +51,13 @@ __P ((const DB_ENV *, int, int, const char *, va_list));
  * CDB___db_fchk --
  *  General flags checking routine.
  *
- * PUBLIC: int CDB___db_fchk __P((DB_ENV *, const char *, u_int32_t, u_int32_t));
+ * PUBLIC: int CDB___db_fchk __P((DB_ENV *, const char *, uint32_t, uint32_t));
  */
 int
 CDB___db_fchk (dbenv, name, flags, ok_flags)
      DB_ENV *dbenv;
      const char *name;
-     u_int32_t flags, ok_flags;
+     uint32_t flags, ok_flags;
 {
   return (LF_ISSET (~ok_flags) ? CDB___db_ferr (dbenv, name, 0) : 0);
 }
@@ -67,13 +67,13 @@ CDB___db_fchk (dbenv, name, flags, ok_flags)
  *  General combination flags checking routine.
  *
  * PUBLIC: int CDB___db_fcchk
- * PUBLIC:    __P((DB_ENV *, const char *, u_int32_t, u_int32_t, u_int32_t));
+ * PUBLIC:    __P((DB_ENV *, const char *, uint32_t, uint32_t, uint32_t));
  */
 int
 CDB___db_fcchk (dbenv, name, flags, flag1, flag2)
      DB_ENV *dbenv;
      const char *name;
-     u_int32_t flags, flag1, flag2;
+     uint32_t flags, flag1, flag2;
 {
   return (LF_ISSET (flag1) &&
           LF_ISSET (flag2) ? CDB___db_ferr (dbenv, name, 1) : 0);
@@ -389,7 +389,7 @@ CDB___db_errfile (dbenv, error, error_set, fmt, ap)
  *
  * PUBLIC: #ifdef __STDC__
  * PUBLIC: int CDB___db_logmsg __P((DB_ENV *,
- * PUBLIC:     DB_TXN *, const char *, u_int32_t, const char *, ...));
+ * PUBLIC:     DB_TXN *, const char *, uint32_t, const char *, ...));
  * PUBLIC: #else
  * PUBLIC: int CDB___db_logmsg();
  * PUBLIC: #endif
@@ -397,14 +397,14 @@ CDB___db_errfile (dbenv, error, error_set, fmt, ap)
 int
 #if defined(__STDC__) || defined(_MSC_VER)      /* WIN32 */
 CDB___db_logmsg (DB_ENV * dbenv,
-                 DB_TXN * txnid, const char *opname, u_int32_t flags,
+                 DB_TXN * txnid, const char *opname, uint32_t flags,
                  const char *fmt, ...)
 #else
 CDB___db_logmsg (dbenv, txnid, opname, flags, fmt, va_alist)
      DB_ENV *dbenv;
      DB_TXN *txnid;
      const char *opname, *fmt;
-     u_int32_t flags;
+     uint32_t flags;
      va_dcl
 #endif
 {

--- a/db/db_ext.h
+++ b/db/db_ext.h
@@ -10,19 +10,19 @@ int CDB___crdel_metapage_recover
 __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___crdel_delete_recover __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___db_open __P ((DB *,
-                        const char *, const char *, DBTYPE, u_int32_t, int));
-int CDB___db_close __P ((DB *, u_int32_t));
-int CDB___db_remove __P ((DB *, const char *, const char *, u_int32_t));
+                        const char *, const char *, DBTYPE, uint32_t, int));
+int CDB___db_close __P ((DB *, uint32_t));
+int CDB___db_remove __P ((DB *, const char *, const char *, uint32_t));
 int CDB___db_backup_name __P ((const char *, char **, DB_LSN *));
 int __db_testcopy __P ((DB *, const char *));
-int CDB___db_cursor __P ((DB *, DB_TXN *, DBC **, u_int32_t));
-int CDB___db_c_dup __P ((DBC *, DBC **, u_int32_t));
+int CDB___db_cursor __P ((DB *, DB_TXN *, DBC **, uint32_t));
+int CDB___db_c_dup __P ((DBC *, DBC **, uint32_t));
 int CDB___db_cprint __P ((DB *));
 int CDB___db_c_destroy __P ((DBC *));
 int CDB___db_fd __P ((DB *, int *));
-int CDB___db_get __P ((DB *, DB_TXN *, DBT *, DBT *, u_int32_t));
-int CDB___db_put __P ((DB *, DB_TXN *, DBT *, DBT *, u_int32_t));
-int CDB___db_sync __P ((DB *, u_int32_t));
+int CDB___db_get __P ((DB *, DB_TXN *, DBT *, DBT *, uint32_t));
+int CDB___db_put __P ((DB *, DB_TXN *, DBT *, DBT *, uint32_t));
+int CDB___db_sync __P ((DB *, uint32_t));
 int CDB___db_log_page __P ((DB *, const char *, DB_LSN *, db_pgno_t, PAGE *));
 int CDB___db_init_recover __P ((DB_ENV *));
 int CDB___db_pgin __P ((db_pgno_t, void *, DBT *));
@@ -32,62 +32,62 @@ int CDB___db_byteswap __P ((db_pgno_t, PAGE *, size_t, int));
 int CDB___db_dispatch __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___db_add_recovery __P ((DB_ENV *,
                                 int (*)(DB_ENV *, DBT *, DB_LSN *, int,
-                                        void *), u_int32_t));
+                                        void *), uint32_t));
 int CDB___db_txnlist_init __P ((void *));
-int CDB___db_txnlist_add __P ((void *, u_int32_t));
-int CDB___db_txnlist_close __P ((void *, u_int32_t, u_int32_t));
-int CDB___db_txnlist_delete __P ((void *, char *, u_int32_t, int));
+int CDB___db_txnlist_add __P ((void *, uint32_t));
+int CDB___db_txnlist_close __P ((void *, uint32_t, uint32_t));
+int CDB___db_txnlist_delete __P ((void *, char *, uint32_t, int));
 void CDB___db_txnlist_end __P ((DB_ENV *, void *));
-int CDB___db_txnlist_find __P ((void *, u_int32_t));
+int CDB___db_txnlist_find __P ((void *, uint32_t));
 void CDB___db_txnlist_gen __P ((void *, int));
 void CDB___db_txnlist_print __P ((void *));
 int CDB___db_dput __P ((DBC *, DBT *, PAGE **, db_indx_t *));
-int CDB___db_drem __P ((DBC *, PAGE **, u_int32_t));
+int CDB___db_drem __P ((DBC *, PAGE **, uint32_t));
 int CDB___db_dend __P ((DBC *, db_pgno_t, PAGE **));
-int CDB___db_ditem __P ((DBC *, PAGE *, u_int32_t, u_int32_t));
-int CDB___db_pitem __P ((DBC *, PAGE *, u_int32_t, u_int32_t, DBT *, DBT *));
-int CDB___db_relink __P ((DBC *, u_int32_t, PAGE *, PAGE **, int));
+int CDB___db_ditem __P ((DBC *, PAGE *, uint32_t, uint32_t));
+int CDB___db_pitem __P ((DBC *, PAGE *, uint32_t, uint32_t, DBT *, DBT *));
+int CDB___db_relink __P ((DBC *, uint32_t, PAGE *, PAGE **, int));
 int CDB___db_ddup __P ((DBC *, db_pgno_t));
 int CDB___db_dsearch __P ((DBC *,
                            int, DBT *, db_pgno_t, db_indx_t *, PAGE **,
                            int *));
-int CDB___db_cursorchk __P ((const DB *, u_int32_t, int));
-int CDB___db_cdelchk __P ((const DB *, u_int32_t, int, int));
-int CDB___db_cgetchk __P ((const DB *, DBT *, DBT *, u_int32_t, int));
+int CDB___db_cursorchk __P ((const DB *, uint32_t, int));
+int CDB___db_cdelchk __P ((const DB *, uint32_t, int, int));
+int CDB___db_cgetchk __P ((const DB *, DBT *, DBT *, uint32_t, int));
 int CDB___db_cputchk __P ((const DB *,
-                           const DBT *, DBT *, u_int32_t, int, int));
-int CDB___db_closechk __P ((const DB *, u_int32_t));
-int CDB___db_delchk __P ((const DB *, DBT *, u_int32_t, int));
-int CDB___db_getchk __P ((const DB *, const DBT *, DBT *, u_int32_t));
-int CDB___db_joinchk __P ((const DB *, u_int32_t));
+                           const DBT *, DBT *, uint32_t, int, int));
+int CDB___db_closechk __P ((const DB *, uint32_t));
+int CDB___db_delchk __P ((const DB *, DBT *, uint32_t, int));
+int CDB___db_getchk __P ((const DB *, const DBT *, DBT *, uint32_t));
+int CDB___db_joinchk __P ((const DB *, uint32_t));
 int CDB___db_putchk
-__P ((const DB *, DBT *, const DBT *, u_int32_t, int, int));
-int CDB___db_statchk __P ((const DB *, u_int32_t));
-int CDB___db_syncchk __P ((const DB *, u_int32_t));
+__P ((const DB *, DBT *, const DBT *, uint32_t, int, int));
+int CDB___db_statchk __P ((const DB *, uint32_t));
+int CDB___db_syncchk __P ((const DB *, uint32_t));
 int CDB___db_eopnotsup __P ((const DB_ENV *));
-int CDB___db_removechk __P ((const DB *, u_int32_t));
-int CDB___db_join __P ((DB *, DBC **, DBC **, u_int32_t));
-int CDB___db_new __P ((DBC *, u_int32_t, PAGE **));
+int CDB___db_removechk __P ((const DB *, uint32_t));
+int CDB___db_join __P ((DB *, DBC **, DBC **, uint32_t));
+int CDB___db_new __P ((DBC *, uint32_t, PAGE **));
 int CDB___db_free __P ((DBC *, PAGE *));
 int CDB___db_lt __P ((DBC *));
 int CDB___db_lget __P ((DBC *,
                         int, db_pgno_t, db_lockmode_t, int, DB_LOCK *));
-int CDB___dbh_am_chk __P ((DB *, u_int32_t));
+int CDB___dbh_am_chk __P ((DB *, uint32_t));
 int CDB___db_goff __P ((DB *, DBT *,
-                        u_int32_t, db_pgno_t, void **, u_int32_t *));
+                        uint32_t, db_pgno_t, void **, uint32_t *));
 int CDB___db_poff __P ((DBC *, const DBT *, db_pgno_t *));
 int CDB___db_ovref __P ((DBC *, db_pgno_t, int32_t));
 int CDB___db_doff __P ((DBC *, db_pgno_t));
-int CDB___db_moff __P ((DB *, const DBT *, db_pgno_t, u_int32_t,
+int CDB___db_moff __P ((DB *, const DBT *, db_pgno_t, uint32_t,
                         int (*)(const DBT *, const DBT *), int *));
 void CDB___db_loadme __P ((void));
 int CDB___db_dump __P ((DB *, char *, char *));
 int CDB___db_prnpage __P ((DB *, db_pgno_t));
-int CDB___db_prpage __P ((DB *, PAGE *, u_int32_t));
+int CDB___db_prpage __P ((DB *, PAGE *, uint32_t));
 int CDB___db_isbad __P ((PAGE *, int));
-void CDB___db_pr __P ((u_int8_t *, u_int32_t));
+void CDB___db_pr __P ((uint8_t *, uint32_t));
 int CDB___db_prdbt __P ((DBT *, int, const char *, FILE *, int));
-void CDB___db_prflags __P ((u_int32_t, const FN *, FILE *));
+void CDB___db_prflags __P ((uint32_t, const FN *, FILE *));
 int CDB___db_addrem_recover __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___db_split_recover __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___db_big_recover __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
@@ -102,8 +102,8 @@ int CDB___db_traverse_dup __P ((DB *,
 int CDB___db_traverse_big
 __P ((DB *, db_pgno_t, int (*)(DB *, PAGE *, void *, int *), void *));
 int CDB___db_reclaim_callback __P ((DB *, PAGE *, void *, int *));
-int CDB___db_ret __P ((DB *, PAGE *, u_int32_t, DBT *, void **, u_int32_t *));
+int CDB___db_ret __P ((DB *, PAGE *, uint32_t, DBT *, void **, uint32_t *));
 int CDB___db_retcopy __P ((DB *, DBT *,
-                           void *, u_int32_t, void **, u_int32_t *));
-int CDB___db_upgrade __P ((DB *, const char *, u_int32_t));
+                           void *, uint32_t, void **, uint32_t *));
+int CDB___db_upgrade __P ((DB *, const char *, uint32_t));
 #endif /* _db_ext_h_ */

--- a/db/db_iface.c
+++ b/db/db_iface.c
@@ -30,12 +30,12 @@ static int CDB___dbt_ferr __P ((const DB *, const char *, const DBT *, int));
  * CDB___db_cursorchk --
  *  Common cursor argument checking routine.
  *
- * PUBLIC: int CDB___db_cursorchk __P((const DB *, u_int32_t, int));
+ * PUBLIC: int CDB___db_cursorchk __P((const DB *, uint32_t, int));
  */
 int
 CDB___db_cursorchk (dbp, flags, isrdonly)
      const DB *dbp;
-     u_int32_t flags;
+     uint32_t flags;
      int isrdonly;
 {
   /* Check for invalid function flags. */
@@ -65,12 +65,12 @@ CDB___db_cursorchk (dbp, flags, isrdonly)
  * CDB___db_cdelchk --
  *  Common cursor delete argument checking routine.
  *
- * PUBLIC: int CDB___db_cdelchk __P((const DB *, u_int32_t, int, int));
+ * PUBLIC: int CDB___db_cdelchk __P((const DB *, uint32_t, int, int));
  */
 int
 CDB___db_cdelchk (dbp, flags, isrdonly, isvalid)
      const DB *dbp;
-     u_int32_t flags;
+     uint32_t flags;
      int isrdonly, isvalid;
 {
   /* Check for changes to a read-only tree. */
@@ -97,13 +97,13 @@ CDB___db_cdelchk (dbp, flags, isrdonly, isvalid)
  * CDB___db_cgetchk --
  *  Common cursor get argument checking routine.
  *
- * PUBLIC: int CDB___db_cgetchk __P((const DB *, DBT *, DBT *, u_int32_t, int));
+ * PUBLIC: int CDB___db_cgetchk __P((const DB *, DBT *, DBT *, uint32_t, int));
  */
 int
 CDB___db_cgetchk (dbp, key, data, flags, isvalid)
      const DB *dbp;
      DBT *key, *data;
-     u_int32_t flags;
+     uint32_t flags;
      int isvalid;
 {
   int key_einval, key_flags, ret;
@@ -185,14 +185,14 @@ CDB___db_cgetchk (dbp, key, data, flags, isvalid)
  *  Common cursor put argument checking routine.
  *
  * PUBLIC: int CDB___db_cputchk __P((const DB *,
- * PUBLIC:    const DBT *, DBT *, u_int32_t, int, int));
+ * PUBLIC:    const DBT *, DBT *, uint32_t, int, int));
  */
 int
 CDB___db_cputchk (dbp, key, data, flags, isrdonly, isvalid)
      const DB *dbp;
      const DBT *key;
      DBT *data;
-     u_int32_t flags;
+     uint32_t flags;
      int isrdonly, isvalid;
 {
   int key_einval, key_flags, ret;
@@ -258,12 +258,12 @@ CDB___db_cputchk (dbp, key, data, flags, isrdonly, isvalid)
  * CDB___db_closechk --
  *  DB->close flag check.
  *
- * PUBLIC: int CDB___db_closechk __P((const DB *, u_int32_t));
+ * PUBLIC: int CDB___db_closechk __P((const DB *, uint32_t));
  */
 int
 CDB___db_closechk (dbp, flags)
      const DB *dbp;
-     u_int32_t flags;
+     uint32_t flags;
 {
   /* Check for invalid function flags. */
   switch (flags)
@@ -282,13 +282,13 @@ CDB___db_closechk (dbp, flags)
  * CDB___db_delchk --
  *  Common delete argument checking routine.
  *
- * PUBLIC: int CDB___db_delchk __P((const DB *, DBT *, u_int32_t, int));
+ * PUBLIC: int CDB___db_delchk __P((const DB *, DBT *, uint32_t, int));
  */
 int
 CDB___db_delchk (dbp, key, flags, isrdonly)
      const DB *dbp;
      DBT *key;
-     u_int32_t flags;
+     uint32_t flags;
      int isrdonly;
 {
   /* Check for changes to a read-only tree. */
@@ -315,14 +315,14 @@ CDB___db_delchk (dbp, key, flags, isrdonly)
  * CDB___db_getchk --
  *  Common get argument checking routine.
  *
- * PUBLIC: int CDB___db_getchk __P((const DB *, const DBT *, DBT *, u_int32_t));
+ * PUBLIC: int CDB___db_getchk __P((const DB *, const DBT *, DBT *, uint32_t));
  */
 int
 CDB___db_getchk (dbp, key, data, flags)
      const DB *dbp;
      const DBT *key;
      DBT *data;
-     u_int32_t flags;
+     uint32_t flags;
 {
   int ret;
 
@@ -368,12 +368,12 @@ CDB___db_getchk (dbp, key, data, flags)
  * CDB___db_joinchk --
  *  Common join argument checking routine.
  *
- * PUBLIC: int CDB___db_joinchk __P((const DB *, u_int32_t));
+ * PUBLIC: int CDB___db_joinchk __P((const DB *, uint32_t));
  */
 int
 CDB___db_joinchk (dbp, flags)
      const DB *dbp;
-     u_int32_t flags;
+     uint32_t flags;
 {
   if (flags != 0)
     return (CDB___db_ferr (dbp->dbenv, "DB->join", 0));
@@ -386,14 +386,14 @@ CDB___db_joinchk (dbp, flags)
  *  Common put argument checking routine.
  *
  * PUBLIC: int CDB___db_putchk
- * PUBLIC:    __P((const DB *, DBT *, const DBT *, u_int32_t, int, int));
+ * PUBLIC:    __P((const DB *, DBT *, const DBT *, uint32_t, int, int));
  */
 int
 CDB___db_putchk (dbp, key, data, flags, isrdonly, isdup)
      const DB *dbp;
      DBT *key;
      const DBT *data;
-     u_int32_t flags;
+     uint32_t flags;
      int isrdonly, isdup;
 {
   int ret;
@@ -441,12 +441,12 @@ CDB___db_putchk (dbp, key, data, flags, isrdonly, isdup)
  * CDB___db_statchk --
  *  Common stat argument checking routine.
  *
- * PUBLIC: int CDB___db_statchk __P((const DB *, u_int32_t));
+ * PUBLIC: int CDB___db_statchk __P((const DB *, uint32_t));
  */
 int
 CDB___db_statchk (dbp, flags)
      const DB *dbp;
-     u_int32_t flags;
+     uint32_t flags;
 {
   /* Check for invalid function flags. */
   switch (flags)
@@ -470,12 +470,12 @@ CDB___db_statchk (dbp, flags)
  * CDB___db_syncchk --
  *  Common sync argument checking routine.
  *
- * PUBLIC: int CDB___db_syncchk __P((const DB *, u_int32_t));
+ * PUBLIC: int CDB___db_syncchk __P((const DB *, uint32_t));
  */
 int
 CDB___db_syncchk (dbp, flags)
      const DB *dbp;
-     u_int32_t flags;
+     uint32_t flags;
 {
   /* Check for invalid function flags. */
   switch (flags)
@@ -584,12 +584,12 @@ CDB___db_rdonly (dbenv, name)
  * CDB___db_removechk --
  *  DB->remove flag check.
  *
- * PUBLIC: int CDB___db_removechk __P((const DB *, u_int32_t));
+ * PUBLIC: int CDB___db_removechk __P((const DB *, uint32_t));
  */
 int
 CDB___db_removechk (dbp, flags)
      const DB *dbp;
-     u_int32_t flags;
+     uint32_t flags;
 {
   /* Check for invalid function flags. */
   switch (flags)

--- a/db/db_int.h
+++ b/db/db_int.h
@@ -94,7 +94,7 @@
 /* Structure used to print flag values. */
 typedef struct __fn
 {
-  u_int32_t mask;               /* Flag value. */
+  uint32_t mask;               /* Flag value. */
   const char *name;             /* Flag name. */
 } FN;
 
@@ -246,11 +246,11 @@ typedef struct __dbpginfo
  */
 typedef struct __db_globals
 {
-  u_int32_t db_mutexlocks;      /* db_set_mutexlocks */
-  u_int32_t db_pageyield;       /* db_set_pageyield */
-  u_int32_t db_panic;           /* db_set_panic */
-  u_int32_t db_region_init;     /* db_set_region_init */
-  u_int32_t db_tas_spins;       /* db_set_tas_spins */
+  uint32_t db_mutexlocks;      /* db_set_mutexlocks */
+  uint32_t db_pageyield;       /* db_set_pageyield */
+  uint32_t db_panic;           /* db_set_panic */
+  uint32_t db_region_init;     /* db_set_region_init */
+  uint32_t db_tas_spins;       /* db_set_tas_spins */
   /* XA: list of opened environments. */
     TAILQ_HEAD (__db_envq, __db_env) db_envq;
 } DB_GLOBALS;

--- a/db/db_join.c
+++ b/db/db_join.c
@@ -25,11 +25,11 @@ static const char sccsid[] = "@(#)db_join.c  11.6 (Sleepycat) 10/19/99";
 #include "btree.h"
 
 static int CDB___db_join_close __P ((DBC *));
-static int CDB___db_join_del __P ((DBC *, u_int32_t));
-static int CDB___db_join_get __P ((DBC *, DBT *, DBT *, u_int32_t));
+static int CDB___db_join_del __P ((DBC *, uint32_t));
+static int CDB___db_join_get __P ((DBC *, DBT *, DBT *, uint32_t));
 static int CDB___db_join_getnext
-__P ((DBC *, DBT *, DBT *, DBT *, u_int32_t));
-static int CDB___db_join_put __P ((DBC *, DBT *, DBT *, u_int32_t));
+__P ((DBC *, DBT *, DBT *, DBT *, uint32_t));
+static int CDB___db_join_put __P ((DBC *, DBT *, DBT *, uint32_t));
 
 /*
  * This is the duplicate-assisted join functionality.  Right now we're
@@ -63,13 +63,13 @@ static int CDB___db_join_put __P ((DBC *, DBT *, DBT *, u_int32_t));
  * key and data are returned.  When no more items are left in the join
  * set, the  c_next operation off the join cursor will return DB_NOTFOUND.
  *
- * PUBLIC: int CDB___db_join __P((DB *, DBC **, DBC **, u_int32_t));
+ * PUBLIC: int CDB___db_join __P((DB *, DBC **, DBC **, uint32_t));
  */
 int
 CDB___db_join (primary, curslist, dbcp, flags)
      DB *primary;
      DBC **curslist, **dbcp;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DBC *dbc;
   JOIN_CURSOR *jc;
@@ -160,7 +160,7 @@ CDB___db_join (primary, curslist, dbcp, flags)
     goto err;
   if ((ret = CDB___os_calloc (nslots, sizeof (DBC *), &jc->j_fdupcurs)) != 0)
     goto err;
-  if ((ret = CDB___os_calloc (nslots, sizeof (u_int8_t),
+  if ((ret = CDB___os_calloc (nslots, sizeof (uint8_t),
                               &jc->j_exhausted)) != 0)
     goto err;
   for (i = 0; curslist[i] != NULL; i++)
@@ -213,7 +213,7 @@ err:if (jc != NULL)
     if (jc->j_fdupcurs != NULL)
       CDB___os_free (jc->j_fdupcurs, nslots * sizeof (DBC *));
     if (jc->j_exhausted != NULL)
-      CDB___os_free (jc->j_exhausted, nslots * sizeof (u_int8_t));
+      CDB___os_free (jc->j_exhausted, nslots * sizeof (uint8_t));
     CDB___os_free (jc, sizeof (JOIN_CURSOR));
   }
   if (dbc != NULL)
@@ -226,7 +226,7 @@ CDB___db_join_put (dbc, key, data, flags)
      DBC *dbc;
      DBT *key;
      DBT *data;
-     u_int32_t flags;
+     uint32_t flags;
 {
   PANIC_CHECK (dbc->dbp->dbenv);
 
@@ -239,7 +239,7 @@ CDB___db_join_put (dbc, key, data, flags)
 static int
 CDB___db_join_del (dbc, flags)
      DBC *dbc;
-     u_int32_t flags;
+     uint32_t flags;
 {
   PANIC_CHECK (dbc->dbp->dbenv);
 
@@ -251,14 +251,14 @@ static int
 CDB___db_join_get (dbc, key, data, flags)
      DBC *dbc;
      DBT *key, *data;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DBT currkey;
   DB *dbp;
   DBC *cp;
   JOIN_CURSOR *jc;
   int ret, i, j;
-  u_int32_t operation;
+  uint32_t operation;
 
   dbp = dbc->dbp;
   memset (&currkey, 0, sizeof (currkey));
@@ -572,7 +572,7 @@ static int
 CDB___db_join_getnext (dbc, key, data, matching, exhausted)
      DBC *dbc;
      DBT *key, *data, *matching;
-     u_int32_t exhausted;
+     uint32_t exhausted;
 {
   int ret, cmp;
   DB *dbp;

--- a/db/db_join.h
+++ b/db/db_join.h
@@ -17,7 +17,7 @@
  */
 typedef struct __join_cursor
 {
-  u_int8_t *j_exhausted;        /* Array of flags; is cursor i exhausted? */
+  uint8_t *j_exhausted;        /* Array of flags; is cursor i exhausted? */
   DBC **j_curslist;             /* Array of cursors in the join: constant. */
   DBC **j_fdupcurs;             /* Cursors w/ first intances of current dup. */
   DBC **j_workcurs;             /* Scratch cursor copies to muck with. */

--- a/db/db_log2.c
+++ b/db/db_log2.c
@@ -50,13 +50,13 @@ static const char sccsid[] = "@(#)db_log2.c  11.2 (Sleepycat) 9/9/99";
 #include "common_ext.h"
 
 /*
- * PUBLIC: u_int32_t CDB___db_log2 __P((u_int32_t));
+ * PUBLIC: uint32_t CDB___db_log2 __P((uint32_t));
  */
-u_int32_t
+uint32_t
 CDB___db_log2 (num)
-     u_int32_t num;
+     uint32_t num;
 {
-  u_int32_t i, limit;
+  uint32_t i, limit;
 
   limit = 1;
   for (i = 0; limit < num; limit = limit << 1)

--- a/db/db_meta.c
+++ b/db/db_meta.c
@@ -65,12 +65,12 @@ static const char sccsid[] = "@(#)db_meta.c  11.8 (Sleepycat) 10/19/99";
  * CDB___db_new --
  *  Get a new page, preferably from the freelist.
  *
- * PUBLIC: int CDB___db_new __P((DBC *, u_int32_t, PAGE **));
+ * PUBLIC: int CDB___db_new __P((DBC *, uint32_t, PAGE **));
  */
 int
 CDB___db_new (dbc, type, pagepp)
      DBC *dbc;
-     u_int32_t type;
+     uint32_t type;
      PAGE **pagepp;
 {
   DBMETA *meta;
@@ -112,7 +112,7 @@ CDB___db_new (dbc, type, pagepp)
   {
     if ((ret = __db_pg_alloc_log (dbp->dbenv, dbc->txn,
                                   &meta->lsn, 0, dbp->log_fileid, &meta->lsn,
-                                  &h->lsn, h->pgno, (u_int32_t) type,
+                                  &h->lsn, h->pgno, (uint32_t) type,
                                   meta->free)) != 0)
       goto err;
     LSN (h) = LSN (meta);
@@ -150,7 +150,7 @@ CDB___db_free (dbc, h)
   DBT ldbt;
   DB_LOCK metalock;
   db_pgno_t pgno;
-  u_int32_t dirty_flag;
+  uint32_t dirty_flag;
   int ret, t_ret;
 
   dbp = dbc->dbp;

--- a/db/db_method.c
+++ b/db/db_method.c
@@ -29,17 +29,17 @@ static const char sccsid[] = "@(#)db_method.c  11.8 (Sleepycat) 9/22/99";
 
 static int CDB___db_get_byteswapped __P ((DB *));
 static DBTYPE CDB___db_get_type __P ((DB *));
-static int CDB___db_init __P ((DB *, u_int32_t));
-static int CDB___db_set_cachesize __P ((DB *, u_int32_t, u_int32_t, int));
+static int CDB___db_init __P ((DB *, uint32_t));
+static int CDB___db_set_cachesize __P ((DB *, uint32_t, uint32_t, int));
 static int CDB___db_set_dup_compare
 __P ((DB *, int (*)(const DBT *, const DBT *)));
 static void CDB___db_set_errcall __P ((DB *, void (*)(const char *, char *)));
 static void CDB___db_set_errfile __P ((DB *, FILE *));
 static void CDB___db_set_feedback __P ((DB *, void (*)(DB *, int, int)));
-static int CDB___db_set_flags __P ((DB *, u_int32_t));
+static int CDB___db_set_flags __P ((DB *, uint32_t));
 static int CDB___db_set_lorder __P ((DB *, int));
 static int CDB___db_set_malloc __P ((DB *, void *(*)(size_t)));
-static int CDB___db_set_pagesize __P ((DB *, u_int32_t));
+static int CDB___db_set_pagesize __P ((DB *, uint32_t));
 static int CDB___db_set_realloc __P ((DB *, void *(*)(void *, size_t)));
 static void CDB___db_set_errpfx __P ((DB *, const char *));
 static void CDB___db_set_paniccall __P ((DB *, void (*)(DB_ENV *, int)));
@@ -54,7 +54,7 @@ int
 CDB_db_create (dbpp, dbenv, flags)
      DB **dbpp;
      DB_ENV *dbenv;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB *dbp;
   int ret;
@@ -117,7 +117,7 @@ CDB_db_create (dbpp, dbenv, flags)
 static int
 CDB___db_init (dbp, flags)
      DB *dbp;
-     u_int32_t flags;
+     uint32_t flags;
 {
   int ret;
 
@@ -182,12 +182,12 @@ CDB___db_init (dbp, flags)
  * CDB___dbh_am_chk --
  *  Error if an unreasonable method is called.
  *
- * PUBLIC: int CDB___dbh_am_chk __P((DB *, u_int32_t));
+ * PUBLIC: int CDB___dbh_am_chk __P((DB *, uint32_t));
  */
 int
 CDB___dbh_am_chk (dbp, flags)
      DB *dbp;
-     u_int32_t flags;
+     uint32_t flags;
 {
   /*
    * We start out allowing any access methods to be called, and as the
@@ -294,7 +294,7 @@ CDB___db_get_type (dbp)
 static int
 CDB___db_set_cachesize (dbp, cache_gbytes, cache_bytes, ncache)
      DB *dbp;
-     u_int32_t cache_gbytes, cache_bytes;
+     uint32_t cache_gbytes, cache_bytes;
      int ncache;
 {
   DB_ILLEGAL_IN_ENV (dbp, "set_cachesize");
@@ -356,7 +356,7 @@ CDB___db_set_feedback (dbp, feedback)
 static int
 CDB___db_set_flags (dbp, flags)
      DB *dbp;
-     u_int32_t flags;
+     uint32_t flags;
 {
   int ret;
 
@@ -415,7 +415,7 @@ CDB___db_set_malloc (dbp, func)
 static int
 CDB___db_set_pagesize (dbp, db_pagesize)
      DB *dbp;
-     u_int32_t db_pagesize;
+     uint32_t db_pagesize;
 {
   DB_ILLEGAL_AFTER_OPEN (dbp, "set_pagesize");
 
@@ -436,7 +436,7 @@ CDB___db_set_pagesize (dbp, db_pagesize)
    * We don't want anything that's not a power-of-2, as we rely on that
    * for alignment of various types on the pages.
    */
-  if ((u_int32_t) 1 << CDB___db_log2 (db_pagesize) != db_pagesize)
+  if ((uint32_t) 1 << CDB___db_log2 (db_pagesize) != db_pagesize)
   {
     CDB___db_err (dbp->dbenv, "page sizes must be a power-of-2");
     return (EINVAL);

--- a/db/db_overflow.c
+++ b/db/db_overflow.c
@@ -71,21 +71,21 @@ static const char sccsid[] = "@(#)db_overflow.c  11.2 (Sleepycat) 9/9/99";
  *  Get an offpage item.
  *
  * PUBLIC: int CDB___db_goff __P((DB *, DBT *,
- * PUBLIC:     u_int32_t, db_pgno_t, void **, u_int32_t *));
+ * PUBLIC:     uint32_t, db_pgno_t, void **, uint32_t *));
  */
 int
 CDB___db_goff (dbp, dbt, tlen, pgno, bpp, bpsz)
      DB *dbp;
      DBT *dbt;
-     u_int32_t tlen;
+     uint32_t tlen;
      db_pgno_t pgno;
      void **bpp;
-     u_int32_t *bpsz;
+     uint32_t *bpsz;
 {
   PAGE *h;
   db_indx_t bytes;
-  u_int32_t curoff, needed, start;
-  u_int8_t *p, *src;
+  uint32_t curoff, needed, start;
+  uint8_t *p, *src;
   int ret;
 
   /*
@@ -149,7 +149,7 @@ CDB___db_goff (dbp, dbt, tlen, pgno, bpp, bpsz)
     /* Check if we need any bytes from this page. */
     if (curoff + OV_LEN (h) >= start)
     {
-      src = (u_int8_t *) h + P_OVERHEAD;
+      src = (uint8_t *) h + P_OVERHEAD;
       bytes = OV_LEN (h);
       if (start > curoff)
       {
@@ -186,8 +186,8 @@ CDB___db_poff (dbc, dbt, pgnop)
   DB_LSN new_lsn, null_lsn;
   DBT tmp_dbt;
   db_indx_t pagespace;
-  u_int32_t sz;
-  u_int8_t *p;
+  uint32_t sz;
+  uint8_t *p;
   int ret;
 
   /*
@@ -239,7 +239,7 @@ CDB___db_poff (dbc, dbt, pgnop)
             PGNO (pagep), PGNO_INVALID, PGNO_INVALID, 0, P_OVERFLOW);
     OV_LEN (pagep) = pagespace;
     OV_REF (pagep) = 1;
-    memcpy ((u_int8_t *) pagep + P_OVERHEAD, p, pagespace);
+    memcpy ((uint8_t *) pagep + P_OVERHEAD, p, pagespace);
 
     /*
      * If this is the first entry, update the user's info.
@@ -332,7 +332,7 @@ CDB___db_doff (dbc, pgno)
 
     if (DB_LOGGING (dbc))
     {
-      tmp_dbt.data = (u_int8_t *) pagep + P_OVERHEAD;
+      tmp_dbt.data = (uint8_t *) pagep + P_OVERHEAD;
       tmp_dbt.size = OV_LEN (pagep);
       ZERO_LSN (null_lsn);
       if ((ret = CDB___db_big_log (dbp->dbenv, dbc->txn,
@@ -362,7 +362,7 @@ CDB___db_doff (dbc, pgno)
  * specified a comparison function.  In this case, we need to materialize
  * the entire object and call their comparison routine.
  *
- * PUBLIC: int CDB___db_moff __P((DB *, const DBT *, db_pgno_t, u_int32_t,
+ * PUBLIC: int CDB___db_moff __P((DB *, const DBT *, db_pgno_t, uint32_t,
  * PUBLIC:     int (*)(const DBT *, const DBT *), int *));
  */
 int
@@ -370,14 +370,14 @@ CDB___db_moff (dbp, dbt, pgno, tlen, cmpfunc, cmpp)
      DB *dbp;
      const DBT *dbt;
      db_pgno_t pgno;
-     u_int32_t tlen;
+     uint32_t tlen;
      int (*cmpfunc) __P ((const DBT *, const DBT *)), *cmpp;
 {
   PAGE *pagep;
   DBT local_dbt;
   void *buf;
-  u_int32_t bufsize, cmp_bytes, key_left;
-  u_int8_t *p1, *p2;
+  uint32_t bufsize, cmp_bytes, key_left;
+  uint8_t *p1, *p2;
   int ret;
 
   /*
@@ -408,7 +408,7 @@ CDB___db_moff (dbp, dbt, pgno, tlen, cmpfunc, cmpp)
     cmp_bytes = OV_LEN (pagep) < key_left ? OV_LEN (pagep) : key_left;
     tlen -= cmp_bytes;
     key_left -= cmp_bytes;
-    for (p2 = (u_int8_t *) pagep + P_OVERHEAD; cmp_bytes-- > 0; ++p1, ++p2)
+    for (p2 = (uint8_t *) pagep + P_OVERHEAD; cmp_bytes-- > 0; ++p1, ++p2)
       if (*p1 != *p2)
       {
         *cmpp = (long) *p1 - (long) *p2;

--- a/db/db_page.h
+++ b/db/db_page.h
@@ -73,16 +73,16 @@ typedef struct _dbmeta
 {
   DB_LSN lsn;                   /* 00-07: LSN. */
   db_pgno_t pgno;               /* 08-11: Current page number. */
-  u_int32_t magic;              /* 12-15: Magic number. */
-  u_int32_t version;            /* 16-19: Version. */
-  u_int32_t pagesize;           /* 20-23: Pagesize. */
-  u_int8_t unused1[1];          /*    24: Unused. */
-  u_int8_t type;                /*    25: Page type. */
-  u_int8_t unused2[2];          /* 26-27: Unused. */
-  u_int32_t free;               /* 28-31: Free list page number. */
-  u_int32_t flags;              /* 32-35: Flags: unique to each AM. */
+  uint32_t magic;              /* 12-15: Magic number. */
+  uint32_t version;            /* 16-19: Version. */
+  uint32_t pagesize;           /* 20-23: Pagesize. */
+  uint8_t unused1[1];          /*    24: Unused. */
+  uint8_t type;                /*    25: Page type. */
+  uint8_t unused2[2];          /* 26-27: Unused. */
+  uint32_t free;               /* 28-31: Free list page number. */
+  uint32_t flags;              /* 32-35: Flags: unique to each AM. */
   /* 36-55: Unique file ID. */
-  u_int8_t uid[DB_FILE_ID_LEN];
+  uint8_t uid[DB_FILE_ID_LEN];
 } DBMETA;
 
 /************************************************************************
@@ -99,11 +99,11 @@ typedef struct _btmeta
 #define  BTM_MASK  0x03f
   DBMETA dbmeta;                /* 00-55: Generic meta-data header. */
 
-  u_int32_t maxkey;             /* 56-59: Btree: Maxkey. */
-  u_int32_t minkey;             /* 60-63: Btree: Minkey. */
-  u_int32_t re_len;             /* 64-67: Recno: fixed-length record length. */
-  u_int32_t re_pad;             /* 68-71: Recno: fixed-length record pad. */
-  u_int32_t root;               /* 72-75: Root page. */
+  uint32_t maxkey;             /* 56-59: Btree: Maxkey. */
+  uint32_t minkey;             /* 60-63: Btree: Minkey. */
+  uint32_t re_len;             /* 64-67: Recno: fixed-length record length. */
+  uint32_t re_pad;             /* 68-71: Recno: fixed-length record pad. */
+  uint32_t root;               /* 72-75: Root page. */
 
   /*
    * Minimum page size is 128.
@@ -119,15 +119,15 @@ typedef struct _hashmeta
 #define  DB_HASH_SUBDB  0x02    /*    Subdatabases. */
   DBMETA dbmeta;                /* 00-55: Generic meta-data page header. */
 
-  u_int32_t max_bucket;         /* 56-59: ID of Maximum bucket in use */
-  u_int32_t high_mask;          /* 60-63: Modulo mask into table */
-  u_int32_t low_mask;           /* 64-67: Modulo mask into table lower half */
-  u_int32_t ffactor;            /* 68-71: Fill factor */
-  u_int32_t nelem;              /* 72-75: Number of keys in hash table */
-  u_int32_t h_charkey;          /* 76-79: Value of hash(CHARKEY) */
+  uint32_t max_bucket;         /* 56-59: ID of Maximum bucket in use */
+  uint32_t high_mask;          /* 60-63: Modulo mask into table */
+  uint32_t low_mask;           /* 64-67: Modulo mask into table lower half */
+  uint32_t ffactor;            /* 68-71: Fill factor */
+  uint32_t nelem;              /* 72-75: Number of keys in hash table */
+  uint32_t h_charkey;          /* 76-79: Value of hash(CHARKEY) */
 #define NCACHED  32             /* number of spare points */
   /* 80-207: Spare pages for overflow */
-  u_int32_t spares[NCACHED];
+  uint32_t spares[NCACHED];
 
   /*
    * Minimum page size is 256.
@@ -145,12 +145,12 @@ typedef struct _qmeta
 {
   DBMETA dbmeta;                /* 00-55: Generic meta-data header. */
 
-  u_int32_t start;              /* 56-59: Start offset. */
-  u_int32_t first_recno;        /* 60-63: First not deleted record. */
-  u_int32_t cur_recno;          /* 64-67: Last recno allocated. */
-  u_int32_t re_len;             /* 68-71: Fixed-length record length. */
-  u_int32_t re_pad;             /* 72-75: Fixed-length record pad. */
-  u_int32_t rec_page;           /* 76-79: Records Per Page. */
+  uint32_t start;              /* 56-59: Start offset. */
+  uint32_t first_recno;        /* 60-63: First not deleted record. */
+  uint32_t cur_recno;          /* 64-67: Last recno allocated. */
+  uint32_t re_len;             /* 68-71: Fixed-length record length. */
+  uint32_t re_pad;             /* 72-75: Fixed-length record pad. */
+  uint32_t rec_page;           /* 76-79: Records Per Page. */
 
   /*
    * Minimum page size is 128.
@@ -202,8 +202,8 @@ typedef struct _db_page
    */
 #define  LEAFLEVEL    1
 #define  MAXBTREELEVEL  255
-  u_int8_t level;               /*    24: Btree tree level. */
-  u_int8_t type;                /*    25: Page type. */
+  uint8_t level;               /*    24: Btree tree level. */
+  uint8_t type;                /*    25: Page type. */
   db_indx_t inp[1];             /* Variable length index of items. */
 } PAGE;
 
@@ -214,10 +214,10 @@ typedef struct _qpage
 {
   DB_LSN lsn;                   /* 00-07: Log sequence number. */
   db_pgno_t pgno;               /* 08-11: Current page number. */
-  u_int32_t unused0[3];         /* 12-23: Unused. */
-  u_int8_t unused1[1];          /*    24: Unused. */
-  u_int8_t type;                /*    25: Page type. */
-  u_int8_t unused2[2];          /* 26-27: Unused. */
+  uint32_t unused0[3];         /* 12-23: Unused. */
+  uint8_t unused1[1];          /*    24: Unused. */
+  uint8_t type;                /*    25: Page type. */
+  uint8_t unused2[2];          /* 26-27: Unused. */
 } QPAGE;
 
 /* Main page element macros. */
@@ -279,7 +279,7 @@ typedef struct _qpage
 #define  P_FREESPACE(pg)    (HOFFSET(pg) - LOFFSET(pg))
 
 /* Get a pointer to the bytes at a specific index. */
-#define  P_ENTRY(pg, indx)  ((u_int8_t *)pg + ((PAGE *)pg)->inp[indx])
+#define  P_ENTRY(pg, indx)  ((uint8_t *)pg + ((PAGE *)pg)->inp[indx])
 
 /************************************************************************
  OVERFLOW PAGE LAYOUT
@@ -327,7 +327,7 @@ typedef struct _qpage
  * field, it requires no alignment, and it's in the same location in all three
  * structures, there's a pair of macros.
  */
-#define  HPAGE_PTYPE(p)    (*(u_int8_t *)p)
+#define  HPAGE_PTYPE(p)    (*(uint8_t *)p)
 #define  HPAGE_TYPE(pg, indx)  (*P_ENTRY(pg, indx))
 
 /*
@@ -350,10 +350,10 @@ typedef struct _qpage
  */
 typedef struct _hkeydata
 {
-  u_int8_t type;                /*    00: Page type. */
-  u_int8_t data[1];             /* Variable length key/data item. */
+  uint8_t type;                /*    00: Page type. */
+  uint8_t data[1];             /* Variable length key/data item. */
 } HKEYDATA;
-#define  HKEYDATA_DATA(p)  (((u_int8_t *)p) + SSZA(HKEYDATA, data))
+#define  HKEYDATA_DATA(p)  (((uint8_t *)p) + SSZA(HKEYDATA, data))
 
 /*
  * The length of any HKEYDATA item. Note that indx is an element index,
@@ -378,7 +378,7 @@ typedef struct _hkeydata
 /* Put a HKEYDATA item at the location referenced by a page entry. */
 #define  PUT_HKEYDATA(pe, kd, len, type) {        \
   ((HKEYDATA *)pe)->type = type;          \
-  memcpy((u_int8_t *)pe + sizeof(u_int8_t), kd, len);    \
+  memcpy((uint8_t *)pe + sizeof(uint8_t), kd, len);    \
 }
 
 /*
@@ -402,14 +402,14 @@ typedef struct _hkeydata
  */
 typedef struct _hoffpage
 {
-  u_int8_t type;                /*    00: Page type and delete flag. */
-  u_int8_t unused[3];           /* 01-03: Padding, unused. */
+  uint8_t type;                /*    00: Page type and delete flag. */
+  uint8_t unused[3];           /* 01-03: Padding, unused. */
   db_pgno_t pgno;               /* 04-07: Offpage page number. */
-  u_int32_t tlen;               /* 08-11: Total length of item. */
+  uint32_t tlen;               /* 08-11: Total length of item. */
 } HOFFPAGE;
 
-#define  HOFFPAGE_PGNO(p)  (((u_int8_t *)p) + SSZ(HOFFPAGE, pgno))
-#define  HOFFPAGE_TLEN(p)  (((u_int8_t *)p) + SSZ(HOFFPAGE, tlen))
+#define  HOFFPAGE_PGNO(p)  (((uint8_t *)p) + SSZ(HOFFPAGE, pgno))
+#define  HOFFPAGE_TLEN(p)  (((uint8_t *)p) + SSZ(HOFFPAGE, tlen))
 
 /*
  * Page space required to add a new HOFFPAGE item to the page, with and
@@ -423,11 +423,11 @@ typedef struct _hoffpage
  */
 typedef struct _hoffdup
 {
-  u_int8_t type;                /*    00: Page type and delete flag. */
-  u_int8_t unused[3];           /* 01-03: Padding, unused. */
+  uint8_t type;                /*    00: Page type and delete flag. */
+  uint8_t unused[3];           /* 01-03: Padding, unused. */
   db_pgno_t pgno;               /* 04-07: Offpage page number. */
 } HOFFDUP;
-#define  HOFFDUP_PGNO(p)    (((u_int8_t *)p) + SSZ(HOFFDUP, pgno))
+#define  HOFFDUP_PGNO(p)    (((uint8_t *)p) + SSZ(HOFFDUP, pgno))
 
 /*
  * Page space required to add a new HOFFDUP item to the page, with and
@@ -469,8 +469,8 @@ typedef struct _hoffdup
 typedef struct _bkeydata
 {
   db_indx_t len;                /* 00-01: Key/data item length. */
-  u_int8_t type;                /*    02: Page type AND DELETE FLAG. */
-  u_int8_t data[1];             /* Variable length key/data item. */
+  uint8_t type;                /*    02: Page type AND DELETE FLAG. */
+  uint8_t data[1];             /* Variable length key/data item. */
 } BKEYDATA;
 
 /* Get a BKEYDATA item for a specific index. */
@@ -493,10 +493,10 @@ typedef struct _bkeydata
 typedef struct _boverflow
 {
   db_indx_t unused1;            /* 00-01: Padding, unused. */
-  u_int8_t type;                /*    02: Page type AND DELETE FLAG. */
-  u_int8_t unused2;             /*    03: Padding, unused. */
+  uint8_t type;                /*    02: Page type AND DELETE FLAG. */
+  uint8_t unused2;             /*    03: Padding, unused. */
   db_pgno_t pgno;               /* 04-07: Next page number. */
-  u_int32_t tlen;               /* 08-11: Total length of item. */
+  uint32_t tlen;               /* 08-11: Total length of item. */
 } BOVERFLOW;
 
 /* Get a BOVERFLOW item for a specific index. */
@@ -531,11 +531,11 @@ typedef struct _boverflow
 typedef struct _binternal
 {
   db_indx_t len;                /* 00-01: Key/data item length. */
-  u_int8_t type;                /*    02: Page type AND DELETE FLAG. */
-  u_int8_t unused;              /*    03: Padding, unused. */
+  uint8_t type;                /*    02: Page type AND DELETE FLAG. */
+  uint8_t unused;              /*    03: Padding, unused. */
   db_pgno_t pgno;               /* 04-07: Page number of referenced page. */
   db_recno_t nrecs;             /* 08-11: Subtree record count. */
-  u_int8_t data[1];             /* Variable length key item. */
+  uint8_t data[1];             /* Variable length key item. */
 } BINTERNAL;
 
 /* Get a BINTERNAL item for a specific index. */

--- a/db/db_pr.c
+++ b/db/db_pr.c
@@ -35,17 +35,17 @@ static const char sccsid[] = "@(#)db_pr.c  11.9 (Sleepycat) 11/10/99";
 #include "qam.h"
 #include "db_am.h"
 
-static int CDB___db_bmeta __P ((DB *, FILE *, BTMETA *, u_int32_t));
-static int CDB___db_hmeta __P ((DB *, FILE *, HMETA *, u_int32_t));
+static int CDB___db_bmeta __P ((DB *, FILE *, BTMETA *, uint32_t));
+static int CDB___db_hmeta __P ((DB *, FILE *, HMETA *, uint32_t));
 static void CDB___db_meta
-__P ((DB *, DBMETA *, FILE *, FN const *, u_int32_t));
+__P ((DB *, DBMETA *, FILE *, FN const *, uint32_t));
 static const char *CDB___db_name __P ((DB *));
-static void CDB___db_prdb __P ((DB *, FILE *, u_int32_t));
+static void CDB___db_prdb __P ((DB *, FILE *, uint32_t));
 static FILE *CDB___db_prinit __P ((FILE *));
 static void CDB___db_proff __P ((void *));
-static int CDB___db_prtree __P ((DB *, u_int32_t));
+static int CDB___db_prtree __P ((DB *, uint32_t));
 static void CDB___db_psize __P ((DB *));
-static int CDB___db_qmeta __P ((DB *, FILE *, QMETA *, u_int32_t));
+static int CDB___db_qmeta __P ((DB *, FILE *, QMETA *, uint32_t));
 
 /*
  * 64K is the maximum page size, so by default we check for offsets larger
@@ -83,7 +83,7 @@ CDB___db_dump (dbp, op, name)
      char *op, *name;
 {
   FILE *fp, *save_fp;
-  u_int32_t flags;
+  uint32_t flags;
 
   COMPQUIET (save_fp, NULL);
 
@@ -139,7 +139,7 @@ static void
 CDB___db_prdb (dbp, fp, flags)
      DB *dbp;
      FILE *fp;
-     u_int32_t flags;
+     uint32_t flags;
 {
   static const FN fn[] = {
     {DB_AM_DISCARD, "discard cached pages"},
@@ -235,7 +235,7 @@ CDB___db_prdb (dbp, fp, flags)
 static int
 CDB___db_prtree (dbp, flags)
      DB *dbp;
-     u_int32_t flags;
+     uint32_t flags;
 {
   PAGE *h;
   db_pgno_t i, last;
@@ -274,12 +274,12 @@ CDB___db_meta (dbp, dbmeta, fp, fn, flags)
      DBMETA *dbmeta;
      FILE *fp;
      FN const *fn;
-     u_int32_t flags;
+     uint32_t flags;
 {
   PAGE *h;
   int cnt;
   db_pgno_t pgno;
-  u_int8_t *p;
+  uint8_t *p;
   int ret;
   const char *sep;
 
@@ -328,7 +328,7 @@ CDB___db_meta (dbp, dbmeta, fp, fn, flags)
   }
 
   fprintf (fp, "\tuid: ");
-  for (p = (u_int8_t *) dbmeta->uid, cnt = 0; cnt < DB_FILE_ID_LEN; ++cnt)
+  for (p = (uint8_t *) dbmeta->uid, cnt = 0; cnt < DB_FILE_ID_LEN; ++cnt)
   {
     fprintf (fp, "%x", *p++);
     if (cnt < DB_FILE_ID_LEN - 1)
@@ -346,7 +346,7 @@ CDB___db_bmeta (dbp, fp, h, flags)
      DB *dbp;
      FILE *fp;
      BTMETA *h;
-     u_int32_t flags;
+     uint32_t flags;
 {
   static const FN mfn[] = {
     {BTM_DUP, "duplicates"},
@@ -379,7 +379,7 @@ CDB___db_hmeta (dbp, fp, h, flags)
      DB *dbp;
      FILE *fp;
      HMETA *h;
-     u_int32_t flags;
+     uint32_t flags;
 {
   static const FN mfn[] = {
     {DB_HASH_DUP, "duplicates"},
@@ -413,7 +413,7 @@ CDB___db_qmeta (dbp, fp, h, flags)
      DB *dbp;
      FILE *fp;
      QMETA *h;
-     u_int32_t flags;
+     uint32_t flags;
 {
   CDB___db_meta (dbp, (DBMETA *) h, fp, NULL, flags);
 
@@ -458,13 +458,13 @@ CDB___db_prnpage (dbp, pgno)
  * CDB___db_prpage
  *  -- Print out a page.
  *
- * PUBLIC: int CDB___db_prpage __P((DB *, PAGE *, u_int32_t));
+ * PUBLIC: int CDB___db_prpage __P((DB *, PAGE *, uint32_t));
  */
 int
 CDB___db_prpage (dbp, h, flags)
      DB *dbp;
      PAGE *h;
-     u_int32_t flags;
+     uint32_t flags;
 {
   BINTERNAL *bi;
   BKEYDATA *bk;
@@ -478,8 +478,8 @@ CDB___db_prpage (dbp, h, flags)
   db_recno_t recno;
   int deleted, ret;
   const char *s;
-  u_int32_t qlen;
-  u_int8_t *ep, *hk, *p;
+  uint32_t qlen;
+  uint8_t *ep, *hk, *p;
   void *sp;
 
   fp = CDB___db_prinit (NULL);
@@ -582,7 +582,7 @@ CDB___db_prpage (dbp, h, flags)
   if (TYPE (h) == P_OVERFLOW)
   {
     fprintf (fp, " ref cnt: %4lu ", (u_long) OV_REF (h));
-    CDB___db_pr ((u_int8_t *) h + P_OVERHEAD, OV_LEN (h));
+    CDB___db_pr ((uint8_t *) h + P_OVERHEAD, OV_LEN (h));
     return (0);
   }
   fprintf (fp, " entries: %4lu", (u_long) NUM_ENT (h));
@@ -594,8 +594,8 @@ CDB___db_prpage (dbp, h, flags)
   ret = 0;
   for (i = 0; i < NUM_ENT (h); i++)
   {
-    if (P_ENTRY (h, i) - (u_int8_t *) h < P_OVERHEAD ||
-        (size_t) (P_ENTRY (h, i) - (u_int8_t *) h) >= set_psize)
+    if (P_ENTRY (h, i) - (uint8_t *) h < P_OVERHEAD ||
+        (size_t) (P_ENTRY (h, i) - (uint8_t *) h) >= set_psize)
     {
       fprintf (fp,
                "ILLEGAL PAGE OFFSET: indx: %lu of %lu\n",
@@ -766,8 +766,8 @@ CDB___db_isbad (h, die)
 
   for (i = 0; i < NUM_ENT (h); i++)
   {
-    if (P_ENTRY (h, i) - (u_int8_t *) h < P_OVERHEAD ||
-        (size_t) (P_ENTRY (h, i) - (u_int8_t *) h) >= set_psize)
+    if (P_ENTRY (h, i) - (uint8_t *) h < P_OVERHEAD ||
+        (size_t) (P_ENTRY (h, i) - (uint8_t *) h) >= set_psize)
     {
       fprintf (fp,
                "ILLEGAL PAGE OFFSET: indx: %lu of %lu\n",
@@ -829,12 +829,12 @@ bad:if (die)
  * CDB___db_pr --
  *  Print out a data element.
  *
- * PUBLIC: void CDB___db_pr __P((u_int8_t *, u_int32_t));
+ * PUBLIC: void CDB___db_pr __P((uint8_t *, uint32_t));
  */
 void
 CDB___db_pr (p, len)
-     u_int8_t *p;
-     u_int32_t len;
+     uint8_t *p;
+     uint32_t len;
 {
   FILE *fp;
   u_int lastch;
@@ -881,8 +881,8 @@ CDB___db_prdbt (dbtp, checkprint, prefix, fp, is_recno)
 {
   static const char hex[] = "0123456789abcdef";
   db_recno_t recno;
-  u_int32_t len;
-  u_int8_t *p;
+  uint32_t len;
+  uint8_t *p;
 
   /*
    * !!!
@@ -915,13 +915,13 @@ CDB___db_prdbt (dbtp, checkprint, prefix, fp, is_recno)
       }
       else
         if (fprintf (fp, "\\%c%c",
-                     hex[(u_int8_t) (*p & 0xf0) >> 4], hex[*p & 0x0f]) != 3)
+                     hex[(uint8_t) (*p & 0xf0) >> 4], hex[*p & 0x0f]) != 3)
         return (EIO);
   }
   else
     for (len = dbtp->size, p = dbtp->data; len--; ++p)
       if (fprintf (fp, "%c%c",
-                   hex[(u_int8_t) (*p & 0xf0) >> 4], hex[*p & 0x0f]) != 2)
+                   hex[(uint8_t) (*p & 0xf0) >> 4], hex[*p & 0x0f]) != 2)
         return (EIO);
 
   return (fprintf (fp, "\n") == 1 ? 0 : EIO);
@@ -957,11 +957,11 @@ CDB___db_proff (vp)
  * CDB___db_prflags --
  *  Print out flags values.
  *
- * PUBLIC: void CDB___db_prflags __P((u_int32_t, const FN *, FILE *));
+ * PUBLIC: void CDB___db_prflags __P((uint32_t, const FN *, FILE *));
  */
 void
 CDB___db_prflags (flags, fn, fp)
-     u_int32_t flags;
+     uint32_t flags;
      FN const *fn;
      FILE *fp;
 {

--- a/db/db_rec.c
+++ b/db/db_rec.c
@@ -42,7 +42,7 @@ CDB___db_addrem_recover (dbenv, dbtp, lsnp, redo, info)
   DBC *dbc;
   DB_MPOOLFILE *mpf;
   PAGE *pagep;
-  u_int32_t change;
+  uint32_t change;
   int cmp_n, cmp_p, ret;
 
   COMPQUIET (info, NULL);
@@ -207,7 +207,7 @@ CDB___db_big_recover (dbenv, dbtp, lsnp, redo, info)
   DBC *dbc;
   DB_MPOOLFILE *mpf;
   PAGE *pagep;
-  u_int32_t change;
+  uint32_t change;
   int cmp_n, cmp_p, ret;
 
   COMPQUIET (info, NULL);
@@ -250,7 +250,7 @@ CDB___db_big_recover (dbenv, dbtp, lsnp, redo, info)
             argp->next_pgno, 0, P_OVERFLOW);
     OV_LEN (pagep) = argp->dbt.size;
     OV_REF (pagep) = 1;
-    memcpy ((u_int8_t *) pagep + P_OVERHEAD, argp->dbt.data, argp->dbt.size);
+    memcpy ((uint8_t *) pagep + P_OVERHEAD, argp->dbt.data, argp->dbt.size);
     PREV_PGNO (pagep) = argp->prev_pgno;
     change = DB_MPOOL_DIRTY;
   }
@@ -572,7 +572,7 @@ CDB___db_addpage_recover (dbenv, dbtp, lsnp, redo, info)
   DBC *dbc;
   DB_MPOOLFILE *mpf;
   PAGE *pagep;
-  u_int32_t change;
+  uint32_t change;
   int cmp_n, cmp_p, ret;
 
   COMPQUIET (info, NULL);
@@ -700,7 +700,7 @@ CDB___db_noop_recover (dbenv, dbtp, lsnp, redo, info)
   DBC *dbc;
   DB_MPOOLFILE *mpf;
   PAGE *pagep;
-  u_int32_t change;
+  uint32_t change;
   int cmp_n, cmp_p, ret;
 
   COMPQUIET (info, NULL);

--- a/db/db_ret.c
+++ b/db/db_ret.c
@@ -28,22 +28,22 @@ static const char sccsid[] = "@(#)db_ret.c  11.1 (Sleepycat) 7/24/99";
  *  Build return DBT.
  *
  * PUBLIC: int CDB___db_ret __P((DB *,
- * PUBLIC:    PAGE *, u_int32_t, DBT *, void **, u_int32_t *));
+ * PUBLIC:    PAGE *, uint32_t, DBT *, void **, uint32_t *));
  */
 int
 CDB___db_ret (dbp, h, indx, dbt, memp, memsize)
      DB *dbp;
      PAGE *h;
-     u_int32_t indx;
+     uint32_t indx;
      DBT *dbt;
      void **memp;
-     u_int32_t *memsize;
+     uint32_t *memsize;
 {
   BKEYDATA *bk;
   HOFFPAGE ho;
   BOVERFLOW *bo;
-  u_int32_t len;
-  u_int8_t *hk;
+  uint32_t len;
+  uint8_t *hk;
   void *data;
 
   switch (TYPE (h))
@@ -84,23 +84,23 @@ CDB___db_ret (dbp, h, indx, dbt, memp, memsize)
  *  Copy the returned data into the user's DBT, handling special flags.
  *
  * PUBLIC: int CDB___db_retcopy __P((DB *, DBT *,
- * PUBLIC:    void *, u_int32_t, void **, u_int32_t *));
+ * PUBLIC:    void *, uint32_t, void **, uint32_t *));
  */
 int
 CDB___db_retcopy (dbp, dbt, data, len, memp, memsize)
      DB *dbp;
      DBT *dbt;
      void *data;
-     u_int32_t len;
+     uint32_t len;
      void **memp;
-     u_int32_t *memsize;
+     uint32_t *memsize;
 {
   int ret;
 
   /* If returning a partial record, reset the length. */
   if (F_ISSET (dbt, DB_DBT_PARTIAL))
   {
-    data = (u_int8_t *) data + dbt->doff;
+    data = (uint8_t *) data + dbt->doff;
     if (len > dbt->doff)
     {
       len -= dbt->doff;

--- a/db/db_salloc.c
+++ b/db/db_salloc.c
@@ -108,15 +108,15 @@ CDB___db_shalloc (p, len, align, retp)
      *  + Subtract the memory the user wants.
      *  + Find the closest previous correctly-aligned address.
      */
-    rp = (u_int8_t *) elp + sizeof (size_t) + elp->len;
-    rp = (u_int8_t *) rp - len;
-    rp = (u_int8_t *) ((ALIGNTYPE) rp & ~(align - 1));
+    rp = (uint8_t *) elp + sizeof (size_t) + elp->len;
+    rp = (uint8_t *) rp - len;
+    rp = (uint8_t *) ((ALIGNTYPE) rp & ~(align - 1));
 
     /*
      * Rp may now point before elp->links, in which case the chunk
      * was too small, and we have to try again.
      */
-    if ((u_int8_t *) rp < (u_int8_t *) & elp->links)
+    if ((uint8_t *) rp < (uint8_t *) & elp->links)
       continue;
 
     *(void **) retp = rp;
@@ -124,11 +124,11 @@ CDB___db_shalloc (p, len, align, retp)
     /*
      * At this point, whether or not we still need to split up a
      * chunk, retp is the address of the region we are returning,
-     * and (u_int8_t *)elp + sizeof(size_t) + elp->len gives us
+     * and (uint8_t *)elp + sizeof(size_t) + elp->len gives us
      * the address of the first byte after the end of the chunk.
      * Make the byte immediately before that the guard byte.
      */
-    *((u_int8_t *) elp + sizeof (size_t) + elp->len - 1) = GUARD_BYTE;
+    *((uint8_t *) elp + sizeof (size_t) + elp->len - 1) = GUARD_BYTE;
 #endif
 
 #define  SHALLOC_FRAGMENT  32
@@ -136,10 +136,10 @@ CDB___db_shalloc (p, len, align, retp)
      * If there are at least SHALLOC_FRAGMENT additional bytes of
      * memory, divide the chunk into two chunks.
      */
-    if ((u_int8_t *) rp >= (u_int8_t *) & elp->links + SHALLOC_FRAGMENT)
+    if ((uint8_t *) rp >= (uint8_t *) & elp->links + SHALLOC_FRAGMENT)
     {
       sp = rp;
-      *--sp = elp->len - ((u_int8_t *) rp - (u_int8_t *) & elp->links);
+      *--sp = elp->len - ((uint8_t *) rp - (uint8_t *) & elp->links);
       elp->len -= *sp + sizeof (size_t);
       return (0);
     }
@@ -154,7 +154,7 @@ CDB___db_shalloc (p, len, align, retp)
      */
 #define  ILLEGAL_SIZE  1
     SH_LIST_REMOVE (elp, links, __data);
-    for (sp = rp; (u_int8_t *)-- sp >= (u_int8_t *) & elp->links;)
+    for (sp = rp; (uint8_t *)-- sp >= (uint8_t *) & elp->links;)
       *sp = ILLEGAL_SIZE;
     return (0);
   }
@@ -185,7 +185,7 @@ CDB___db_shalloc_free (regionp, ptr)
     ;
   ptr = sp;
 
-  newp = (struct __data *) ((u_int8_t *) ptr - sizeof (size_t));
+  newp = (struct __data *) ((uint8_t *) ptr - sizeof (size_t));
   free_size = newp->len;
 
 #ifdef DIAGNOSTIC
@@ -195,7 +195,7 @@ CDB___db_shalloc_free (regionp, ptr)
    *
    * Check it to make sure it hasn't been stomped.
    */
-  if (*((u_int8_t *) ptr + free_size - 1) != GUARD_BYTE)
+  if (*((uint8_t *) ptr + free_size - 1) != GUARD_BYTE)
   {
     /*
      * Eventually, once we push a DB_ENV handle down to these
@@ -234,7 +234,7 @@ CDB___db_shalloc_free (regionp, ptr)
    * Check for coalescing with the next element.
    */
   merged = 0;
-  if ((u_int8_t *) ptr + free_size == (u_int8_t *) elp)
+  if ((uint8_t *) ptr + free_size == (uint8_t *) elp)
   {
     newp->len += elp->len + sizeof (size_t);
     SH_LIST_REMOVE (elp, links, __data);
@@ -246,8 +246,8 @@ CDB___db_shalloc_free (regionp, ptr)
   }
 
   /* Check for coalescing with the previous element. */
-  if (lastp != NULL && (u_int8_t *) lastp +
-      lastp->len + sizeof (size_t) == (u_int8_t *) newp)
+  if (lastp != NULL && (uint8_t *) lastp +
+      lastp->len + sizeof (size_t) == (uint8_t *) newp)
   {
     lastp->len += newp->len + sizeof (size_t);
 
@@ -316,7 +316,7 @@ CDB___db_shsizeof (ptr)
   for (sp = (size_t *) ptr; sp[-1] == ILLEGAL_SIZE; --sp)
     ;
 
-  elp = (struct __data *) ((u_int8_t *) sp - sizeof (size_t));
+  elp = (struct __data *) ((uint8_t *) sp - sizeof (size_t));
   return (elp->len);
 }
 

--- a/db/db_shash.c
+++ b/db/db_shash.c
@@ -28,8 +28,8 @@ static const char sccsid[] = "@(#)db_shash.c  11.1 (Sleepycat) 7/25/99";
  */
 static const struct
 {
-  u_int32_t power;
-  u_int32_t prime;
+  uint32_t power;
+  uint32_t prime;
 } list[] =
 {
   {
@@ -114,11 +114,11 @@ static const struct
  * CDB___db_tablesize --
  *  Choose a size for the hash table.
  *
- * PUBLIC: int CDB___db_tablesize __P((u_int32_t));
+ * PUBLIC: int CDB___db_tablesize __P((uint32_t));
  */
 int
 CDB___db_tablesize (n_buckets)
-     u_int32_t n_buckets;
+     uint32_t n_buckets;
 {
   int i;
 
@@ -149,14 +149,14 @@ CDB___db_tablesize (n_buckets)
  * CDB___db_hashinit --
  *  Initialize a hash table that resides in shared memory.
  *
- * PUBLIC: void CDB___db_hashinit __P((void *, u_int32_t));
+ * PUBLIC: void CDB___db_hashinit __P((void *, uint32_t));
  */
 void
 CDB___db_hashinit (begin, nelements)
      void *begin;
-     u_int32_t nelements;
+     uint32_t nelements;
 {
-  u_int32_t i;
+  uint32_t i;
   SH_TAILQ_HEAD (hash_head) * headp;
 
   headp = (struct hash_head *) begin;

--- a/db/db_swap.h
+++ b/db/db_swap.h
@@ -45,26 +45,26 @@
  *  P_32_SWAP  swap a referenced memory location
  */
 #define  M_32_SWAP(a) {              \
-  u_int32_t _tmp;              \
+  uint32_t _tmp;              \
   _tmp = a;              \
-  ((u_int8_t *)&a)[0] = ((u_int8_t *)&_tmp)[3];      \
-  ((u_int8_t *)&a)[1] = ((u_int8_t *)&_tmp)[2];      \
-  ((u_int8_t *)&a)[2] = ((u_int8_t *)&_tmp)[1];      \
-  ((u_int8_t *)&a)[3] = ((u_int8_t *)&_tmp)[0];      \
+  ((uint8_t *)&a)[0] = ((uint8_t *)&_tmp)[3];      \
+  ((uint8_t *)&a)[1] = ((uint8_t *)&_tmp)[2];      \
+  ((uint8_t *)&a)[2] = ((uint8_t *)&_tmp)[1];      \
+  ((uint8_t *)&a)[3] = ((uint8_t *)&_tmp)[0];      \
 }
 #define  P_32_COPY(a, b) {            \
-  ((u_int8_t *)b)[0] = ((u_int8_t *)a)[0];      \
-  ((u_int8_t *)b)[1] = ((u_int8_t *)a)[1];      \
-  ((u_int8_t *)b)[2] = ((u_int8_t *)a)[2];      \
-  ((u_int8_t *)b)[3] = ((u_int8_t *)a)[3];      \
+  ((uint8_t *)b)[0] = ((uint8_t *)a)[0];      \
+  ((uint8_t *)b)[1] = ((uint8_t *)a)[1];      \
+  ((uint8_t *)b)[2] = ((uint8_t *)a)[2];      \
+  ((uint8_t *)b)[3] = ((uint8_t *)a)[3];      \
 }
 #define  P_32_SWAP(a) {              \
-  u_int32_t _tmp;              \
+  uint32_t _tmp;              \
   P_32_COPY(a, &_tmp);            \
-  ((u_int8_t *)a)[0] = ((u_int8_t *)&_tmp)[3];      \
-  ((u_int8_t *)a)[1] = ((u_int8_t *)&_tmp)[2];      \
-  ((u_int8_t *)a)[2] = ((u_int8_t *)&_tmp)[1];      \
-  ((u_int8_t *)a)[3] = ((u_int8_t *)&_tmp)[0];      \
+  ((uint8_t *)a)[0] = ((uint8_t *)&_tmp)[3];      \
+  ((uint8_t *)a)[1] = ((uint8_t *)&_tmp)[2];      \
+  ((uint8_t *)a)[2] = ((uint8_t *)&_tmp)[1];      \
+  ((uint8_t *)a)[3] = ((uint8_t *)&_tmp)[0];      \
 }
 
 /*
@@ -74,28 +74,28 @@
  *  P_16_SWAP  swap a referenced memory location
  */
 #define  M_16_SWAP(a) {              \
-  u_int16_t _tmp;              \
-  _tmp = (u_int16_t)a;            \
-  ((u_int8_t *)&a)[0] = ((u_int8_t *)&_tmp)[1];      \
-  ((u_int8_t *)&a)[1] = ((u_int8_t *)&_tmp)[0];      \
+  uint16_t _tmp;              \
+  _tmp = (uint16_t)a;            \
+  ((uint8_t *)&a)[0] = ((uint8_t *)&_tmp)[1];      \
+  ((uint8_t *)&a)[1] = ((uint8_t *)&_tmp)[0];      \
 }
 #define  P_16_COPY(a, b) {            \
-  ((u_int8_t *)b)[0] = ((u_int8_t *)a)[0];      \
-  ((u_int8_t *)b)[1] = ((u_int8_t *)a)[1];      \
+  ((uint8_t *)b)[0] = ((uint8_t *)a)[0];      \
+  ((uint8_t *)b)[1] = ((uint8_t *)a)[1];      \
 }
 #define  P_16_SWAP(a) {              \
-  u_int16_t _tmp;              \
+  uint16_t _tmp;              \
   P_16_COPY(a, &_tmp);            \
-  ((u_int8_t *)a)[0] = ((u_int8_t *)&_tmp)[1];      \
-  ((u_int8_t *)a)[1] = ((u_int8_t *)&_tmp)[0];      \
+  ((uint8_t *)a)[0] = ((uint8_t *)&_tmp)[1];      \
+  ((uint8_t *)a)[1] = ((uint8_t *)&_tmp)[0];      \
 }
 
 #define  SWAP32(p) {              \
   P_32_SWAP(p);              \
-  (p) += sizeof(u_int32_t);          \
+  (p) += sizeof(uint32_t);          \
 }
 #define  SWAP16(p) {              \
   P_16_SWAP(p);              \
-  (p) += sizeof(u_int16_t);          \
+  (p) += sizeof(uint16_t);          \
 }
 #endif /* !_DB_SWAP_H_ */

--- a/db/db_upg.c
+++ b/db/db_upg.c
@@ -27,7 +27,7 @@ static const char revid[] =
 #include "qam.h"
 
 static int (*const func_31_list[P_PAGETYPE_MAX])
-__P ((DB *, char *, u_int32_t, DB_FH *, PAGE *, int *)) =
+__P ((DB *, char *, uint32_t, DB_FH *, PAGE *, int *)) =
 {
   NULL,                         /* P_INVALID */
     NULL,                       /* __P_DUPLICATE */
@@ -41,27 +41,27 @@ __P ((DB *, char *, u_int32_t, DB_FH *, PAGE *, int *)) =
     CDB___bam_31_btreemeta,     /* P_BTREEMETA */
 };
 
-static int __db_page_pass __P ((DB *, char *, u_int32_t, int (*const[])
-                                (DB *, char *, u_int32_t, DB_FH *, PAGE *,
+static int __db_page_pass __P ((DB *, char *, uint32_t, int (*const[])
+                                (DB *, char *, uint32_t, DB_FH *, PAGE *,
                                  int *), DB_FH *));
 
 /*
  * CDB___db_upgrade --
  *  Upgrade an existing database.
  *
- * PUBLIC: int CDB___db_upgrade __P((DB *, const char *, u_int32_t));
+ * PUBLIC: int CDB___db_upgrade __P((DB *, const char *, uint32_t));
  */
 int
 CDB___db_upgrade (dbp, fname, flags)
      DB *dbp;
      const char *fname;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB_ENV *dbenv;
   DB_FH fh;
   size_t n;
   int ret, t_ret;
-  u_int8_t mbuf[256];
+  uint8_t mbuf[256];
   char *real_name;
 
   dbenv = dbp->dbenv;
@@ -116,7 +116,7 @@ CDB___db_upgrade (dbp, fname, flags)
        * We need the page size to do more.  Rip it out of
        * the meta-data page.
        */
-      memcpy (&dbp->pgsize, mbuf + 20, sizeof (u_int32_t));
+      memcpy (&dbp->pgsize, mbuf + 20, sizeof (uint32_t));
 
       if ((ret =
            __db_page_pass (dbp, real_name, flags, func_31_list, &fh)) != 0)
@@ -152,7 +152,7 @@ CDB___db_upgrade (dbp, fname, flags)
        * We need the page size to do more.  Rip it out of
        * the meta-data page.
        */
-      memcpy (&dbp->pgsize, mbuf + 20, sizeof (u_int32_t));
+      memcpy (&dbp->pgsize, mbuf + 20, sizeof (uint32_t));
 
       if ((ret =
            __db_page_pass (dbp, real_name, flags, func_31_list, &fh)) != 0)
@@ -232,9 +232,9 @@ static int
 __db_page_pass (dbp, real_name, flags, fl, fhp)
      DB *dbp;
      char *real_name;
-     u_int32_t flags;
+     uint32_t flags;
      int (*const fl[P_PAGETYPE_MAX])
-  __P ((DB *, char *, u_int32_t, DB_FH *, PAGE *, int *));
+  __P ((DB *, char *, uint32_t, DB_FH *, PAGE *, int *));
      DB_FH *fhp;
 {
   DB_ENV *dbenv;
@@ -299,7 +299,7 @@ CDB___db_lastpgno (dbp, real_name, fhp, pgno_lastp)
 {
   DB_ENV *dbenv;
   db_pgno_t pgno_last;
-  u_int32_t mbytes, bytes;
+  uint32_t mbytes, bytes;
   int ret;
 
   dbenv = dbp->dbenv;

--- a/db/db_upg_opd.c
+++ b/db/db_upg_opd.c
@@ -27,9 +27,9 @@ static const char revid[] =
 #include "qam.h"
 
 static int __db_build_bi
-__P ((DB *, DB_FH *, PAGE *, PAGE *, u_int32_t, int *));
+__P ((DB *, DB_FH *, PAGE *, PAGE *, uint32_t, int *));
 static int __db_build_ri
-__P ((DB *, DB_FH *, PAGE *, PAGE *, u_int32_t, int *));
+__P ((DB *, DB_FH *, PAGE *, PAGE *, uint32_t, int *));
 static int __db_up_ovref __P ((DB *, DB_FH *, db_pgno_t));
 
 #define  GET_PAGE(dbp, fhp, pgno, page) {        \
@@ -220,12 +220,12 @@ __db_build_bi (dbp, fhp, ipage, page, indx, nomemp)
      DB *dbp;
      DB_FH *fhp;
      PAGE *ipage, *page;
-     u_int32_t indx;
+     uint32_t indx;
      int *nomemp;
 {
   BINTERNAL bi, *child_bi;
   BKEYDATA *child_bk;
-  u_int8_t *p;
+  uint8_t *p;
   int ret;
 
   switch (TYPE (page))
@@ -317,7 +317,7 @@ __db_build_ri (dbp, fhp, ipage, page, indx, nomemp)
      DB *dbp;
      DB_FH *fhp;
      PAGE *ipage, *page;
-     u_int32_t indx;
+     uint32_t indx;
      int *nomemp;
 {
   RINTERNAL ri;

--- a/db/db_upgrade.c
+++ b/db/db_upgrade.c
@@ -28,13 +28,13 @@ static const char sccsid[] = "@(#)db_upgrade.c  11.3 (Sleepycat) 10/20/99";
  * CDB___db_upgrade --
  *  Upgrade an existing database.
  *
- * PUBLIC: int CDB___db_upgrade __P((DB *, const char *, u_int32_t));
+ * PUBLIC: int CDB___db_upgrade __P((DB *, const char *, uint32_t));
  */
 int
 CDB___db_upgrade (dbp, fname, flags)
      DB *dbp;
      const char *fname;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB_ENV *dbenv;
   DB_FH fh;

--- a/db/db_upgrade.h
+++ b/db/db_upgrade.h
@@ -21,16 +21,16 @@ typedef struct _dbmeta30
 {
   DB_LSN lsn;                   /* 00-07: LSN. */
   db_pgno_t pgno;               /* 08-11: Current page number. */
-  u_int32_t magic;              /* 12-15: Magic number. */
-  u_int32_t version;            /* 16-19: Version. */
-  u_int32_t pagesize;           /* 20-23: Pagesize. */
-  u_int8_t unused1[1];          /*    24: Unused. */
-  u_int8_t type;                /*    25: Page type. */
-  u_int8_t unused2[2];          /* 26-27: Unused. */
-  u_int32_t free;               /* 28-31: Free list page number. */
-  u_int32_t flags;              /* 32-35: Flags: unique to each AM. */
+  uint32_t magic;              /* 12-15: Magic number. */
+  uint32_t version;            /* 16-19: Version. */
+  uint32_t pagesize;           /* 20-23: Pagesize. */
+  uint8_t unused1[1];          /*    24: Unused. */
+  uint8_t type;                /*    25: Page type. */
+  uint8_t unused2[2];          /* 26-27: Unused. */
+  uint32_t free;               /* 28-31: Free list page number. */
+  uint32_t flags;              /* 32-35: Flags: unique to each AM. */
   /* 36-55: Unique file ID. */
-  u_int8_t uid[DB_FILE_ID_LEN];
+  uint8_t uid[DB_FILE_ID_LEN];
 } DBMETA30;
 
 /************************************************************************
@@ -40,11 +40,11 @@ typedef struct _btmeta30
 {
   DBMETA30 dbmeta;              /* 00-55: Generic meta-data header. */
 
-  u_int32_t maxkey;             /* 56-59: Btree: Maxkey. */
-  u_int32_t minkey;             /* 60-63: Btree: Minkey. */
-  u_int32_t re_len;             /* 64-67: Recno: fixed-length record length. */
-  u_int32_t re_pad;             /* 68-71: Recno: fixed-length record pad. */
-  u_int32_t root;               /* 72-75: Root page. */
+  uint32_t maxkey;             /* 56-59: Btree: Maxkey. */
+  uint32_t minkey;             /* 60-63: Btree: Minkey. */
+  uint32_t re_len;             /* 64-67: Recno: fixed-length record length. */
+  uint32_t re_pad;             /* 68-71: Recno: fixed-length record pad. */
+  uint32_t root;               /* 72-75: Root page. */
 
   /*
    * Minimum page size is 128.
@@ -58,15 +58,15 @@ typedef struct _hashmeta30
 {
   DBMETA30 dbmeta;              /* 00-55: Generic meta-data page header. */
 
-  u_int32_t max_bucket;         /* 56-59: ID of Maximum bucket in use */
-  u_int32_t high_mask;          /* 60-63: Modulo mask into table */
-  u_int32_t low_mask;           /* 64-67: Modulo mask into table lower half */
-  u_int32_t ffactor;            /* 68-71: Fill factor */
-  u_int32_t nelem;              /* 72-75: Number of keys in hash table */
-  u_int32_t h_charkey;          /* 76-79: Value of hash(CHARKEY) */
+  uint32_t max_bucket;         /* 56-59: ID of Maximum bucket in use */
+  uint32_t high_mask;          /* 60-63: Modulo mask into table */
+  uint32_t low_mask;           /* 64-67: Modulo mask into table lower half */
+  uint32_t ffactor;            /* 68-71: Fill factor */
+  uint32_t nelem;              /* 72-75: Number of keys in hash table */
+  uint32_t h_charkey;          /* 76-79: Value of hash(CHARKEY) */
 #define  NCACHED30  32          /* number of spare points */
   /* 80-207: Spare pages for overflow */
-  u_int32_t spares[NCACHED30];
+  uint32_t spares[NCACHED30];
 
   /*
    * Minimum page size is 256.
@@ -84,12 +84,12 @@ typedef struct _qmeta30
 {
   DBMETA30 dbmeta;              /* 00-55: Generic meta-data header. */
 
-  u_int32_t start;              /* 56-59: Start offset. */
-  u_int32_t first_recno;        /* 60-63: First not deleted record. */
-  u_int32_t cur_recno;          /* 64-67: Last recno allocated. */
-  u_int32_t re_len;             /* 68-71: Fixed-length record length. */
-  u_int32_t re_pad;             /* 72-75: Fixed-length record pad. */
-  u_int32_t rec_page;           /* 76-79: Records Per Page. */
+  uint32_t start;              /* 56-59: Start offset. */
+  uint32_t first_recno;        /* 60-63: First not deleted record. */
+  uint32_t cur_recno;          /* 64-67: Last recno allocated. */
+  uint32_t re_len;             /* 68-71: Fixed-length record length. */
+  uint32_t re_pad;             /* 72-75: Fixed-length record pad. */
+  uint32_t rec_page;           /* 76-79: Records Per Page. */
 
   /*
    * Minimum page size is 128.
@@ -109,17 +109,17 @@ typedef struct _btmeta2X
 {
   DB_LSN lsn;                   /* 00-07: LSN. */
   db_pgno_t pgno;               /* 08-11: Current page number. */
-  u_int32_t magic;              /* 12-15: Magic number. */
-  u_int32_t version;            /* 16-19: Version. */
-  u_int32_t pagesize;           /* 20-23: Pagesize. */
-  u_int32_t maxkey;             /* 24-27: Btree: Maxkey. */
-  u_int32_t minkey;             /* 28-31: Btree: Minkey. */
-  u_int32_t free;               /* 32-35: Free list page number. */
-  u_int32_t flags;              /* 36-39: Flags. */
-  u_int32_t re_len;             /* 40-43: Recno: fixed-length record length. */
-  u_int32_t re_pad;             /* 44-47: Recno: fixed-length record pad. */
+  uint32_t magic;              /* 12-15: Magic number. */
+  uint32_t version;            /* 16-19: Version. */
+  uint32_t pagesize;           /* 20-23: Pagesize. */
+  uint32_t maxkey;             /* 24-27: Btree: Maxkey. */
+  uint32_t minkey;             /* 28-31: Btree: Minkey. */
+  uint32_t free;               /* 32-35: Free list page number. */
+  uint32_t flags;              /* 36-39: Flags. */
+  uint32_t re_len;             /* 40-43: Recno: fixed-length record length. */
+  uint32_t re_pad;             /* 44-47: Recno: fixed-length record pad. */
   /* 48-67: Unique file ID. */
-  u_int8_t uid[DB_FILE_ID_LEN];
+  uint8_t uid[DB_FILE_ID_LEN];
 } BTMETA2X;
 
 /************************************************************************
@@ -134,23 +134,23 @@ typedef struct hashhdr
 {                               /* Disk resident portion */
   DB_LSN lsn;                   /* 00-07: LSN of the header page */
   db_pgno_t pgno;               /* 08-11: Page number (btree compatibility). */
-  u_int32_t magic;              /* 12-15: Magic NO for hash tables */
-  u_int32_t version;            /* 16-19: Version ID */
-  u_int32_t pagesize;           /* 20-23: Bucket/Page Size */
-  u_int32_t ovfl_point;         /* 24-27: Overflow page allocation location */
-  u_int32_t last_freed;         /* 28-31: Last freed overflow page pgno */
-  u_int32_t max_bucket;         /* 32-35: ID of Maximum bucket in use */
-  u_int32_t high_mask;          /* 36-39: Modulo mask into table */
-  u_int32_t low_mask;           /* 40-43: Modulo mask into table lower half */
-  u_int32_t ffactor;            /* 44-47: Fill factor */
-  u_int32_t nelem;              /* 48-51: Number of keys in hash table */
-  u_int32_t h_charkey;          /* 52-55: Value of hash(CHARKEY) */
-  u_int32_t flags;              /* 56-59: Allow duplicates. */
+  uint32_t magic;              /* 12-15: Magic NO for hash tables */
+  uint32_t version;            /* 16-19: Version ID */
+  uint32_t pagesize;           /* 20-23: Bucket/Page Size */
+  uint32_t ovfl_point;         /* 24-27: Overflow page allocation location */
+  uint32_t last_freed;         /* 28-31: Last freed overflow page pgno */
+  uint32_t max_bucket;         /* 32-35: ID of Maximum bucket in use */
+  uint32_t high_mask;          /* 36-39: Modulo mask into table */
+  uint32_t low_mask;           /* 40-43: Modulo mask into table lower half */
+  uint32_t ffactor;            /* 44-47: Fill factor */
+  uint32_t nelem;              /* 48-51: Number of keys in hash table */
+  uint32_t h_charkey;          /* 52-55: Value of hash(CHARKEY) */
+  uint32_t flags;              /* 56-59: Allow duplicates. */
 #define  NCACHED2X  32          /* number of spare points */
   /* 60-187: Spare pages for overflow */
-  u_int32_t spares[NCACHED2X];
+  uint32_t spares[NCACHED2X];
   /* 188-207: Unique file ID. */
-  u_int8_t uid[DB_FILE_ID_LEN];
+  uint8_t uid[DB_FILE_ID_LEN];
 
   /*
    * Minimum page size is 256.

--- a/db/db_verify.h
+++ b/db/db_verify.h
@@ -113,12 +113,12 @@ struct __vrfy_dbinfo
   db_pgno_t last_pgno;
 
   /* Queue needs these to verify data pages in the first pass. */
-  u_int32_t re_len;
-  u_int32_t rec_page;
+  uint32_t re_len;
+  uint32_t rec_page;
 
 #define  SALVAGE_PRINTHEADER  0x01
 #define  SALVAGE_PRINTFOOTER  0x02
-  u_int32_t flags;
+  uint32_t flags;
 };                              /* VRFY_DBINFO */
 
 /*
@@ -131,10 +131,10 @@ struct __vrfy_dbinfo
  */
 struct __vrfy_pageinfo
 {
-  u_int8_t type;
-  u_int8_t bt_level;
-  u_int8_t unused1;
-  u_int8_t unused2;
+  uint8_t type;
+  uint8_t bt_level;
+  uint8_t unused1;
+  uint8_t unused2;
   db_pgno_t pgno;
   db_pgno_t prev_pgno;
   db_pgno_t next_pgno;
@@ -144,21 +144,21 @@ struct __vrfy_pageinfo
   db_pgno_t free;               /* Free list head. */
 
   db_indx_t entries;            /* Actual number of entries. */
-  u_int16_t unused;
+  uint16_t unused;
   db_recno_t rec_cnt;           /* Record count. */
-  u_int32_t re_len;             /* Record length. */
-  u_int32_t bt_minkey;
-  u_int32_t bt_maxkey;
-  u_int32_t h_ffactor;
-  u_int32_t h_nelem;
+  uint32_t re_len;             /* Record length. */
+  uint32_t bt_minkey;
+  uint32_t bt_maxkey;
+  uint32_t h_ffactor;
+  uint32_t h_nelem;
 
   /* overflow pages */
   /*
    * Note that refcount is the refcount for an overflow page; pi_refcount
    * is this structure's own refcount!
    */
-  u_int32_t refcount;
-  u_int32_t olen;
+  uint32_t refcount;
+  uint32_t olen;
 
 #define  VRFY_DUPS_UNSORTED  0x0001     /* Have to flag the negative! */
 #define  VRFY_HAS_DUPS    0x0002
@@ -171,10 +171,10 @@ struct __vrfy_pageinfo
 #define  VRFY_IS_RECNO    0x0100
 #define  VRFY_IS_RRECNO    0x0200
 #define  VRFY_OVFL_LEAFSEEN  0x0400
-  u_int32_t flags;
+  uint32_t flags;
 
     LIST_ENTRY (__vrfy_pageinfo) links;
-  u_int32_t pi_refcount;
+  uint32_t pi_refcount;
 };                              /* VRFY_PAGEINFO */
 
 struct __vrfy_childinfo
@@ -184,9 +184,9 @@ struct __vrfy_childinfo
 #define  V_DUPLICATE  1         /* off-page dup metadata */
 #define  V_OVERFLOW  2          /* overflow page */
 #define  V_RECNO    3           /* btree internal or leaf page */
-  u_int32_t type;
+  uint32_t type;
   db_recno_t nrecs;             /* record count on a btree subtree */
-  u_int32_t tlen;               /* ovfl. item total size */
+  uint32_t tlen;               /* ovfl. item total size */
 
     LIST_ENTRY (__vrfy_childinfo) links;
 };                              /* VRFY_CHILDINFO */

--- a/db/db_vrfy.c
+++ b/db/db_vrfy.c
@@ -31,29 +31,29 @@ static const char revid[] =
 #include "qam.h"
 
 static int __db_guesspgsize __P ((DB_ENV *, DB_FH *));
-static int __db_is_valid_magicno __P ((u_int32_t, DBTYPE *));
-static int __db_is_valid_pagetype __P ((u_int32_t));
+static int __db_is_valid_magicno __P ((uint32_t, DBTYPE *));
+static int __db_is_valid_pagetype __P ((uint32_t));
 static int __db_meta2pgset
-__P ((DB *, VRFY_DBINFO *, db_pgno_t, u_int32_t, DB *));
+__P ((DB *, VRFY_DBINFO *, db_pgno_t, uint32_t, DB *));
 static int __db_salvage_subdbs
 __P ((DB *, VRFY_DBINFO *, void *,
-      int (*)(void *, const void *), u_int32_t, int *));
+      int (*)(void *, const void *), uint32_t, int *));
 static int __db_salvage_unknowns
-__P ((DB *, VRFY_DBINFO *, void *, int (*)(void *, const void *), u_int32_t));
+__P ((DB *, VRFY_DBINFO *, void *, int (*)(void *, const void *), uint32_t));
 static int __db_vrfy_common
-__P ((DB *, VRFY_DBINFO *, PAGE *, db_pgno_t, u_int32_t));
+__P ((DB *, VRFY_DBINFO *, PAGE *, db_pgno_t, uint32_t));
 static int __db_vrfy_freelist
-__P ((DB *, VRFY_DBINFO *, db_pgno_t, u_int32_t));
+__P ((DB *, VRFY_DBINFO *, db_pgno_t, uint32_t));
 static int __db_vrfy_invalid
-__P ((DB *, VRFY_DBINFO *, PAGE *, db_pgno_t, u_int32_t));
+__P ((DB *, VRFY_DBINFO *, PAGE *, db_pgno_t, uint32_t));
 static int __db_vrfy_orderchkonly
-__P ((DB *, VRFY_DBINFO *, const char *, const char *, u_int32_t));
-static int __db_vrfy_pagezero __P ((DB *, VRFY_DBINFO *, DB_FH *, u_int32_t));
-static int __db_vrfy_subdbs __P ((DB *, VRFY_DBINFO *, char *, u_int32_t));
+__P ((DB *, VRFY_DBINFO *, const char *, const char *, uint32_t));
+static int __db_vrfy_pagezero __P ((DB *, VRFY_DBINFO *, DB_FH *, uint32_t));
+static int __db_vrfy_subdbs __P ((DB *, VRFY_DBINFO *, char *, uint32_t));
 static int __db_vrfy_structure
-__P ((DB *, VRFY_DBINFO *, char *, db_pgno_t, u_int32_t));
+__P ((DB *, VRFY_DBINFO *, char *, db_pgno_t, uint32_t));
 static int __db_vrfy_walkpages
-__P ((DB *, VRFY_DBINFO *, void *, int (*)(void *, const void *), u_int32_t));
+__P ((DB *, VRFY_DBINFO *, void *, int (*)(void *, const void *), uint32_t));
 
 /*
  * This is the code for DB->verify, the DB database consistency checker.
@@ -81,14 +81,14 @@ __P ((DB *, VRFY_DBINFO *, void *, int (*)(void *, const void *), u_int32_t));
  *  non-C APIs.
  *
  * PUBLIC: int CDB___db_verify
- * PUBLIC:     __P((DB *, const char *, const char *, FILE *, u_int32_t));
+ * PUBLIC:     __P((DB *, const char *, const char *, FILE *, uint32_t));
  */
 int
 CDB___db_verify (dbp, file, database, outfile, flags)
      DB *dbp;
      const char *file, *database;
      FILE *outfile;
-     u_int32_t flags;
+     uint32_t flags;
 {
 
   return (CDB___db_verify_internal (dbp,
@@ -124,7 +124,7 @@ CDB___db_verify_callback (handle, str_arg)
  *  Inner meat of CDB___db_verify.
  *
  * PUBLIC: int CDB___db_verify_internal __P((DB *, const char *,
- * PUBLIC:     const char *, void *, int (*)(void *, const void *), u_int32_t));
+ * PUBLIC:     const char *, void *, int (*)(void *, const void *), uint32_t));
  */
 int
 CDB___db_verify_internal (dbp_orig, name, subdb, handle, callback, flags)
@@ -132,7 +132,7 @@ CDB___db_verify_internal (dbp_orig, name, subdb, handle, callback, flags)
      const char *name, *subdb;
      void *handle;
      int (*callback) __P ((void *, const void *));
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB *dbp;
   DB_ENV *dbenv;
@@ -389,14 +389,14 @@ __db_vrfy_pagezero (dbp, vdp, fhp, flags)
      DB *dbp;
      VRFY_DBINFO *vdp;
      DB_FH *fhp;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DBMETA *meta;
   DB_ENV *dbenv;
   VRFY_PAGEINFO *pip;
   db_pgno_t freelist;
   int t_ret, ret, nr, swapped;
-  u_int8_t mbuf[DBMETASIZE];
+  uint8_t mbuf[DBMETASIZE];
 
   swapped = ret = t_ret = 0;
   freelist = 0;
@@ -555,7 +555,7 @@ __db_vrfy_walkpages (dbp, vdp, handle, callback, flags)
      VRFY_DBINFO *vdp;
      void *handle;
      int (*callback) __P ((void *, const void *));
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB_ENV *dbenv;
   PAGE *h;
@@ -696,7 +696,7 @@ __db_vrfy_structure (dbp, vdp, dbname, meta_pgno, flags)
      VRFY_DBINFO *vdp;
      char *dbname;
      db_pgno_t meta_pgno;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB *pgset;
   DB_ENV *dbenv;
@@ -840,7 +840,7 @@ err:if (pip != NULL)
  */
 static int
 __db_is_valid_pagetype (type)
-     u_int32_t type;
+     uint32_t type;
 {
   switch (type)
   {
@@ -866,7 +866,7 @@ __db_is_valid_pagetype (type)
  */
 static int
 __db_is_valid_magicno (magic, typep)
-     u_int32_t magic;
+     uint32_t magic;
      DBTYPE *typep;
 {
   switch (magic)
@@ -895,11 +895,11 @@ __db_vrfy_common (dbp, vdp, h, pgno, flags)
      VRFY_DBINFO *vdp;
      PAGE *h;
      db_pgno_t pgno;
-     u_int32_t flags;
+     uint32_t flags;
 {
   VRFY_PAGEINFO *pip;
   int ret, t_ret;
-  u_int8_t *p;
+  uint8_t *p;
 
   if ((ret = CDB___db_vrfy_getpageinfo (vdp, pgno, &pip)) != 0)
     return (ret);
@@ -915,7 +915,7 @@ __db_vrfy_common (dbp, vdp, h, pgno, flags)
    */
   if (pgno != 0 && PGNO (h) == 0)
   {
-    for (p = (u_int8_t *) h; p < (u_int8_t *) h + dbp->pgsize; p++)
+    for (p = (uint8_t *) h; p < (uint8_t *) h + dbp->pgsize; p++)
       if (*p != 0)
       {
         EPRINT ((dbp->dbenv,
@@ -964,7 +964,7 @@ __db_vrfy_invalid (dbp, vdp, h, pgno, flags)
      VRFY_DBINFO *vdp;
      PAGE *h;
      db_pgno_t pgno;
-     u_int32_t flags;
+     uint32_t flags;
 {
   VRFY_PAGEINFO *pip;
   int ret, t_ret;
@@ -998,7 +998,7 @@ __db_vrfy_invalid (dbp, vdp, h, pgno, flags)
  *  in.
  *
  * PUBLIC: int CDB___db_vrfy_datapage
- * PUBLIC:     __P((DB *, VRFY_DBINFO *, PAGE *, db_pgno_t, u_int32_t));
+ * PUBLIC:     __P((DB *, VRFY_DBINFO *, PAGE *, db_pgno_t, uint32_t));
  */
 int
 CDB___db_vrfy_datapage (dbp, vdp, h, pgno, flags)
@@ -1006,7 +1006,7 @@ CDB___db_vrfy_datapage (dbp, vdp, h, pgno, flags)
      VRFY_DBINFO *vdp;
      PAGE *h;
      db_pgno_t pgno;
-     u_int32_t flags;
+     uint32_t flags;
 {
   VRFY_PAGEINFO *pip;
   int isbad, ret, t_ret;
@@ -1119,7 +1119,7 @@ CDB___db_vrfy_datapage (dbp, vdp, h, pgno, flags)
  *  normal mpool routines.
  *
  * PUBLIC: int CDB___db_vrfy_meta
- * PUBLIC:     __P((DB *, VRFY_DBINFO *, DBMETA *, db_pgno_t, u_int32_t));
+ * PUBLIC:     __P((DB *, VRFY_DBINFO *, DBMETA *, db_pgno_t, uint32_t));
  */
 int
 CDB___db_vrfy_meta (dbp, vdp, meta, pgno, flags)
@@ -1127,7 +1127,7 @@ CDB___db_vrfy_meta (dbp, vdp, meta, pgno, flags)
      VRFY_DBINFO *vdp;
      DBMETA *meta;
      db_pgno_t pgno;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DBTYPE dbtype, magtype;
   VRFY_PAGEINFO *pip;
@@ -1214,7 +1214,7 @@ __db_vrfy_freelist (dbp, vdp, meta, flags)
      DB *dbp;
      VRFY_DBINFO *vdp;
      db_pgno_t meta;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB *pgset;
   VRFY_PAGEINFO *pip;
@@ -1277,7 +1277,7 @@ __db_vrfy_subdbs (dbp, vdp, dbname, flags)
      DB *dbp;
      VRFY_DBINFO *vdp;
      char *dbname;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB *mdbp;
   DBC *dbc;
@@ -1285,7 +1285,7 @@ __db_vrfy_subdbs (dbp, vdp, dbname, flags)
   VRFY_PAGEINFO *pip;
   db_pgno_t meta_pgno;
   int ret, t_ret, isbad;
-  u_int8_t type;
+  uint8_t type;
 
   isbad = 0;
   dbc = NULL;
@@ -1377,7 +1377,7 @@ __db_vrfy_orderchkonly (dbp, vdp, name, subdb, flags)
      DB *dbp;
      VRFY_DBINFO *vdp;
      const char *name, *subdb;
-     u_int32_t flags;
+     uint32_t flags;
 {
   BTMETA *btmeta;
   DB *mdbp, *pgset;
@@ -1387,7 +1387,7 @@ __db_vrfy_orderchkonly (dbp, vdp, name, subdb, flags)
   HMETA *hmeta;
   PAGE *h, *currpg;
   db_pgno_t meta_pgno, p, pgno;
-  u_int32_t bucket;
+  uint32_t bucket;
   int t_ret, ret;
 
   currpg = h = NULL;
@@ -1522,7 +1522,7 @@ err:if (pgsc != NULL)
  *  DB_AGGRESSIVE) key/data pairs.
  *
  * PUBLIC: int CDB___db_salvage __P((DB *, VRFY_DBINFO *, db_pgno_t, PAGE *,
- * PUBLIC:     void *, int (*)(void *, const void *), u_int32_t));
+ * PUBLIC:     void *, int (*)(void *, const void *), uint32_t));
  */
 int
 CDB___db_salvage (dbp, vdp, pgno, h, handle, callback, flags)
@@ -1532,7 +1532,7 @@ CDB___db_salvage (dbp, vdp, pgno, h, handle, callback, flags)
      PAGE *h;
      void *handle;
      int (*callback) __P ((void *, const void *));
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB_ASSERT (LF_ISSET (DB_SALVAGE));
 
@@ -1593,12 +1593,12 @@ __db_salvage_unknowns (dbp, vdp, handle, callback, flags)
      VRFY_DBINFO *vdp;
      void *handle;
      int (*callback) __P ((void *, const void *));
-     u_int32_t flags;
+     uint32_t flags;
 {
   DBT unkdbt, key, *dbt;
   PAGE *h;
   db_pgno_t pgno;
-  u_int32_t pgtype;
+  uint32_t pgtype;
   int ret, err_ret;
   void *ovflbuf;
 
@@ -1687,7 +1687,7 @@ __db_salvage_unknowns (dbp, vdp, handle, callback, flags)
  * the entry stores.
  */
 #define  INP_OFFSET(h, i)  \
-    ((db_indx_t)((u_int8_t *)(h)->inp + (i) - (u_int8_t *)(h)))
+    ((db_indx_t)((uint8_t *)(h)->inp + (i) - (uint8_t *)(h)))
 
 /*
  * CDB___db_vrfy_inpitem --
@@ -1701,16 +1701,16 @@ __db_salvage_unknowns (dbp, vdp, handle, callback, flags)
  *  if anything else is wrong.
  *
  * PUBLIC: int CDB___db_vrfy_inpitem __P((DB *, PAGE *,
- * PUBLIC:     db_pgno_t, u_int32_t, int, u_int32_t, u_int32_t *, u_int32_t *));
+ * PUBLIC:     db_pgno_t, uint32_t, int, uint32_t, uint32_t *, uint32_t *));
  */
 int
 CDB___db_vrfy_inpitem (dbp, h, pgno, i, is_btree, flags, himarkp, offsetp)
      DB *dbp;
      PAGE *h;
      db_pgno_t pgno;
-     u_int32_t i;
+     uint32_t i;
      int is_btree;
-     u_int32_t flags, *himarkp, *offsetp;
+     uint32_t flags, *himarkp, *offsetp;
 {
   BKEYDATA *bk;
   db_indx_t offset, len;
@@ -1722,7 +1722,7 @@ CDB___db_vrfy_inpitem (dbp, h, pgno, i, is_btree, flags, himarkp, offsetp)
    * page forward, has not collided with the data, which grow from the
    * end of the page backward.
    */
-  if ((u_int8_t *) h->inp + i >= (u_int8_t *) h + *himarkp)
+  if ((uint8_t *) h->inp + i >= (uint8_t *) h + *himarkp)
   {
     /* We've collided with the data.  We need to bail. */
     EPRINT ((dbp->dbenv,
@@ -1774,14 +1774,14 @@ CDB___db_vrfy_inpitem (dbp, h, pgno, i, is_btree, flags, himarkp, offsetp)
  *  if DUPSORT is not set and a btree if it is.
  *
  * PUBLIC: int CDB___db_vrfy_duptype
- * PUBLIC:     __P((DB *, VRFY_DBINFO *, db_pgno_t, u_int32_t));
+ * PUBLIC:     __P((DB *, VRFY_DBINFO *, db_pgno_t, uint32_t));
  */
 int
 CDB___db_vrfy_duptype (dbp, vdp, pgno, flags)
      DB *dbp;
      VRFY_DBINFO *vdp;
      db_pgno_t pgno;
-     u_int32_t flags;
+     uint32_t flags;
 {
   VRFY_PAGEINFO *pip;
   int ret, isbad;
@@ -1846,7 +1846,7 @@ CDB___db_vrfy_duptype (dbp, vdp, pgno, flags)
  *  in any cycles.
  *
  * PUBLIC: int CDB___db_salvage_duptree __P((DB *, VRFY_DBINFO *, db_pgno_t,
- * PUBLIC:     DBT *, void *, int (*)(void *, const void *), u_int32_t));
+ * PUBLIC:     DBT *, void *, int (*)(void *, const void *), uint32_t));
  */
 int
 CDB___db_salvage_duptree (dbp, vdp, pgno, key, handle, callback, flags)
@@ -1856,7 +1856,7 @@ CDB___db_salvage_duptree (dbp, vdp, pgno, key, handle, callback, flags)
      DBT *key;
      void *handle;
      int (*callback) __P ((void *, const void *));
-     u_int32_t flags;
+     uint32_t flags;
 {
   PAGE *h;
   int ret, t_ret;
@@ -1914,7 +1914,7 @@ __db_salvage_subdbs (dbp, vdp, handle, callback, flags, hassubsp)
      VRFY_DBINFO *vdp;
      void *handle;
      int (*callback) __P ((void *, const void *));
-     u_int32_t flags;
+     uint32_t flags;
      int *hassubsp;
 {
   BTMETA *btmeta;
@@ -2021,7 +2021,7 @@ err:if (pgsc != NULL)
  *
  * PUBLIC: int CDB___db_salvage_subdbpg
  * PUBLIC:     __P((DB *, VRFY_DBINFO *, PAGE *, void *,
- * PUBLIC:     int (*)(void *, const void *), u_int32_t));
+ * PUBLIC:     int (*)(void *, const void *), uint32_t));
  */
 int
 CDB___db_salvage_subdbpg (dbp, vdp, master, handle, callback, flags)
@@ -2030,7 +2030,7 @@ CDB___db_salvage_subdbpg (dbp, vdp, master, handle, callback, flags)
      PAGE *master;
      void *handle;
      int (*callback) __P ((void *, const void *));
-     u_int32_t flags;
+     uint32_t flags;
 {
   BKEYDATA *bkkey, *bkdata;
   BOVERFLOW *bo;
@@ -2212,7 +2212,7 @@ __db_meta2pgset (dbp, vdp, pgno, flags, pgset)
      DB *dbp;
      VRFY_DBINFO *vdp;
      db_pgno_t pgno;
-     u_int32_t flags;
+     uint32_t flags;
      DB *pgset;
 {
   PAGE *h;
@@ -2251,8 +2251,8 @@ __db_guesspgsize (dbenv, fhp)
 {
   db_pgno_t i;
   size_t nr;
-  u_int32_t guess;
-  u_int8_t type;
+  uint32_t guess;
+  uint8_t type;
   int ret;
 
   for (guess = DB_MAX_PGSIZE; guess >= DB_MIN_PGSIZE; guess >>= 1)

--- a/db/db_vrfyutil.c
+++ b/db/db_vrfyutil.c
@@ -32,12 +32,12 @@ static int __db_vrfy_pgset_iinc __P ((DB *, db_pgno_t, int));
  *  Allocate and initialize a VRFY_DBINFO structure.
  *
  * PUBLIC: int CDB___db_vrfy_dbinfo_create
- * PUBLIC:     __P((DB_ENV *, u_int32_t, VRFY_DBINFO **));
+ * PUBLIC:     __P((DB_ENV *, uint32_t, VRFY_DBINFO **));
  */
 int
 CDB___db_vrfy_dbinfo_create (dbenv, pgsize, vdpp)
      DB_ENV *dbenv;
-     u_int32_t pgsize;
+     uint32_t pgsize;
      VRFY_DBINFO **vdpp;
 {
   DB *cdbp, *pgdbp, *pgset;
@@ -267,12 +267,12 @@ CDB___db_vrfy_putpageinfo (vdp, pip)
  *  (A mapping from page number to int, used by the *_meta2pgset functions,
  *  as well as for keeping track of which pages the verifier has seen.)
  *
- * PUBLIC: int CDB___db_vrfy_pgset __P((DB_ENV *, u_int32_t, DB **));
+ * PUBLIC: int CDB___db_vrfy_pgset __P((DB_ENV *, uint32_t, DB **));
  */
 int
 CDB___db_vrfy_pgset (dbenv, pgsize, dbpp)
      DB_ENV *dbenv;
-     u_int32_t pgsize;
+     uint32_t pgsize;
      DB **dbpp;
 {
   DB *dbp;
@@ -643,19 +643,19 @@ CDB___db_salvage_destroy (vdp)
  *  in this search, as well as the page we're returning.
  *
  * PUBLIC: int CDB___db_salvage_getnext
- * PUBLIC:     __P((VRFY_DBINFO *, db_pgno_t *, u_int32_t *));
+ * PUBLIC:     __P((VRFY_DBINFO *, db_pgno_t *, uint32_t *));
  */
 int
 CDB___db_salvage_getnext (vdp, pgnop, pgtypep)
      VRFY_DBINFO *vdp;
      db_pgno_t *pgnop;
-     u_int32_t *pgtypep;
+     uint32_t *pgtypep;
 {
   DB *dbp;
   DBC *dbc;
   DBT key, data;
   int ret;
-  u_int32_t pgtype;
+  uint32_t pgtype;
 
   dbp = vdp->salvage_pages;
 
@@ -667,7 +667,7 @@ CDB___db_salvage_getnext (vdp, pgnop, pgtypep)
 
   while ((ret = dbc->c_get (dbc, &key, &data, DB_NEXT)) == 0)
   {
-    DB_ASSERT (data.size == sizeof (u_int32_t));
+    DB_ASSERT (data.size == sizeof (uint32_t));
     memcpy (&pgtype, data.data, sizeof (pgtype));
 
     if ((ret = dbc->c_del (dbc, 0)) != 0)
@@ -681,10 +681,10 @@ CDB___db_salvage_getnext (vdp, pgnop, pgtypep)
   if (0)
   {
   found:DB_ASSERT (key.size == sizeof (db_pgno_t));
-    DB_ASSERT (data.size == sizeof (u_int32_t));
+    DB_ASSERT (data.size == sizeof (uint32_t));
 
     *pgnop = *(db_pgno_t *) key.data;
-    *pgtypep = *(u_int32_t *) data.data;
+    *pgtypep = *(uint32_t *) data.data;
   }
 
 err:(void) dbc->c_close (dbc);
@@ -709,7 +709,7 @@ CDB___db_salvage_isdone (vdp, pgno)
   DBT key, data;
   DB *dbp;
   int ret;
-  u_int32_t currtype;
+  uint32_t currtype;
 
   dbp = vdp->salvage_pages;
 
@@ -718,7 +718,7 @@ CDB___db_salvage_isdone (vdp, pgno)
 
   currtype = SALVAGE_INVALID;
   data.data = &currtype;
-  data.ulen = sizeof (u_int32_t);
+  data.ulen = sizeof (uint32_t);
   data.flags = DB_DBT_USERMEM;
 
   key.data = &pgno;
@@ -764,7 +764,7 @@ CDB___db_salvage_markdone (vdp, pgno)
   DBT key, data;
   DB *dbp;
   int pgtype, ret;
-  u_int32_t currtype;
+  uint32_t currtype;
 
   pgtype = SALVAGE_IGNORE;
   dbp = vdp->salvage_pages;
@@ -774,7 +774,7 @@ CDB___db_salvage_markdone (vdp, pgno)
 
   currtype = SALVAGE_INVALID;
   data.data = &currtype;
-  data.ulen = sizeof (u_int32_t);
+  data.ulen = sizeof (uint32_t);
   data.flags = DB_DBT_USERMEM;
 
   key.data = &pgno;
@@ -790,7 +790,7 @@ CDB___db_salvage_markdone (vdp, pgno)
   if ((ret = CDB___db_salvage_isdone (vdp, pgno)) != 0)
     return (ret);
 
-  data.size = sizeof (u_int32_t);
+  data.size = sizeof (uint32_t);
   data.data = &pgtype;
 
   return (dbp->put (dbp, NULL, &key, &data, 0));
@@ -802,13 +802,13 @@ CDB___db_salvage_markdone (vdp, pgno)
  *  must be dealt with later.
  *
  * PUBLIC: int CDB___db_salvage_markneeded
- * PUBLIC:     __P((VRFY_DBINFO *, db_pgno_t, u_int32_t));
+ * PUBLIC:     __P((VRFY_DBINFO *, db_pgno_t, uint32_t));
  */
 int
 CDB___db_salvage_markneeded (vdp, pgno, pgtype)
      VRFY_DBINFO *vdp;
      db_pgno_t pgno;
-     u_int32_t pgtype;
+     uint32_t pgtype;
 {
   DB *dbp;
   DBT key, data;
@@ -823,7 +823,7 @@ CDB___db_salvage_markneeded (vdp, pgno, pgtype)
   key.size = sizeof (db_pgno_t);
 
   data.data = &pgtype;
-  data.size = sizeof (u_int32_t);
+  data.size = sizeof (uint32_t);
 
   /*
    * Put an entry for this page, with pgno as key and type as data,

--- a/db/env_ext.h
+++ b/db/env_ext.h
@@ -7,21 +7,21 @@ void CDB___db_shalloc_free __P ((void *, void *));
 size_t CDB___db_shalloc_count __P ((void *));
 size_t CDB___db_shsizeof __P ((void *));
 void CDB___db_shalloc_dump __P ((void *, FILE *));
-int CDB___db_tablesize __P ((u_int32_t));
-void CDB___db_hashinit __P ((void *, u_int32_t));
+int CDB___db_tablesize __P ((uint32_t));
+void CDB___db_hashinit __P ((void *, uint32_t));
 int CDB___dbenv_init __P ((DB_ENV *));
 int CDB___db_mi_env __P ((DB_ENV *, const char *));
 int CDB___db_mi_open __P ((DB_ENV *, const char *, int));
 int CDB___db_env_config __P ((DB_ENV *, int));
 int CDB___dbenv_open __P ((DB_ENV *,
-                           const char *, char *const *, u_int32_t, int));
+                           const char *, char *const *, uint32_t, int));
 int CDB___dbenv_remove __P ((DB_ENV *,
-                             const char *, char *const *, u_int32_t));
-int CDB___dbenv_close __P ((DB_ENV *, u_int32_t));
+                             const char *, char *const *, uint32_t));
+int CDB___dbenv_close __P ((DB_ENV *, uint32_t));
 int CDB___db_appname __P ((DB_ENV *, APPNAME,
-                           const char *, const char *, u_int32_t, DB_FH *,
+                           const char *, const char *, uint32_t, DB_FH *,
                            char **));
-int CDB___db_apprec __P ((DB_ENV *, u_int32_t));
+int CDB___db_apprec __P ((DB_ENV *, uint32_t));
 int CDB___db_e_attach __P ((DB_ENV *));
 int CDB___db_e_detach __P ((DB_ENV *, int));
 int CDB___db_e_remove __P ((DB_ENV *, int));

--- a/db/env_method.c
+++ b/db/env_method.c
@@ -52,8 +52,8 @@ static void CDB___dbenv_set_paniccall
 __P ((DB_ENV *, void (*)(DB_ENV *, int)));
 static int CDB___dbenv_set_recovery_init __P ((DB_ENV *, int (*)(DB_ENV *)));
 static int CDB___dbenv_set_region_init __P ((DB_ENV *, int));
-static int CDB___dbenv_set_tas_spins __P ((DB_ENV *, u_int32_t));
-static int CDB___dbenv_set_verbose __P ((DB_ENV *, u_int32_t, int));
+static int CDB___dbenv_set_tas_spins __P ((DB_ENV *, uint32_t));
+static int CDB___dbenv_set_verbose __P ((DB_ENV *, uint32_t, int));
 
 /*
  * CDB_db_env_create --
@@ -62,7 +62,7 @@ static int CDB___dbenv_set_verbose __P ((DB_ENV *, u_int32_t, int));
 int
 CDB_db_env_create (dbenvpp, flags)
      DB_ENV **dbenvpp;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB_ENV *dbenv;
   int ret;
@@ -277,7 +277,7 @@ CDB___dbenv_set_region_init (dbenv, onoff)
 static int
 CDB___dbenv_set_tas_spins (dbenv, tas_spins)
      DB_ENV *dbenv;
-     u_int32_t tas_spins;
+     uint32_t tas_spins;
 {
   COMPQUIET (dbenv, NULL);
 
@@ -288,7 +288,7 @@ CDB___dbenv_set_tas_spins (dbenv, tas_spins)
 static int
 CDB___dbenv_set_verbose (dbenv, which, onoff)
      DB_ENV *dbenv;
-     u_int32_t which;
+     uint32_t which;
      int onoff;
 {
   switch (which)

--- a/db/env_open.c
+++ b/db/env_open.c
@@ -40,11 +40,11 @@ static const char sccsid[] = "@(#)env_open.c  11.8 (Sleepycat) 11/10/99";
 #include "txn.h"
 
 static int CDB___dbenv_config
-__P ((DB_ENV *, const char *, char *const *, u_int32_t));
+__P ((DB_ENV *, const char *, char *const *, uint32_t));
 static int CDB___dbenv_refresh __P ((DB_ENV *));
-static int CDB___db_home __P ((DB_ENV *, const char *, u_int32_t));
+static int CDB___db_home __P ((DB_ENV *, const char *, uint32_t));
 static int CDB___db_parse __P ((DB_ENV *, char *));
-static int CDB___db_tmp_open __P ((DB_ENV *, u_int32_t, char *, DB_FH *));
+static int CDB___db_tmp_open __P ((DB_ENV *, uint32_t, char *, DB_FH *));
 
 /*
  * CDB_db_version --
@@ -68,14 +68,14 @@ CDB_db_version (majverp, minverp, patchp)
  *  Initialize an environment.
  *
  * PUBLIC: int CDB___dbenv_open __P((DB_ENV *,
- * PUBLIC:     const char *, char * const *, u_int32_t, int));
+ * PUBLIC:     const char *, char * const *, uint32_t, int));
  */
 int
 CDB___dbenv_open (dbenv, db_home, db_config, flags, mode)
      DB_ENV *dbenv;
      const char *db_home;
      char *const *db_config;
-     u_int32_t flags;
+     uint32_t flags;
      int mode;
 {
   DB_ENV *rm_dbenv;
@@ -241,14 +241,14 @@ err:(void) CDB___dbenv_refresh (dbenv);
  *  Discard an environment.
  *
  * PUBLIC: int CDB___dbenv_remove __P((DB_ENV *,
- * PUBLIC:     const char *, char * const *, u_int32_t));
+ * PUBLIC:     const char *, char * const *, uint32_t));
  */
 int
 CDB___dbenv_remove (dbenv, db_home, db_config, flags)
      DB_ENV *dbenv;
      const char *db_home;
      char *const *db_config;
-     u_int32_t flags;
+     uint32_t flags;
 {
   int ret, t_ret;
 
@@ -286,7 +286,7 @@ CDB___dbenv_config (dbenv, db_home, db_config, flags)
      DB_ENV *dbenv;
      const char *db_home;
      char *const *db_config;
-     u_int32_t flags;
+     uint32_t flags;
 {
   FILE *fp;
   int ret;
@@ -373,12 +373,12 @@ CDB___dbenv_config (dbenv, db_home, db_config, flags)
  * CDB___dbenv_close --
  *  DB_ENV destructor.
  *
- * PUBLIC: int CDB___dbenv_close __P((DB_ENV *, u_int32_t));
+ * PUBLIC: int CDB___dbenv_close __P((DB_ENV *, uint32_t));
  */
 int
 CDB___dbenv_close (dbenv, flags)
      DB_ENV *dbenv;
-     u_int32_t flags;
+     uint32_t flags;
 {
   int ret;
 
@@ -533,14 +533,14 @@ CDB___dbenv_refresh (dbenv)
  *  it in allocated space.
  *
  * PUBLIC: int CDB___db_appname __P((DB_ENV *, APPNAME,
- * PUBLIC:    const char *, const char *, u_int32_t, DB_FH *, char **));
+ * PUBLIC:    const char *, const char *, uint32_t, DB_FH *, char **));
  */
 int
 CDB___db_appname (dbenv, appname, dir, file, tmp_oflags, fhp, namep)
      DB_ENV *dbenv;
      APPNAME appname;
      const char *dir, *file;
-     u_int32_t tmp_oflags;
+     uint32_t tmp_oflags;
      DB_FH *fhp;
      char **namep;
 {
@@ -758,7 +758,7 @@ static int
 CDB___db_home (dbenv, db_home, flags)
      DB_ENV *dbenv;
      const char *db_home;
-     u_int32_t flags;
+     uint32_t flags;
 {
   const char *p;
 
@@ -884,7 +884,7 @@ err:                           /*
 static int
 CDB___db_tmp_open (dbenv, tmp_oflags, path, fhp)
      DB_ENV *dbenv;
-     u_int32_t tmp_oflags;
+     uint32_t tmp_oflags;
      char *path;
      DB_FH *fhp;
 {

--- a/db/env_recover.c
+++ b/db/env_recover.c
@@ -38,18 +38,18 @@ static const char sccsid[] = "@(#)env_recover.c  11.6 (Sleepycat) 10/1/99";
 #include "txn.h"
 
 static float CDB___lsn_diff
-__P ((DB_LSN *, DB_LSN *, DB_LSN *, u_int32_t, int));
+__P ((DB_LSN *, DB_LSN *, DB_LSN *, uint32_t, int));
 
 /*
  * CDB___db_apprec --
  *  Perform recovery.
  *
- * PUBLIC: int CDB___db_apprec __P((DB_ENV *, u_int32_t));
+ * PUBLIC: int CDB___db_apprec __P((DB_ENV *, uint32_t));
  */
 int
 CDB___db_apprec (dbenv, flags)
      DB_ENV *dbenv;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DBT data;
   DB_LSN ckp_lsn, first_lsn, last_lsn, lsn, open_lsn;
@@ -282,7 +282,7 @@ CDB___db_apprec (dbenv, flags)
   (void) time (&now);
   region = ((DB_TXNMGR *) dbenv->tx_handle)->reginfo.primary;
   region->last_ckp = ckp_lsn;
-  region->time_ckp = (u_int32_t) now;
+  region->time_ckp = (uint32_t) now;
   if ((ret = CDB_txn_checkpoint (dbenv, 0, 0)) != 0)
     goto out;
   region->last_txnid = TXN_MINIMUM;
@@ -322,7 +322,7 @@ out:if (is_thread)
 static float
 CDB___lsn_diff (low, high, current, max, is_forward)
      DB_LSN *low, *high, *current;
-     u_int32_t max;
+     uint32_t max;
      int is_forward;
 {
   float nf;

--- a/db/env_region.c
+++ b/db/env_region.c
@@ -48,7 +48,7 @@ CDB___db_e_attach (dbenv)
   REGION *rp, tregion;
   size_t size;
   ssize_t nrw;
-  u_int32_t mbytes, bytes;
+  uint32_t mbytes, bytes;
   int retry_cnt, ret, segid;
   char buf[sizeof (DB_REGION_FMT) + 20];
 
@@ -241,7 +241,7 @@ loop:renv = NULL;
    * as well, but that should be fine.
    */
   infop->primary = R_ADDR (infop, 0);
-  infop->addr = (u_int8_t *) infop->addr + sizeof (REGENV);
+  infop->addr = (uint8_t *) infop->addr + sizeof (REGENV);
 
   /*
    * Check if the environment has had a catastrophic failure.
@@ -364,7 +364,7 @@ creation:
    * shifted as well, but that should be fine.
    */
   infop->primary = R_ADDR (infop, 0);
-  infop->addr = (u_int8_t *) infop->addr + sizeof (REGENV);
+  infop->addr = (uint8_t *) infop->addr + sizeof (REGENV);
   CDB___db_shalloc_init (infop->addr, tregion.size - sizeof (REGENV));
 
   /*
@@ -712,7 +712,7 @@ CDB___db_e_remfile (dbenv)
     NULL,
   };
   int cnt, fcnt, lastrm, ret;
-  u_int8_t saved_byte;
+  uint8_t saved_byte;
   const char *dir;
   char *p, **names, *path, buf[sizeof (DB_REGION_FMT) + 20];
 
@@ -1111,7 +1111,7 @@ CDB___db_faultmem (addr, size, created)
      int created;
 {
   int ret;
-  u_int8_t *p, *t;
+  uint8_t *p, *t;
 
   /*
    * It's sometimes significantly faster to page-fault in all of the
@@ -1129,10 +1129,10 @@ CDB___db_faultmem (addr, size, created)
   if (DB_GLOBAL (db_region_init))
   {
     if (created)
-      for (p = addr, t = (u_int8_t *) addr + size; p < t; p += OS_VMPAGESIZE)
+      for (p = addr, t = (uint8_t *) addr + size; p < t; p += OS_VMPAGESIZE)
         p[0] = 0xdb;
     else
-      for (p = addr, t = (u_int8_t *) addr + size; p < t; p += OS_VMPAGESIZE)
+      for (p = addr, t = (uint8_t *) addr + size; p < t; p += OS_VMPAGESIZE)
         ret |= p[0];
   }
 

--- a/db/hash.c
+++ b/db/hash.c
@@ -67,18 +67,18 @@ static const char sccsid[] = "@(#)hash.c  11.29 (Sleepycat) 11/14/99";
 #include "txn.h"
 
 static int CDB___ham_c_close __P ((DBC *));
-static int CDB___ham_c_del __P ((DBC *, u_int32_t));
+static int CDB___ham_c_del __P ((DBC *, uint32_t));
 static int CDB___ham_c_destroy __P ((DBC *));
-static int CDB___ham_c_get __P ((DBC *, DBT *, DBT *, u_int32_t));
-static int CDB___ham_c_put __P ((DBC *, DBT *, DBT *, u_int32_t));
-static int CDB___ham_delete __P ((DB *, DB_TXN *, DBT *, u_int32_t));
-static int CDB___ham_dup_return __P ((DBC *, DBT *, u_int32_t));
+static int CDB___ham_c_get __P ((DBC *, DBT *, DBT *, uint32_t));
+static int CDB___ham_c_put __P ((DBC *, DBT *, DBT *, uint32_t));
+static int CDB___ham_delete __P ((DB *, DB_TXN *, DBT *, uint32_t));
+static int CDB___ham_dup_return __P ((DBC *, DBT *, uint32_t));
 static int CDB___ham_expand_table __P ((DBC *));
 static int CDB___ham_init_htab __P ((DBC *,
-                                     const char *, db_pgno_t, u_int32_t,
-                                     u_int32_t));
+                                     const char *, db_pgno_t, uint32_t,
+                                     uint32_t));
 static int CDB___ham_lookup
-__P ((DBC *, const DBT *, u_int32_t, db_lockmode_t));
+__P ((DBC *, const DBT *, uint32_t, db_lockmode_t));
 static int CDB___ham_overwrite __P ((DBC *, DBT *));
 
 /*
@@ -93,7 +93,7 @@ CDB___ham_metachk (dbp, name, hashm)
      HMETA *hashm;
 {
   DB_ENV *dbenv;
-  u_int32_t vers;
+  uint32_t vers;
   int ret;
 
   dbenv = dbp->dbenv;
@@ -288,7 +288,7 @@ CDB___ham_init_htab (dbc, name, pgno, nelem, ffactor)
      DBC *dbc;
      const char *name;
      db_pgno_t pgno;
-     u_int32_t nelem, ffactor;
+     uint32_t nelem, ffactor;
 {
   DB *dbp;
   DB_LOCK metalock;
@@ -429,7 +429,7 @@ CDB___ham_delete (dbp, txn, key, flags)
      DB *dbp;
      DB_TXN *txn;
      DBT *key;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DBC *dbc;
   HASH_CURSOR *hcp;
@@ -542,7 +542,7 @@ CDB___ham_c_destroy (dbc)
 static int
 CDB___ham_c_del (dbc, flags)
      DBC *dbc;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB *dbp;
   DBT repldbt;
@@ -763,7 +763,7 @@ CDB___ham_c_get (dbc, key, data, flags)
      DBC *dbc;
      DBT *key;
      DBT *data;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB *dbp;
   HASH_CURSOR *hcp, save_curs;
@@ -943,12 +943,12 @@ CDB___ham_c_put (dbc, key, data, flags)
      DBC *dbc;
      DBT *key;
      DBT *data;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB *dbp;
   DBT tmp_val, *myval;
   HASH_CURSOR *hcp, save_curs;
-  u_int32_t nbytes;
+  uint32_t nbytes;
   int ret, t_ret;
 
   /*
@@ -1033,7 +1033,7 @@ CDB___ham_c_put (dbc, key, data, flags)
                                        &dbc->rdata.size)) == 0)
         {
           memset (tmp_val.data, 0, data->doff);
-          memcpy ((u_int8_t *) tmp_val.data +
+          memcpy ((uint8_t *) tmp_val.data +
                   data->doff, data->data, data->size);
           myval = &tmp_val;
         }
@@ -1097,7 +1097,7 @@ CDB___ham_expand_table (dbc)
   PAGE *h;
   HASH_CURSOR *hcp;
   db_pgno_t pgno;
-  u_int32_t old_bucket, new_bucket;
+  uint32_t old_bucket, new_bucket;
   int ret;
 
   dbp = dbc->dbp;
@@ -1194,19 +1194,19 @@ CDB___ham_expand_table (dbc)
 }
 
 /*
- * PUBLIC: u_int32_t CDB___ham_call_hash __P((HASH_CURSOR *, u_int8_t *, int32_t));
+ * PUBLIC: uint32_t CDB___ham_call_hash __P((HASH_CURSOR *, uint8_t *, int32_t));
  */
-u_int32_t
+uint32_t
 CDB___ham_call_hash (hcp, k, len)
      HASH_CURSOR *hcp;
-     u_int8_t *k;
+     uint8_t *k;
      int32_t len;
 {
-  u_int32_t n, bucket;
+  uint32_t n, bucket;
   HASH *hashp;
 
   hashp = hcp->dbc->dbp->h_internal;
-  n = (u_int32_t) (hashp->h_hash (k, len));
+  n = (uint32_t) (hashp->h_hash (k, len));
 
   bucket = n & hcp->hdr->high_mask;
   if (bucket > hcp->hdr->max_bucket)
@@ -1222,7 +1222,7 @@ static int
 CDB___ham_dup_return (dbc, val, flags)
      DBC *dbc;
      DBT *val;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB *dbp;
   HASH_CURSOR *hcp;
@@ -1230,8 +1230,8 @@ CDB___ham_dup_return (dbc, val, flags)
   DBT *myval, tmp_val;
   db_indx_t ndx;
   db_pgno_t pgno;
-  u_int32_t off, tlen;
-  u_int8_t *hk, type;
+  uint32_t off, tlen;
+  uint8_t *hk, type;
   int cmp, ret;
   db_indx_t len;
 
@@ -1340,7 +1340,7 @@ CDB___ham_dup_return (dbc, val, flags)
       hk = H_PAIRDATA (hcp->pagep, hcp->bndx);
       if (((HKEYDATA *) hk)->type == H_OFFPAGE)
       {
-        memcpy (&tlen, HOFFPAGE_TLEN (hk), sizeof (u_int32_t));
+        memcpy (&tlen, HOFFPAGE_TLEN (hk), sizeof (uint32_t));
         memcpy (&pgno, HOFFPAGE_PGNO (hk), sizeof (db_pgno_t));
         if ((ret = CDB___db_moff (dbp, val,
                                   pgno, tlen, dbp->dup_compare, &cmp)) != 0)
@@ -1437,8 +1437,8 @@ CDB___ham_overwrite (dbc, nval)
   HASH_CURSOR *hcp;
   DBT *myval, tmp_val, tmp_val2;
   void *newrec;
-  u_int8_t *hk, *p;
-  u_int32_t len, nondup_size;
+  uint8_t *hk, *p;
+  uint32_t len, nondup_size;
   db_pgno_t prev;
   db_indx_t newsize, dndx;
   int ret;
@@ -1593,7 +1593,7 @@ CDB___ham_overwrite (dbc, nval)
       if (nval->doff + nval->dlen < tmp_val.size)
       {
         len = tmp_val.size - nval->doff - nval->dlen;
-        memcpy (p, (u_int8_t *) tmp_val.data + nval->doff + nval->dlen, len);
+        memcpy (p, (uint8_t *) tmp_val.data + nval->doff + nval->dlen, len);
         p += len;
       }
 
@@ -1606,7 +1606,7 @@ CDB___ham_overwrite (dbc, nval)
        */
       if (dbc->dbp->dup_compare != NULL)
       {
-        tmp_val2.data = (u_int8_t *) newrec + sizeof (db_indx_t);
+        tmp_val2.data = (uint8_t *) newrec + sizeof (db_indx_t);
         tmp_val2.size = newsize;
         if (dbc->dbp->dup_compare (&tmp_val, &tmp_val2) != 0)
         {
@@ -1681,7 +1681,7 @@ CDB___ham_overwrite (dbc, nval)
     tmp_val.doff = 0;
     hk = H_PAIRDATA (hcp->pagep, hcp->bndx);
     if (HPAGE_PTYPE (hk) == H_OFFPAGE)
-      memcpy (&tmp_val.dlen, HOFFPAGE_TLEN (hk), sizeof (u_int32_t));
+      memcpy (&tmp_val.dlen, HOFFPAGE_TLEN (hk), sizeof (uint32_t));
     else
       tmp_val.dlen = LEN_HDATA (hcp->pagep,
                                 hcp->hdr->dbmeta.pagesize, hcp->bndx);
@@ -1707,15 +1707,15 @@ static int
 CDB___ham_lookup (dbc, key, sought, mode)
      DBC *dbc;
      const DBT *key;
-     u_int32_t sought;
+     uint32_t sought;
      db_lockmode_t mode;
 {
   DB *dbp;
   HASH_CURSOR *hcp;
   db_pgno_t pgno;
-  u_int32_t tlen;
+  uint32_t tlen;
   int match, ret, t_ret;
-  u_int8_t *hk;
+  uint8_t *hk;
 
   dbp = dbc->dbp;
   hcp = (HASH_CURSOR *) dbc->internal;
@@ -1727,7 +1727,7 @@ CDB___ham_lookup (dbc, key, sought, mode)
     return (ret);
   hcp->seek_size = sought;
 
-  hcp->bucket = CDB___ham_call_hash (hcp, (u_int8_t *) key->data, key->size);
+  hcp->bucket = CDB___ham_call_hash (hcp, (uint8_t *) key->data, key->size);
   while (1)
   {
     if ((ret = CDB___ham_item_next (dbc, mode)) != 0)
@@ -1740,7 +1740,7 @@ CDB___ham_lookup (dbc, key, sought, mode)
     switch (HPAGE_PTYPE (hk))
     {
     case H_OFFPAGE:
-      memcpy (&tlen, HOFFPAGE_TLEN (hk), sizeof (u_int32_t));
+      memcpy (&tlen, HOFFPAGE_TLEN (hk), sizeof (uint32_t));
       if (tlen == key->size)
       {
         memcpy (&pgno, HOFFPAGE_PGNO (hk), sizeof (db_pgno_t));
@@ -1789,14 +1789,14 @@ CDB___ham_lookup (dbc, key, sought, mode)
  *  Initialize a dbt using some possibly already allocated storage
  *  for items.
  *
- * PUBLIC: int CDB___ham_init_dbt __P((DBT *, u_int32_t, void **, u_int32_t *));
+ * PUBLIC: int CDB___ham_init_dbt __P((DBT *, uint32_t, void **, uint32_t *));
  */
 int
 CDB___ham_init_dbt (dbt, size, bufp, sizep)
      DBT *dbt;
-     u_int32_t size;
+     uint32_t size;
      void **bufp;
-     u_int32_t *sizep;
+     uint32_t *sizep;
 {
   int ret;
 
@@ -1826,13 +1826,13 @@ CDB___ham_init_dbt (dbt, size, bufp, sizep)
  * dup indicates if the addition occurred into a duplicate set.
  *
  * PUBLIC: void CDB___ham_c_update
- * PUBLIC:    __P((HASH_CURSOR *, db_pgno_t, u_int32_t, int, int));
+ * PUBLIC:    __P((HASH_CURSOR *, db_pgno_t, uint32_t, int, int));
  */
 void
 CDB___ham_c_update (hcp, chg_pgno, len, add, is_dup)
      HASH_CURSOR *hcp;
      db_pgno_t chg_pgno;
-     u_int32_t len;
+     uint32_t len;
      int add, is_dup;
 {
   DB *dbp;
@@ -1958,13 +1958,13 @@ CDB___ham_c_update (hcp, chg_pgno, len, add, is_dup)
  * move items off page.
  *
  * PUBLIC: int CDB___ham_get_clist __P((DB *,
- * PUBLIC:     db_pgno_t, u_int32_t, HASH_CURSOR ***));
+ * PUBLIC:     db_pgno_t, uint32_t, HASH_CURSOR ***));
  */
 int
 CDB___ham_get_clist (dbp, bucket, indx, listp)
      DB *dbp;
      db_pgno_t bucket;
-     u_int32_t indx;
+     uint32_t indx;
      HASH_CURSOR ***listp;
 {
   DBC *cp;

--- a/db/hash.h
+++ b/db/hash.h
@@ -47,10 +47,10 @@ typedef struct hash_t
 {
   DB *dbp;                      /* Pointer to enclosing DB */
   db_pgno_t meta_pgno;          /* Page number of the meta data page. */
-  u_int32_t h_ffactor;          /* Fill factor. */
-  u_int32_t h_nelem;            /* Number of elements. */
+  uint32_t h_ffactor;          /* Fill factor. */
+  uint32_t h_nelem;            /* Number of elements. */
   /* Hash function. */
-    u_int32_t (*h_hash) __P ((const void *, u_int32_t));
+    uint32_t (*h_hash) __P ((const void *, uint32_t));
 } HASH;
 
 /* Cursor structure definitions. */
@@ -77,7 +77,7 @@ typedef struct cursor_t
   db_indx_t dup_off;            /* Offset within a duplicate set. */
   db_indx_t dup_len;            /* Length of current duplicate. */
   db_indx_t dup_tlen;           /* Total length of duplicate entry. */
-  u_int32_t seek_size;          /* Number of bytes we need for add. */
+  uint32_t seek_size;          /* Number of bytes we need for add. */
   db_pgno_t seek_found_page;    /* Page on which we can insert. */
 
 #define  H_DELETED  0x0001      /* Cursor item is deleted. */
@@ -88,7 +88,7 @@ typedef struct cursor_t
 #define  H_OK    0x0020         /* Request succeeded. */
 #define H_DIRTY    0x0040       /* Meta-data page needs to be written */
 #define  H_ORIGINAL  0x0080     /* Bucket lock existed on entry. */
-  u_int32_t flags;
+  uint32_t flags;
 } HASH_CURSOR;
 
 #define  IS_VALID(C) ((C)->bucket != BUCKET_INVALID)

--- a/db/hash_auto.c
+++ b/db/hash_auto.c
@@ -22,21 +22,21 @@ CDB___ham_insdel_log (dbenv, txnid, ret_lsnp, flags,
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
-     u_int32_t opcode;
+     uint32_t flags;
+     uint32_t opcode;
      int32_t fileid;
      db_pgno_t pgno;
-     u_int32_t ndx;
+     uint32_t ndx;
      DB_LSN *pagelsn;
      const DBT *key;
      const DBT *data;
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t zero;
-  u_int32_t rectype, txn_num;
+  uint32_t zero;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -56,8 +56,8 @@ CDB___ham_insdel_log (dbenv, txnid, ret_lsnp, flags,
     + sizeof (pgno)
     + sizeof (ndx)
     + sizeof (*pagelsn)
-    + sizeof (u_int32_t) + (key == NULL ? 0 : key->size)
-    + sizeof (u_int32_t) + (data == NULL ? 0 : data->size);
+    + sizeof (uint32_t) + (key == NULL ? 0 : key->size)
+    + sizeof (uint32_t) + (data == NULL ? 0 : data->size);
   if ((ret = CDB___os_malloc (logrec.size, NULL, &logrec.data)) != 0)
     return (ret);
 
@@ -84,8 +84,8 @@ CDB___ham_insdel_log (dbenv, txnid, ret_lsnp, flags,
   if (key == NULL)
   {
     zero = 0;
-    memcpy (bp, &zero, sizeof (u_int32_t));
-    bp += sizeof (u_int32_t);
+    memcpy (bp, &zero, sizeof (uint32_t));
+    bp += sizeof (uint32_t);
   }
   else
   {
@@ -97,8 +97,8 @@ CDB___ham_insdel_log (dbenv, txnid, ret_lsnp, flags,
   if (data == NULL)
   {
     zero = 0;
-    memcpy (bp, &zero, sizeof (u_int32_t));
-    bp += sizeof (u_int32_t);
+    memcpy (bp, &zero, sizeof (uint32_t));
+    bp += sizeof (uint32_t);
   }
   else
   {
@@ -107,7 +107,7 @@ CDB___ham_insdel_log (dbenv, txnid, ret_lsnp, flags,
     memcpy (bp, data->data, data->size);
     bp += data->size;
   }
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -124,7 +124,7 @@ CDB___ham_insdel_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __ham_insdel_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -151,7 +151,7 @@ CDB___ham_insdel_print (notused1, dbtp, lsnp, notused2, notused3)
   printf ("\tkey: ");
   for (i = 0; i < argp->key.size; i++)
   {
-    ch = ((u_int8_t *) argp->key.data)[i];
+    ch = ((uint8_t *) argp->key.data)[i];
     if (isprint (ch) || ch == 0xa)
       putchar (ch);
     else
@@ -161,7 +161,7 @@ CDB___ham_insdel_print (notused1, dbtp, lsnp, notused2, notused3)
   printf ("\tdata: ");
   for (i = 0; i < argp->data.size; i++)
   {
-    ch = ((u_int8_t *) argp->data.data)[i];
+    ch = ((uint8_t *) argp->data.data)[i];
     if (isprint (ch) || ch == 0xa)
       putchar (ch);
     else
@@ -179,7 +179,7 @@ CDB___ham_insdel_read (recbuf, argpp)
      __ham_insdel_args **argpp;
 {
   __ham_insdel_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__ham_insdel_args) +
@@ -205,13 +205,13 @@ CDB___ham_insdel_read (recbuf, argpp)
   memcpy (&argp->pagelsn, bp, sizeof (argp->pagelsn));
   bp += sizeof (argp->pagelsn);
   memset (&argp->key, 0, sizeof (argp->key));
-  memcpy (&argp->key.size, bp, sizeof (u_int32_t));
-  bp += sizeof (u_int32_t);
+  memcpy (&argp->key.size, bp, sizeof (uint32_t));
+  bp += sizeof (uint32_t);
   argp->key.data = bp;
   bp += argp->key.size;
   memset (&argp->data, 0, sizeof (argp->data));
-  memcpy (&argp->data.size, bp, sizeof (u_int32_t));
-  bp += sizeof (u_int32_t);
+  memcpy (&argp->data.size, bp, sizeof (uint32_t));
+  bp += sizeof (uint32_t);
   argp->data.data = bp;
   bp += argp->data.size;
   *argpp = argp;
@@ -225,8 +225,8 @@ CDB___ham_newpage_log (dbenv, txnid, ret_lsnp, flags,
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
-     u_int32_t opcode;
+     uint32_t flags;
+     uint32_t opcode;
      int32_t fileid;
      db_pgno_t prev_pgno;
      DB_LSN *prevlsn;
@@ -237,9 +237,9 @@ CDB___ham_newpage_log (dbenv, txnid, ret_lsnp, flags,
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t rectype, txn_num;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -295,7 +295,7 @@ CDB___ham_newpage_log (dbenv, txnid, ret_lsnp, flags,
   else
     memset (bp, 0, sizeof (*nextlsn));
   bp += sizeof (*nextlsn);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -312,7 +312,7 @@ CDB___ham_newpage_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __ham_newpage_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -352,7 +352,7 @@ CDB___ham_newpage_read (recbuf, argpp)
      __ham_newpage_args **argpp;
 {
   __ham_newpage_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__ham_newpage_args) +
@@ -393,18 +393,18 @@ CDB___ham_splitmeta_log (dbenv, txnid, ret_lsnp, flags,
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
+     uint32_t flags;
      int32_t fileid;
-     u_int32_t bucket;
-     u_int32_t ovflpoint;
-     u_int32_t spares;
+     uint32_t bucket;
+     uint32_t ovflpoint;
+     uint32_t spares;
      DB_LSN *metalsn;
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t rectype, txn_num;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -445,7 +445,7 @@ CDB___ham_splitmeta_log (dbenv, txnid, ret_lsnp, flags,
   else
     memset (bp, 0, sizeof (*metalsn));
   bp += sizeof (*metalsn);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -462,7 +462,7 @@ CDB___ham_splitmeta_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __ham_splitmeta_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -497,7 +497,7 @@ CDB___ham_splitmeta_read (recbuf, argpp)
      __ham_splitmeta_args **argpp;
 {
   __ham_splitmeta_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__ham_splitmeta_args) +
@@ -532,19 +532,19 @@ CDB___ham_splitdata_log (dbenv, txnid, ret_lsnp, flags,
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
+     uint32_t flags;
      int32_t fileid;
-     u_int32_t opcode;
+     uint32_t opcode;
      db_pgno_t pgno;
      const DBT *pageimage;
      DB_LSN *pagelsn;
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t zero;
-  u_int32_t rectype, txn_num;
+  uint32_t zero;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -562,7 +562,7 @@ CDB___ham_splitdata_log (dbenv, txnid, ret_lsnp, flags,
     + sizeof (fileid)
     + sizeof (opcode)
     + sizeof (pgno)
-    + sizeof (u_int32_t) + (pageimage == NULL ? 0 : pageimage->size)
+    + sizeof (uint32_t) + (pageimage == NULL ? 0 : pageimage->size)
     + sizeof (*pagelsn);
   if ((ret = CDB___os_malloc (logrec.size, NULL, &logrec.data)) != 0)
     return (ret);
@@ -583,8 +583,8 @@ CDB___ham_splitdata_log (dbenv, txnid, ret_lsnp, flags,
   if (pageimage == NULL)
   {
     zero = 0;
-    memcpy (bp, &zero, sizeof (u_int32_t));
-    bp += sizeof (u_int32_t);
+    memcpy (bp, &zero, sizeof (uint32_t));
+    bp += sizeof (uint32_t);
   }
   else
   {
@@ -598,7 +598,7 @@ CDB___ham_splitdata_log (dbenv, txnid, ret_lsnp, flags,
   else
     memset (bp, 0, sizeof (*pagelsn));
   bp += sizeof (*pagelsn);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -615,7 +615,7 @@ CDB___ham_splitdata_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __ham_splitdata_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -639,7 +639,7 @@ CDB___ham_splitdata_print (notused1, dbtp, lsnp, notused2, notused3)
   printf ("\tpageimage: ");
   for (i = 0; i < argp->pageimage.size; i++)
   {
-    ch = ((u_int8_t *) argp->pageimage.data)[i];
+    ch = ((uint8_t *) argp->pageimage.data)[i];
     if (isprint (ch) || ch == 0xa)
       putchar (ch);
     else
@@ -659,7 +659,7 @@ CDB___ham_splitdata_read (recbuf, argpp)
      __ham_splitdata_args **argpp;
 {
   __ham_splitdata_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__ham_splitdata_args) +
@@ -681,8 +681,8 @@ CDB___ham_splitdata_read (recbuf, argpp)
   memcpy (&argp->pgno, bp, sizeof (argp->pgno));
   bp += sizeof (argp->pgno);
   memset (&argp->pageimage, 0, sizeof (argp->pageimage));
-  memcpy (&argp->pageimage.size, bp, sizeof (u_int32_t));
-  bp += sizeof (u_int32_t);
+  memcpy (&argp->pageimage.size, bp, sizeof (uint32_t));
+  bp += sizeof (uint32_t);
   argp->pageimage.data = bp;
   bp += argp->pageimage.size;
   memcpy (&argp->pagelsn, bp, sizeof (argp->pagelsn));
@@ -698,22 +698,22 @@ CDB___ham_replace_log (dbenv, txnid, ret_lsnp, flags,
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
+     uint32_t flags;
      int32_t fileid;
      db_pgno_t pgno;
-     u_int32_t ndx;
+     uint32_t ndx;
      DB_LSN *pagelsn;
      int32_t off;
      const DBT *olditem;
      const DBT *newitem;
-     u_int32_t makedup;
+     uint32_t makedup;
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t zero;
-  u_int32_t rectype, txn_num;
+  uint32_t zero;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -733,8 +733,8 @@ CDB___ham_replace_log (dbenv, txnid, ret_lsnp, flags,
     + sizeof (ndx)
     + sizeof (*pagelsn)
     + sizeof (off)
-    + sizeof (u_int32_t) + (olditem == NULL ? 0 : olditem->size)
-    + sizeof (u_int32_t) + (newitem == NULL ? 0 : newitem->size)
+    + sizeof (uint32_t) + (olditem == NULL ? 0 : olditem->size)
+    + sizeof (uint32_t) + (newitem == NULL ? 0 : newitem->size)
     + sizeof (makedup);
   if ((ret = CDB___os_malloc (logrec.size, NULL, &logrec.data)) != 0)
     return (ret);
@@ -762,8 +762,8 @@ CDB___ham_replace_log (dbenv, txnid, ret_lsnp, flags,
   if (olditem == NULL)
   {
     zero = 0;
-    memcpy (bp, &zero, sizeof (u_int32_t));
-    bp += sizeof (u_int32_t);
+    memcpy (bp, &zero, sizeof (uint32_t));
+    bp += sizeof (uint32_t);
   }
   else
   {
@@ -775,8 +775,8 @@ CDB___ham_replace_log (dbenv, txnid, ret_lsnp, flags,
   if (newitem == NULL)
   {
     zero = 0;
-    memcpy (bp, &zero, sizeof (u_int32_t));
-    bp += sizeof (u_int32_t);
+    memcpy (bp, &zero, sizeof (uint32_t));
+    bp += sizeof (uint32_t);
   }
   else
   {
@@ -787,7 +787,7 @@ CDB___ham_replace_log (dbenv, txnid, ret_lsnp, flags,
   }
   memcpy (bp, &makedup, sizeof (makedup));
   bp += sizeof (makedup);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -804,7 +804,7 @@ CDB___ham_replace_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __ham_replace_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -831,7 +831,7 @@ CDB___ham_replace_print (notused1, dbtp, lsnp, notused2, notused3)
   printf ("\tolditem: ");
   for (i = 0; i < argp->olditem.size; i++)
   {
-    ch = ((u_int8_t *) argp->olditem.data)[i];
+    ch = ((uint8_t *) argp->olditem.data)[i];
     if (isprint (ch) || ch == 0xa)
       putchar (ch);
     else
@@ -841,7 +841,7 @@ CDB___ham_replace_print (notused1, dbtp, lsnp, notused2, notused3)
   printf ("\tnewitem: ");
   for (i = 0; i < argp->newitem.size; i++)
   {
-    ch = ((u_int8_t *) argp->newitem.data)[i];
+    ch = ((uint8_t *) argp->newitem.data)[i];
     if (isprint (ch) || ch == 0xa)
       putchar (ch);
     else
@@ -860,7 +860,7 @@ CDB___ham_replace_read (recbuf, argpp)
      __ham_replace_args **argpp;
 {
   __ham_replace_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__ham_replace_args) +
@@ -886,13 +886,13 @@ CDB___ham_replace_read (recbuf, argpp)
   memcpy (&argp->off, bp, sizeof (argp->off));
   bp += sizeof (argp->off);
   memset (&argp->olditem, 0, sizeof (argp->olditem));
-  memcpy (&argp->olditem.size, bp, sizeof (u_int32_t));
-  bp += sizeof (u_int32_t);
+  memcpy (&argp->olditem.size, bp, sizeof (uint32_t));
+  bp += sizeof (uint32_t);
   argp->olditem.data = bp;
   bp += argp->olditem.size;
   memset (&argp->newitem, 0, sizeof (argp->newitem));
-  memcpy (&argp->newitem.size, bp, sizeof (u_int32_t));
-  bp += sizeof (u_int32_t);
+  memcpy (&argp->newitem.size, bp, sizeof (uint32_t));
+  bp += sizeof (uint32_t);
   argp->newitem.data = bp;
   bp += argp->newitem.size;
   memcpy (&argp->makedup, bp, sizeof (argp->makedup));
@@ -908,22 +908,22 @@ CDB___ham_newpgno_log (dbenv, txnid, ret_lsnp, flags,
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
-     u_int32_t opcode;
+     uint32_t flags;
+     uint32_t opcode;
      int32_t fileid;
      db_pgno_t pgno;
      db_pgno_t free_pgno;
-     u_int32_t old_type;
+     uint32_t old_type;
      db_pgno_t old_pgno;
-     u_int32_t new_type;
+     uint32_t new_type;
      DB_LSN *pagelsn;
      DB_LSN *metalsn;
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t rectype, txn_num;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -979,7 +979,7 @@ CDB___ham_newpgno_log (dbenv, txnid, ret_lsnp, flags,
   else
     memset (bp, 0, sizeof (*metalsn));
   bp += sizeof (*metalsn);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -996,7 +996,7 @@ CDB___ham_newpgno_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __ham_newpgno_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -1036,7 +1036,7 @@ CDB___ham_newpgno_read (recbuf, argpp)
      __ham_newpgno_args **argpp;
 {
   __ham_newpgno_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__ham_newpgno_args) +
@@ -1079,19 +1079,19 @@ CDB___ham_ovfl_log (dbenv, txnid, ret_lsnp, flags,
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
+     uint32_t flags;
      int32_t fileid;
      db_pgno_t start_pgno;
-     u_int32_t npages;
+     uint32_t npages;
      db_pgno_t free_pgno;
-     u_int32_t ovflpoint;
+     uint32_t ovflpoint;
      DB_LSN *metalsn;
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t rectype, txn_num;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -1135,7 +1135,7 @@ CDB___ham_ovfl_log (dbenv, txnid, ret_lsnp, flags,
   else
     memset (bp, 0, sizeof (*metalsn));
   bp += sizeof (*metalsn);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -1152,7 +1152,7 @@ CDB___ham_ovfl_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __ham_ovfl_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -1188,7 +1188,7 @@ CDB___ham_ovfl_read (recbuf, argpp)
      __ham_ovfl_args **argpp;
 {
   __ham_ovfl_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__ham_ovfl_args) +
@@ -1226,7 +1226,7 @@ CDB___ham_copypage_log (dbenv, txnid, ret_lsnp, flags,
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
+     uint32_t flags;
      int32_t fileid;
      db_pgno_t pgno;
      DB_LSN *pagelsn;
@@ -1238,10 +1238,10 @@ CDB___ham_copypage_log (dbenv, txnid, ret_lsnp, flags,
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t zero;
-  u_int32_t rectype, txn_num;
+  uint32_t zero;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -1263,7 +1263,7 @@ CDB___ham_copypage_log (dbenv, txnid, ret_lsnp, flags,
     + sizeof (*nextlsn)
     + sizeof (nnext_pgno)
     + sizeof (*nnextlsn)
-    + sizeof (u_int32_t) + (page == NULL ? 0 : page->size);
+    + sizeof (uint32_t) + (page == NULL ? 0 : page->size);
   if ((ret = CDB___os_malloc (logrec.size, NULL, &logrec.data)) != 0)
     return (ret);
 
@@ -1300,8 +1300,8 @@ CDB___ham_copypage_log (dbenv, txnid, ret_lsnp, flags,
   if (page == NULL)
   {
     zero = 0;
-    memcpy (bp, &zero, sizeof (u_int32_t));
-    bp += sizeof (u_int32_t);
+    memcpy (bp, &zero, sizeof (uint32_t));
+    bp += sizeof (uint32_t);
   }
   else
   {
@@ -1310,7 +1310,7 @@ CDB___ham_copypage_log (dbenv, txnid, ret_lsnp, flags,
     memcpy (bp, page->data, page->size);
     bp += page->size;
   }
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -1327,7 +1327,7 @@ CDB___ham_copypage_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __ham_copypage_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -1358,7 +1358,7 @@ CDB___ham_copypage_print (notused1, dbtp, lsnp, notused2, notused3)
   printf ("\tpage: ");
   for (i = 0; i < argp->page.size; i++)
   {
-    ch = ((u_int8_t *) argp->page.data)[i];
+    ch = ((uint8_t *) argp->page.data)[i];
     if (isprint (ch) || ch == 0xa)
       putchar (ch);
     else
@@ -1376,7 +1376,7 @@ CDB___ham_copypage_read (recbuf, argpp)
      __ham_copypage_args **argpp;
 {
   __ham_copypage_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__ham_copypage_args) +
@@ -1406,8 +1406,8 @@ CDB___ham_copypage_read (recbuf, argpp)
   memcpy (&argp->nnextlsn, bp, sizeof (argp->nnextlsn));
   bp += sizeof (argp->nnextlsn);
   memset (&argp->page, 0, sizeof (argp->page));
-  memcpy (&argp->page.size, bp, sizeof (u_int32_t));
-  bp += sizeof (u_int32_t);
+  memcpy (&argp->page.size, bp, sizeof (uint32_t));
+  bp += sizeof (uint32_t);
   argp->page.data = bp;
   bp += argp->page.size;
   *argpp = argp;
@@ -1420,18 +1420,18 @@ CDB___ham_metagroup_log (dbenv, txnid, ret_lsnp, flags,
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
+     uint32_t flags;
      int32_t fileid;
-     u_int32_t bucket;
+     uint32_t bucket;
      db_pgno_t pgno;
      DB_LSN *metalsn;
      DB_LSN *pagelsn;
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t rectype, txn_num;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -1474,7 +1474,7 @@ CDB___ham_metagroup_log (dbenv, txnid, ret_lsnp, flags,
   else
     memset (bp, 0, sizeof (*pagelsn));
   bp += sizeof (*pagelsn);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -1491,7 +1491,7 @@ CDB___ham_metagroup_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __ham_metagroup_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -1527,7 +1527,7 @@ CDB___ham_metagroup_read (recbuf, argpp)
      __ham_metagroup_args **argpp;
 {
   __ham_metagroup_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__ham_metagroup_args) +
@@ -1562,19 +1562,19 @@ CDB___ham_groupalloc_log (dbenv, txnid, ret_lsnp, flags,
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
+     uint32_t flags;
      int32_t fileid;
      db_pgno_t pgno;
      DB_LSN *metalsn;
      DB_LSN *mmetalsn;
      db_pgno_t start_pgno;
-     u_int32_t num;
+     uint32_t num;
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t rectype, txn_num;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -1621,7 +1621,7 @@ CDB___ham_groupalloc_log (dbenv, txnid, ret_lsnp, flags,
   bp += sizeof (start_pgno);
   memcpy (bp, &num, sizeof (num));
   bp += sizeof (num);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -1638,7 +1638,7 @@ CDB___ham_groupalloc_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __ham_groupalloc_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -1675,7 +1675,7 @@ CDB___ham_groupalloc_read (recbuf, argpp)
      __ham_groupalloc_args **argpp;
 {
   __ham_groupalloc_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__ham_groupalloc_args) +

--- a/db/hash_auto.h
+++ b/db/hash_auto.h
@@ -7,21 +7,21 @@
 
 typedef struct _ham_insdel_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
-  u_int32_t opcode;
+  uint32_t opcode;
   int32_t fileid;
   db_pgno_t pgno;
-  u_int32_t ndx;
+  uint32_t ndx;
   DB_LSN pagelsn;
   DBT key;
   DBT data;
 } __ham_insdel_args;
 
 int CDB___ham_insdel_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, u_int32_t, int32_t, db_pgno_t,
-      u_int32_t, DB_LSN *, const DBT *, const DBT *));
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, uint32_t, int32_t, db_pgno_t,
+      uint32_t, DB_LSN *, const DBT *, const DBT *));
 int CDB___ham_insdel_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___ham_insdel_read __P ((void *, __ham_insdel_args **));
 
@@ -29,10 +29,10 @@ int CDB___ham_insdel_read __P ((void *, __ham_insdel_args **));
 
 typedef struct _ham_newpage_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
-  u_int32_t opcode;
+  uint32_t opcode;
   int32_t fileid;
   db_pgno_t prev_pgno;
   DB_LSN prevlsn;
@@ -43,7 +43,7 @@ typedef struct _ham_newpage_args
 } __ham_newpage_args;
 
 int CDB___ham_newpage_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, u_int32_t, int32_t, db_pgno_t,
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, uint32_t, int32_t, db_pgno_t,
       DB_LSN *, db_pgno_t, DB_LSN *, db_pgno_t, DB_LSN *));
 int CDB___ham_newpage_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___ham_newpage_read __P ((void *, __ham_newpage_args **));
@@ -52,19 +52,19 @@ int CDB___ham_newpage_read __P ((void *, __ham_newpage_args **));
 
 typedef struct _ham_splitmeta_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
   int32_t fileid;
-  u_int32_t bucket;
-  u_int32_t ovflpoint;
-  u_int32_t spares;
+  uint32_t bucket;
+  uint32_t ovflpoint;
+  uint32_t spares;
   DB_LSN metalsn;
 } __ham_splitmeta_args;
 
 int CDB___ham_splitmeta_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, int32_t, u_int32_t, u_int32_t,
-      u_int32_t, DB_LSN *));
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, int32_t, uint32_t, uint32_t,
+      uint32_t, DB_LSN *));
 int CDB___ham_splitmeta_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___ham_splitmeta_read __P ((void *, __ham_splitmeta_args **));
 
@@ -72,18 +72,18 @@ int CDB___ham_splitmeta_read __P ((void *, __ham_splitmeta_args **));
 
 typedef struct _ham_splitdata_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
   int32_t fileid;
-  u_int32_t opcode;
+  uint32_t opcode;
   db_pgno_t pgno;
   DBT pageimage;
   DB_LSN pagelsn;
 } __ham_splitdata_args;
 
 int CDB___ham_splitdata_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, int32_t, u_int32_t, db_pgno_t,
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, int32_t, uint32_t, db_pgno_t,
       const DBT *, DB_LSN *));
 int CDB___ham_splitdata_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___ham_splitdata_read __P ((void *, __ham_splitdata_args **));
@@ -92,22 +92,22 @@ int CDB___ham_splitdata_read __P ((void *, __ham_splitdata_args **));
 
 typedef struct _ham_replace_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
   int32_t fileid;
   db_pgno_t pgno;
-  u_int32_t ndx;
+  uint32_t ndx;
   DB_LSN pagelsn;
   int32_t off;
   DBT olditem;
   DBT newitem;
-  u_int32_t makedup;
+  uint32_t makedup;
 } __ham_replace_args;
 
 int CDB___ham_replace_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, int32_t, db_pgno_t, u_int32_t,
-      DB_LSN *, int32_t, const DBT *, const DBT *, u_int32_t));
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, int32_t, db_pgno_t, uint32_t,
+      DB_LSN *, int32_t, const DBT *, const DBT *, uint32_t));
 int CDB___ham_replace_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___ham_replace_read __P ((void *, __ham_replace_args **));
 
@@ -115,23 +115,23 @@ int CDB___ham_replace_read __P ((void *, __ham_replace_args **));
 
 typedef struct _ham_newpgno_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
-  u_int32_t opcode;
+  uint32_t opcode;
   int32_t fileid;
   db_pgno_t pgno;
   db_pgno_t free_pgno;
-  u_int32_t old_type;
+  uint32_t old_type;
   db_pgno_t old_pgno;
-  u_int32_t new_type;
+  uint32_t new_type;
   DB_LSN pagelsn;
   DB_LSN metalsn;
 } __ham_newpgno_args;
 
 int CDB___ham_newpgno_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, u_int32_t, int32_t, db_pgno_t,
-      db_pgno_t, u_int32_t, db_pgno_t, u_int32_t, DB_LSN *, DB_LSN *));
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, uint32_t, int32_t, db_pgno_t,
+      db_pgno_t, uint32_t, db_pgno_t, uint32_t, DB_LSN *, DB_LSN *));
 int CDB___ham_newpgno_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___ham_newpgno_read __P ((void *, __ham_newpgno_args **));
 
@@ -139,20 +139,20 @@ int CDB___ham_newpgno_read __P ((void *, __ham_newpgno_args **));
 
 typedef struct _ham_ovfl_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
   int32_t fileid;
   db_pgno_t start_pgno;
-  u_int32_t npages;
+  uint32_t npages;
   db_pgno_t free_pgno;
-  u_int32_t ovflpoint;
+  uint32_t ovflpoint;
   DB_LSN metalsn;
 } __ham_ovfl_args;
 
 int CDB___ham_ovfl_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, int32_t, db_pgno_t, u_int32_t,
-      db_pgno_t, u_int32_t, DB_LSN *));
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, int32_t, db_pgno_t, uint32_t,
+      db_pgno_t, uint32_t, DB_LSN *));
 int CDB___ham_ovfl_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___ham_ovfl_read __P ((void *, __ham_ovfl_args **));
 
@@ -160,7 +160,7 @@ int CDB___ham_ovfl_read __P ((void *, __ham_ovfl_args **));
 
 typedef struct _ham_copypage_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
   int32_t fileid;
@@ -174,7 +174,7 @@ typedef struct _ham_copypage_args
 } __ham_copypage_args;
 
 int CDB___ham_copypage_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, int32_t, db_pgno_t, DB_LSN *,
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, int32_t, db_pgno_t, DB_LSN *,
       db_pgno_t, DB_LSN *, db_pgno_t, DB_LSN *, const DBT *));
 int CDB___ham_copypage_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___ham_copypage_read __P ((void *, __ham_copypage_args **));
@@ -183,18 +183,18 @@ int CDB___ham_copypage_read __P ((void *, __ham_copypage_args **));
 
 typedef struct _ham_metagroup_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
   int32_t fileid;
-  u_int32_t bucket;
+  uint32_t bucket;
   db_pgno_t pgno;
   DB_LSN metalsn;
   DB_LSN pagelsn;
 } __ham_metagroup_args;
 
 int CDB___ham_metagroup_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, int32_t, u_int32_t, db_pgno_t,
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, int32_t, uint32_t, db_pgno_t,
       DB_LSN *, DB_LSN *));
 int CDB___ham_metagroup_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___ham_metagroup_read __P ((void *, __ham_metagroup_args **));
@@ -203,7 +203,7 @@ int CDB___ham_metagroup_read __P ((void *, __ham_metagroup_args **));
 
 typedef struct _ham_groupalloc_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
   int32_t fileid;
@@ -211,12 +211,12 @@ typedef struct _ham_groupalloc_args
   DB_LSN metalsn;
   DB_LSN mmetalsn;
   db_pgno_t start_pgno;
-  u_int32_t num;
+  uint32_t num;
 } __ham_groupalloc_args;
 
 int CDB___ham_groupalloc_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, int32_t, db_pgno_t, DB_LSN *,
-      DB_LSN *, db_pgno_t, u_int32_t));
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, int32_t, db_pgno_t, DB_LSN *,
+      DB_LSN *, db_pgno_t, uint32_t));
 int CDB___ham_groupalloc_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___ham_groupalloc_read __P ((void *, __ham_groupalloc_args **));
 int CDB___ham_init_print __P ((DB_ENV *));

--- a/db/hash_conv.c
+++ b/db/hash_conv.c
@@ -94,12 +94,12 @@ int
 CDB___ham_mswap (pg)
      void *pg;
 {
-  u_int8_t *p;
+  uint8_t *p;
   int i;
 
   CDB___db_metaswap (pg);
 
-  p = (u_int8_t *) pg + sizeof (DBMETA);
+  p = (uint8_t *) pg + sizeof (DBMETA);
 
   SWAP32 (p);                   /* max_bucket */
   SWAP32 (p);                   /* high_mask */

--- a/db/hash_dup.c
+++ b/db/hash_dup.c
@@ -69,7 +69,7 @@ static const char sccsid[] = "@(#)hash_dup.c  11.17 (Sleepycat) 11/14/99";
 #include "hash.h"
 #include "btree.h"
 
-static int CDB___ham_check_move __P ((DBC *, u_int32_t));
+static int CDB___ham_check_move __P ((DBC *, uint32_t));
 
 /*
  * Called from hash_access to add a duplicate key. nval is the new
@@ -84,21 +84,21 @@ static int CDB___ham_check_move __P ((DBC *, u_int32_t));
  * Case 4: The element is large enough to push the duplicate set onto a
  *     separate page.
  *
- * PUBLIC: int CDB___ham_add_dup __P((DBC *, DBT *, u_int32_t));
+ * PUBLIC: int CDB___ham_add_dup __P((DBC *, DBT *, uint32_t));
  */
 int
 CDB___ham_add_dup (dbc, nval, flags)
      DBC *dbc;
      DBT *nval;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB *dbp;
   HASH_CURSOR *hcp;
   DBT pval, tmp_val;
-  u_int32_t add_bytes, new_size;
+  uint32_t add_bytes, new_size;
   db_indx_t dndx;
   int cmp, ret;
-  u_int8_t *hk;
+  uint8_t *hk;
 
   dbp = dbc->dbp;
   hcp = (HASH_CURSOR *) dbc->internal;
@@ -302,7 +302,7 @@ CDB___ham_dup_convert (dbc)
   HOFFPAGE ho;
   db_indx_t dndx, i, len, off;
   int c, ret;
-  u_int8_t *p, *pend;
+  uint8_t *p, *pend;
 
   /*
    * Create a new page for the duplicates.
@@ -326,7 +326,7 @@ CDB___ham_dup_convert (dbc)
     dbt.size = LEN_HDATA (hcp->pagep, dbp->pgsize, hcp->bndx);
     dbt.data = HKEYDATA_DATA (H_PAIRDATA (hcp->pagep, hcp->bndx));
     ret = CDB___db_pitem (dbc, hcp->dpagep,
-                          (u_int32_t) dndx, BKEYDATA_SIZE (dbt.size), NULL,
+                          (uint32_t) dndx, BKEYDATA_SIZE (dbt.size), NULL,
                           &dbt);
     if (ret == 0)
       CDB___ham_dirty_page (dbp, hcp->dpagep);
@@ -344,7 +344,7 @@ CDB___ham_dup_convert (dbc)
     dbt.data = &bo;
 
     ret = CDB___db_pitem (dbc, hcp->dpagep,
-                          (u_int32_t) dndx, dbt.size, &dbt, NULL);
+                          (uint32_t) dndx, dbt.size, &dbt, NULL);
     if (ret == 0)
       CDB___ham_dirty_page (dbp, hcp->dpagep);
     break;
@@ -402,7 +402,7 @@ CDB___ham_dup_convert (dbc)
      * the old duplicate item.
      */
     CDB___ham_move_offpage (dbc, hcp->pagep,
-                            (u_int32_t) H_DATAINDEX (hcp->bndx), hcp->dpgno);
+                            (uint32_t) H_DATAINDEX (hcp->bndx), hcp->dpgno);
 
     /* Can probably just do a "put" here. */
     ret = CDB___ham_dirty_page (dbp, hcp->pagep);
@@ -423,18 +423,18 @@ CDB___ham_dup_convert (dbc)
  * information set appropriately. If the incoming dbt is a partial, assume
  * we are creating a new entry and make sure that we do any initial padding.
  *
- * PUBLIC: int CDB___ham_make_dup __P((const DBT *, DBT *d, void **, u_int32_t *));
+ * PUBLIC: int CDB___ham_make_dup __P((const DBT *, DBT *d, void **, uint32_t *));
  */
 int
 CDB___ham_make_dup (notdup, duplicate, bufp, sizep)
      const DBT *notdup;
      DBT *duplicate;
      void **bufp;
-     u_int32_t *sizep;
+     uint32_t *sizep;
 {
   db_indx_t tsize, item_size;
   int ret;
-  u_int8_t *p;
+  uint8_t *p;
 
   item_size = (db_indx_t) notdup->size;
   if (F_ISSET (notdup, DB_DBT_PARTIAL))
@@ -475,7 +475,7 @@ CDB___ham_make_dup (notdup, duplicate, bufp, sizep)
 static int
 CDB___ham_check_move (dbc, add_len)
      DBC *dbc;
-     u_int32_t add_len;
+     uint32_t add_len;
 {
   DB *dbp;
   HASH_CURSOR *hcp;
@@ -483,8 +483,8 @@ CDB___ham_check_move (dbc, add_len)
   DB_LSN new_lsn;
   PAGE *next_pagep;
   db_pgno_t next_pgno;
-  u_int32_t new_datalen, old_len, rectype;
-  u_int8_t *hk;
+  uint32_t new_datalen, old_len, rectype;
+  uint8_t *hk;
   int ret;
 
   dbp = dbc->dbp;
@@ -595,7 +595,7 @@ CDB___ham_check_move (dbc, add_len)
     if ((ret = CDB___ham_insdel_log (dbp->dbenv,
                                      dbc->txn, &new_lsn, 0, rectype,
                                      dbp->log_fileid, PGNO (next_pagep),
-                                     (u_int32_t) H_NUMPAIRS (next_pagep),
+                                     (uint32_t) H_NUMPAIRS (next_pagep),
                                      &LSN (next_pagep), &k, &d)) != 0)
       return (ret);
 
@@ -636,13 +636,13 @@ CDB___ham_check_move (dbc, add_len)
  * This is really just a special case of __onpage_replace; we should
  * probably combine them.
  *
- * PUBLIC: void CDB___ham_move_offpage __P((DBC *, PAGE *, u_int32_t, db_pgno_t));
+ * PUBLIC: void CDB___ham_move_offpage __P((DBC *, PAGE *, uint32_t, db_pgno_t));
  */
 void
 CDB___ham_move_offpage (dbc, pagep, ndx, pgno)
      DBC *dbc;
      PAGE *pagep;
-     u_int32_t ndx;
+     uint32_t ndx;
      db_pgno_t pgno;
 {
   DB *dbp;
@@ -652,7 +652,7 @@ CDB___ham_move_offpage (dbc, pagep, ndx, pgno)
   HOFFDUP od;
   db_indx_t i;
   int32_t shrink;
-  u_int8_t *src;
+  uint8_t *src;
 
   dbp = dbc->dbp;
   hcp = (HASH_CURSOR *) dbc->internal;
@@ -670,7 +670,7 @@ CDB___ham_move_offpage (dbc, pagep, ndx, pgno)
     old_dbt.size = LEN_HITEM (pagep, dbp->pgsize, ndx);
     (void) CDB___ham_replace_log (dbp->dbenv,
                                   dbc->txn, &LSN (pagep), 0, dbp->log_fileid,
-                                  PGNO (pagep), (u_int32_t) ndx, &LSN (pagep),
+                                  PGNO (pagep), (uint32_t) ndx, &LSN (pagep),
                                   -1, &old_dbt, &new_dbt, 0);
   }
 
@@ -679,7 +679,7 @@ CDB___ham_move_offpage (dbc, pagep, ndx, pgno)
   if (shrink != 0)
   {
     /* Copy data. */
-    src = (u_int8_t *) (pagep) + HOFFSET (pagep);
+    src = (uint8_t *) (pagep) + HOFFSET (pagep);
     memmove (src + shrink, src, pagep->inp[ndx] - HOFFSET (pagep));
     HOFFSET (pagep) += shrink;
 
@@ -697,13 +697,13 @@ CDB___ham_move_offpage (dbc, pagep, ndx, pgno)
  *  Locate a particular duplicate in a duplicate set.  Make sure that
  *  we exit with the cursor set appropriately.
  *
- * PUBLIC: void CDB___ham_dsearch __P((DBC *, DBT *, u_int32_t *, int *));
+ * PUBLIC: void CDB___ham_dsearch __P((DBC *, DBT *, uint32_t *, int *));
  */
 void
 CDB___ham_dsearch (dbc, dbt, offp, cmpp)
      DBC *dbc;
      DBT *dbt;
-     u_int32_t *offp;
+     uint32_t *offp;
      int *cmpp;
 {
   DB *dbp;
@@ -711,7 +711,7 @@ CDB___ham_dsearch (dbc, dbt, offp, cmpp)
   DBT cur;
   db_indx_t i, len;
   int (*func) __P ((const DBT *, const DBT *));
-  u_int8_t *data;
+  uint8_t *data;
 
   dbp = dbc->dbp;
   hcp = (HASH_CURSOR *) dbc->internal;
@@ -728,7 +728,7 @@ CDB___ham_dsearch (dbc, dbt, offp, cmpp)
     memcpy (&len, data, sizeof (db_indx_t));
     data += sizeof (db_indx_t);
     cur.data = data;
-    cur.size = (u_int32_t) len;
+    cur.size = (uint32_t) len;
     *cmpp = func (dbt, &cur);
     if (*cmpp == 0 || (*cmpp < 0 && dbp->dup_compare != NULL))
       break;
@@ -746,13 +746,13 @@ CDB___ham_dsearch (dbc, dbt, offp, cmpp)
  *  Adjust the cursors when splitting a page.
  *
  * PUBLIC: void CDB___ham_ca_split __P((DB *,
- * PUBLIC:    db_pgno_t, db_pgno_t, db_pgno_t, u_int32_t, int));
+ * PUBLIC:    db_pgno_t, db_pgno_t, db_pgno_t, uint32_t, int));
  */
 void
 CDB___ham_ca_split (dbp, ppgno, lpgno, rpgno, split_indx, cleft)
      DB *dbp;
      db_pgno_t ppgno, lpgno, rpgno;
-     u_int32_t split_indx;
+     uint32_t split_indx;
      int cleft;
 {
   HASH_CURSOR *hcp;

--- a/db/hash_ext.h
+++ b/db/hash_ext.h
@@ -5,27 +5,27 @@ int CDB___ham_metachk __P ((DB *, const char *, HMETA *));
 int CDB___ham_open __P ((DB *, const char *, db_pgno_t));
 int CDB___ham_c_init __P ((DBC *));
 int CDB___ham_c_dup __P ((DBC *, DBC *));
-u_int32_t CDB___ham_call_hash __P ((HASH_CURSOR *, u_int8_t *, int32_t));
-int CDB___ham_init_dbt __P ((DBT *, u_int32_t, void **, u_int32_t *));
-void CDB___ham_c_update __P ((HASH_CURSOR *, db_pgno_t, u_int32_t, int, int));
-int CDB___ham_get_clist __P ((DB *, db_pgno_t, u_int32_t, HASH_CURSOR ***));
+uint32_t CDB___ham_call_hash __P ((HASH_CURSOR *, uint8_t *, int32_t));
+int CDB___ham_init_dbt __P ((DBT *, uint32_t, void **, uint32_t *));
+void CDB___ham_c_update __P ((HASH_CURSOR *, db_pgno_t, uint32_t, int, int));
+int CDB___ham_get_clist __P ((DB *, db_pgno_t, uint32_t, HASH_CURSOR ***));
 int CDB___ham_init_recover __P ((DB_ENV *));
 int CDB___ham_pgin __P ((db_pgno_t, void *, DBT *));
 int CDB___ham_pgout __P ((db_pgno_t, void *, DBT *));
 int CDB___ham_mswap __P ((void *));
-int CDB___ham_add_dup __P ((DBC *, DBT *, u_int32_t));
+int CDB___ham_add_dup __P ((DBC *, DBT *, uint32_t));
 int CDB___ham_dup_convert __P ((DBC *));
-int CDB___ham_make_dup __P ((const DBT *, DBT * d, void **, u_int32_t *));
-void CDB___ham_move_offpage __P ((DBC *, PAGE *, u_int32_t, db_pgno_t));
-void CDB___ham_dsearch __P ((DBC *, DBT *, u_int32_t *, int *));
+int CDB___ham_make_dup __P ((const DBT *, DBT * d, void **, uint32_t *));
+void CDB___ham_move_offpage __P ((DBC *, PAGE *, uint32_t, db_pgno_t));
+void CDB___ham_dsearch __P ((DBC *, DBT *, uint32_t *, int *));
 void CDB___ham_ca_split __P ((DB *,
-                              db_pgno_t, db_pgno_t, db_pgno_t, u_int32_t,
+                              db_pgno_t, db_pgno_t, db_pgno_t, uint32_t,
                               int));
 int CDB___ham_cprint __P ((DB *));
-u_int32_t CDB___ham_func2 __P ((const void *, u_int32_t));
-u_int32_t CDB___ham_func3 __P ((const void *, u_int32_t));
-u_int32_t CDB___ham_func4 __P ((const void *, u_int32_t));
-u_int32_t CDB___ham_func5 __P ((const void *, u_int32_t));
+uint32_t CDB___ham_func2 __P ((const void *, uint32_t));
+uint32_t CDB___ham_func3 __P ((const void *, uint32_t));
+uint32_t CDB___ham_func4 __P ((const void *, uint32_t));
+uint32_t CDB___ham_func5 __P ((const void *, uint32_t));
 int CDB___ham_get_meta __P ((DBC *));
 int CDB___ham_release_meta __P ((DBC *));
 int CDB___ham_dirty_meta __P ((DBC *));
@@ -41,23 +41,23 @@ int CDB___ham_item_prev __P ((DBC *, db_lockmode_t));
 int CDB___ham_item_next __P ((DBC *, db_lockmode_t));
 void CDB___ham_putitem __P ((PAGE * p, const DBT *, int));
 void CDB___ham_reputpair
-__P ((PAGE * p, u_int32_t, u_int32_t, const DBT *, const DBT *));
+__P ((PAGE * p, uint32_t, uint32_t, const DBT *, const DBT *));
 int CDB___ham_del_pair __P ((DBC *, int));
-int CDB___ham_replpair __P ((DBC *, DBT *, u_int32_t));
-void CDB___ham_onpage_replace __P ((PAGE *, size_t, u_int32_t, int32_t,
+int CDB___ham_replpair __P ((DBC *, DBT *, uint32_t));
+void CDB___ham_onpage_replace __P ((PAGE *, size_t, uint32_t, int32_t,
                                     int32_t, DBT *));
-int CDB___ham_split_page __P ((DBC *, u_int32_t, u_int32_t));
+int CDB___ham_split_page __P ((DBC *, uint32_t, uint32_t));
 int CDB___ham_add_el __P ((DBC *, const DBT *, const DBT *, int));
-void CDB___ham_copy_item __P ((size_t, PAGE *, u_int32_t, PAGE *));
+void CDB___ham_copy_item __P ((size_t, PAGE *, uint32_t, PAGE *));
 int CDB___ham_add_ovflpage __P ((DBC *, PAGE *, int, PAGE **));
 int CDB___ham_put_page __P ((DB *, PAGE *, int32_t));
 int CDB___ham_dirty_page __P ((DB *, PAGE *));
 int CDB___ham_get_page __P ((DB *, db_pgno_t, PAGE **));
 db_pgno_t CDB___bucket_to_page __P ((HASH_CURSOR *, db_pgno_t));
 int CDB___ham_get_cpage __P ((DBC *, db_lockmode_t));
-int CDB___ham_next_cpage __P ((DBC *, db_pgno_t, int, u_int32_t));
+int CDB___ham_next_cpage __P ((DBC *, db_pgno_t, int, uint32_t));
 int CDB___ham_lock_bucket __P ((DBC *, db_lockmode_t));
-void CDB___ham_dpair __P ((DB *, PAGE *, u_int32_t));
+void CDB___ham_dpair __P ((DB *, PAGE *, uint32_t));
 int CDB___ham_insdel_recover __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___ham_newpage_recover __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___ham_replace_recover __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
@@ -73,7 +73,7 @@ __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___ham_groupalloc_recover
 __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___ham_reclaim __P ((DB *, DB_TXN * txn));
-int CDB___ham_stat __P ((DB *, void *, void *(*)(size_t), u_int32_t));
+int CDB___ham_stat __P ((DB *, void *, void *(*)(size_t), uint32_t));
 int CDB___ham_traverse __P ((DB *, DBC *, db_lockmode_t,
                              int (*)(DB *, PAGE *, void *, int *), void *));
 int CDB___ham_upgrade __P ((DB *, int, char *, DB_FH *, char *));

--- a/db/hash_func.c
+++ b/db/hash_func.c
@@ -58,18 +58,18 @@ static const char sccsid[] = "@(#)hash_func.c  11.2 (Sleepycat) 9/9/99";
  * CDB___ham_func2 --
  *  Phong Vo's linear congruential hash.
  *
- * PUBLIC: u_int32_t CDB___ham_func2 __P((const void *, u_int32_t));
+ * PUBLIC: uint32_t CDB___ham_func2 __P((const void *, uint32_t));
  */
 #define  DCHARHASH(h, c)  ((h) = 0x63c63cd9*(h) + 0x9c39c33d + (c))
 
-u_int32_t
+uint32_t
 CDB___ham_func2 (key, len)
      const void *key;
-     u_int32_t len;
+     uint32_t len;
 {
-  const u_int8_t *e, *k;
-  u_int32_t h;
-  u_int8_t c;
+  const uint8_t *e, *k;
+  uint32_t h;
+  uint8_t c;
 
   k = key;
   e = k + len;
@@ -92,15 +92,15 @@ CDB___ham_func2 (key, len)
  * iteration, perform 8 HASHC's so we handle all 8 bytes.  Essentially, this
  * saves us 7 cmp & branch instructions.
  *
- * PUBLIC: u_int32_t CDB___ham_func3 __P((const void *, u_int32_t));
+ * PUBLIC: uint32_t CDB___ham_func3 __P((const void *, uint32_t));
  */
-u_int32_t
+uint32_t
 CDB___ham_func3 (key, len)
      const void *key;
-     u_int32_t len;
+     uint32_t len;
 {
-  const u_int8_t *k;
-  u_int32_t n, loop;
+  const uint8_t *k;
+  uint32_t n, loop;
 
   if (len == 0)
     return (0);
@@ -142,15 +142,15 @@ CDB___ham_func3 (key, len)
  *  slightly worse than CDB___ham_func5 on strings, it performs horribly on
  *  numbers.
  *
- * PUBLIC: u_int32_t CDB___ham_func4 __P((const void *, u_int32_t));
+ * PUBLIC: uint32_t CDB___ham_func4 __P((const void *, uint32_t));
  */
-u_int32_t
+uint32_t
 CDB___ham_func4 (key, len)
      const void *key;
-     u_int32_t len;
+     uint32_t len;
 {
-  const u_int8_t *k;
-  u_int32_t h, loop;
+  const uint8_t *k;
+  uint32_t h, loop;
 
   if (len == 0)
     return (0);
@@ -202,15 +202,15 @@ CDB___ham_func4 (key, len)
  * This hash produces the fewest collisions of any function that we've seen so
  * far, and works well on both numbers and strings.
  *
- * PUBLIC: u_int32_t CDB___ham_func5 __P((const void *, u_int32_t));
+ * PUBLIC: uint32_t CDB___ham_func5 __P((const void *, uint32_t));
  */
-u_int32_t
+uint32_t
 CDB___ham_func5 (key, len)
      const void *key;
-     u_int32_t len;
+     uint32_t len;
 {
-  const u_int8_t *k, *e;
-  u_int32_t h;
+  const uint8_t *k, *e;
+  uint32_t h;
 
   k = key;
   e = k + len;

--- a/db/hash_method.c
+++ b/db/hash_method.c
@@ -19,10 +19,10 @@ static const char sccsid[] = "@(#)hash_method.c  11.3 (Sleepycat) 9/29/99";
 #include "db_page.h"
 #include "hash.h"
 
-static int CDB___ham_set_h_ffactor __P ((DB *, u_int32_t));
+static int CDB___ham_set_h_ffactor __P ((DB *, uint32_t));
 static int CDB___ham_set_h_hash
-__P ((DB *, u_int32_t (*)(const void *, u_int32_t)));
-static int CDB___ham_set_h_nelem __P ((DB *, u_int32_t));
+__P ((DB *, uint32_t (*)(const void *, uint32_t)));
+static int CDB___ham_set_h_nelem __P ((DB *, uint32_t));
 
 /*
  * CDB___ham_db_create --
@@ -74,7 +74,7 @@ CDB___ham_db_close (dbp)
 static int
 CDB___ham_set_h_ffactor (dbp, h_ffactor)
      DB *dbp;
-     u_int32_t h_ffactor;
+     uint32_t h_ffactor;
 {
   HASH *hashp;
 
@@ -93,7 +93,7 @@ CDB___ham_set_h_ffactor (dbp, h_ffactor)
 static int
 CDB___ham_set_h_hash (dbp, func)
      DB *dbp;
-u_int32_t (*func) __P ((const void *, u_int32_t));
+uint32_t (*func) __P ((const void *, uint32_t));
 {
   HASH *hashp;
 
@@ -112,7 +112,7 @@ u_int32_t (*func) __P ((const void *, u_int32_t));
 static int
 CDB___ham_set_h_nelem (dbp, h_nelem)
      DB *dbp;
-     u_int32_t h_nelem;
+     uint32_t h_nelem;
 {
   HASH *hashp;
 

--- a/db/hash_page.c
+++ b/db/hash_page.c
@@ -559,7 +559,7 @@ CDB___ham_putitem (p, dbt, type)
      const DBT *dbt;
      int type;
 {
-  u_int16_t n, off;
+  uint16_t n, off;
 
   n = NUM_ENT (p);
 
@@ -583,7 +583,7 @@ CDB___ham_putitem (p, dbt, type)
 
 /*
  * PUBLIC: void CDB___ham_reputpair
- * PUBLIC:    __P((PAGE *p, u_int32_t, u_int32_t, const DBT *, const DBT *));
+ * PUBLIC:    __P((PAGE *p, uint32_t, uint32_t, const DBT *, const DBT *));
  *
  * This is a special case to restore a key/data pair to its original
  * location during recovery.  We are guaranteed that the pair fits
@@ -593,17 +593,17 @@ CDB___ham_putitem (p, dbt, type)
 void
 CDB___ham_reputpair (p, psize, ndx, key, data)
      PAGE *p;
-     u_int32_t psize, ndx;
+     uint32_t psize, ndx;
      const DBT *key, *data;
 {
   db_indx_t i, movebytes, newbytes;
-  u_int8_t *from;
+  uint8_t *from;
 
   /* First shuffle the existing items up on the page.  */
   movebytes =
     (ndx == 0 ? psize : p->inp[H_DATAINDEX (ndx - 1)]) - HOFFSET (p);
   newbytes = key->size + data->size;
-  from = (u_int8_t *) p + HOFFSET (p);
+  from = (uint8_t *) p + HOFFSET (p);
   memmove (from - newbytes, from, movebytes);
 
   /*
@@ -715,7 +715,7 @@ CDB___ham_del_pair (dbc, reclaim_page)
     if ((ret = CDB___ham_insdel_log (dbenv,
                                      dbc->txn, &new_lsn, 0, DELPAIR,
                                      dbp->log_fileid, PGNO (p),
-                                     (u_int32_t) ndx, &LSN (p), &key_dbt,
+                                     (uint32_t) ndx, &LSN (p), &key_dbt,
                                      &data_dbt)) != 0)
       return (ret);
 
@@ -895,22 +895,22 @@ CDB___ham_del_pair (dbc, reclaim_page)
  *  Given the key data indicated by the cursor, replace part/all of it
  *  according to the fields in the dbt.
  *
- * PUBLIC: int CDB___ham_replpair __P((DBC *, DBT *, u_int32_t));
+ * PUBLIC: int CDB___ham_replpair __P((DBC *, DBT *, uint32_t));
  */
 int
 CDB___ham_replpair (dbc, dbt, make_dup)
      DBC *dbc;
      DBT *dbt;
-     u_int32_t make_dup;
+     uint32_t make_dup;
 {
   DB *dbp;
   HASH_CURSOR *hcp;
   DBT old_dbt, tdata, tmp;
   DB_LSN new_lsn;
   int32_t change;               /* XXX: Possible overflow. */
-  u_int32_t dup, len;
+  uint32_t dup, len;
   int is_big, ret, type;
-  u_int8_t *beg, *dest, *end, *hk, *src;
+  uint8_t *beg, *dest, *end, *hk, *src;
 
   /*
    * Big item replacements are handled in generic code.
@@ -941,7 +941,7 @@ CDB___ham_replpair (dbc, dbt, make_dup)
   is_big = HPAGE_PTYPE (hk) == H_OFFPAGE;
 
   if (is_big)
-    memcpy (&len, HOFFPAGE_TLEN (hk), sizeof (u_int32_t));
+    memcpy (&len, HOFFPAGE_TLEN (hk), sizeof (uint32_t));
   else
     len = LEN_HKEYDATA (hcp->pagep, dbp->pgsize, H_DATAINDEX (hcp->bndx));
 
@@ -1001,18 +1001,18 @@ CDB___ham_replpair (dbc, dbt, make_dup)
         if ((ret = CDB___os_realloc (tdata.size + change,
                                      NULL, &tdata.data)) != 0)
           return (ret);
-        memset ((u_int8_t *) tdata.data + tdata.size, 0, change);
+        memset ((uint8_t *) tdata.data + tdata.size, 0, change);
       }
-      end = (u_int8_t *) tdata.data + tdata.size;
+      end = (uint8_t *) tdata.data + tdata.size;
 
-      src = (u_int8_t *) tdata.data + dbt->doff + dbt->dlen;
+      src = (uint8_t *) tdata.data + dbt->doff + dbt->dlen;
       if (src < end && tdata.size > dbt->doff + dbt->dlen)
       {
         len = tdata.size - dbt->doff - dbt->dlen;
         dest = src + change;
         memmove (dest, src, len);
       }
-      memcpy ((u_int8_t *) tdata.data + dbt->doff, dbt->data, dbt->size);
+      memcpy ((uint8_t *) tdata.data + dbt->doff, dbt->data, dbt->size);
       tdata.size += change;
 
       /* Now add the pair. */
@@ -1043,9 +1043,9 @@ CDB___ham_replpair (dbc, dbt, make_dup)
     if ((ret = CDB___ham_replace_log (dbp->dbenv,
                                       dbc->txn, &new_lsn, 0, dbp->log_fileid,
                                       PGNO (hcp->pagep),
-                                      (u_int32_t) H_DATAINDEX (hcp->bndx),
+                                      (uint32_t) H_DATAINDEX (hcp->bndx),
                                       &LSN (hcp->pagep),
-                                      (u_int32_t) dbt->doff, &old_dbt, dbt,
+                                      (uint32_t) dbt->doff, &old_dbt, dbt,
                                       make_dup)) != 0)
       return (ret);
 
@@ -1053,7 +1053,7 @@ CDB___ham_replpair (dbc, dbt, make_dup)
   }
 
   CDB___ham_onpage_replace (hcp->pagep, dbp->pgsize,
-                            (u_int32_t) H_DATAINDEX (hcp->bndx),
+                            (uint32_t) H_DATAINDEX (hcp->bndx),
                             (int32_t) dbt->doff, change, dbt);
 
   return (0);
@@ -1070,30 +1070,30 @@ CDB___ham_replpair (dbc, dbt, make_dup)
  * off: Offset at which we are beginning the replacement.
  * change: the number of bytes (+ or -) that the element is growing/shrinking.
  * dbt: the new data that gets written at beg.
- * PUBLIC: void CDB___ham_onpage_replace __P((PAGE *, size_t, u_int32_t, int32_t,
+ * PUBLIC: void CDB___ham_onpage_replace __P((PAGE *, size_t, uint32_t, int32_t,
  * PUBLIC:     int32_t,  DBT *));
  */
 void
 CDB___ham_onpage_replace (pagep, pgsize, ndx, off, change, dbt)
      PAGE *pagep;
      size_t pgsize;
-     u_int32_t ndx;
+     uint32_t ndx;
      int32_t off;
      int32_t change;
      DBT *dbt;
 {
   db_indx_t i;
   int32_t len;
-  u_int8_t *src, *dest;
+  uint8_t *src, *dest;
   int zero_me;
 
   if (change != 0)
   {
     zero_me = 0;
-    src = (u_int8_t *) (pagep) + HOFFSET (pagep);
+    src = (uint8_t *) (pagep) + HOFFSET (pagep);
     if (off < 0)
       len = pagep->inp[ndx] - HOFFSET (pagep);
-    else if ((u_int32_t) off >= LEN_HKEYDATA (pagep, pgsize, ndx))
+    else if ((uint32_t) off >= LEN_HKEYDATA (pagep, pgsize, ndx))
     {
       len = HKEYDATA_DATA (P_ENTRY (pagep, ndx)) +
         LEN_HKEYDATA (pagep, pgsize, ndx) - src;
@@ -1118,12 +1118,12 @@ CDB___ham_onpage_replace (pagep, pgsize, ndx, off, change, dbt)
 }
 
 /*
- * PUBLIC: int CDB___ham_split_page __P((DBC *, u_int32_t, u_int32_t));
+ * PUBLIC: int CDB___ham_split_page __P((DBC *, uint32_t, uint32_t));
  */
 int
 CDB___ham_split_page (dbc, obucket, nbucket)
      DBC *dbc;
-     u_int32_t obucket, nbucket;
+     uint32_t obucket, nbucket;
 {
   DB *dbp;
   HASH_CURSOR *hcp, **harray;
@@ -1133,7 +1133,7 @@ CDB___ham_split_page (dbc, obucket, nbucket)
   PAGE **pp, *old_pagep, *temp_pagep, *new_pagep;
   db_indx_t n;
   db_pgno_t bucket_pgno, npgno, next_pgno;
-  u_int32_t big_len, len;
+  uint32_t big_len, len;
   int i, ret, tret;
   void *big_buf;
 
@@ -1336,7 +1336,7 @@ CDB___ham_add_el (dbc, key, val, type)
   DB_LSN new_lsn;
   HOFFPAGE doff, koff;
   db_pgno_t next_pgno;
-  u_int32_t data_size, key_size, pairsize, rectype;
+  uint32_t data_size, key_size, pairsize, rectype;
   int do_expand, is_keybig, is_databig, ret;
   int key_type, data_type;
 
@@ -1445,7 +1445,7 @@ CDB___ham_add_el (dbc, key, val, type)
     if ((ret = CDB___ham_insdel_log (dbp->dbenv, dbc->txn, &new_lsn, 0,
                                      rectype, dbp->log_fileid,
                                      PGNO (hcp->pagep),
-                                     (u_int32_t) H_NUMPAIRS (hcp->pagep),
+                                     (uint32_t) H_NUMPAIRS (hcp->pagep),
                                      &LSN (hcp->pagep), pkey, pdata)) != 0)
       return (ret);
 
@@ -1472,7 +1472,7 @@ CDB___ham_add_el (dbc, key, val, type)
     hcp->hdr->nelem++;
 
   if (do_expand || (hcp->hdr->ffactor != 0 &&
-                    (u_int32_t) H_NUMPAIRS (hcp->pagep) > hcp->hdr->ffactor))
+                    (uint32_t) H_NUMPAIRS (hcp->pagep) > hcp->hdr->ffactor))
     F_SET (hcp, H_EXPAND);
   return (0);
 }
@@ -1484,16 +1484,16 @@ CDB___ham_add_el (dbc, key, val, type)
  * H_DUPLICATE, H_OFFDUP).  Since we log splits at a high level, we
  * do not need to do any logging here.
  *
- * PUBLIC: void CDB___ham_copy_item __P((size_t, PAGE *, u_int32_t, PAGE *));
+ * PUBLIC: void CDB___ham_copy_item __P((size_t, PAGE *, uint32_t, PAGE *));
  */
 void
 CDB___ham_copy_item (pgsize, src_page, src_ndx, dest_page)
      size_t pgsize;
      PAGE *src_page;
-     u_int32_t src_ndx;
+     uint32_t src_ndx;
      PAGE *dest_page;
 {
-  u_int32_t len;
+  uint32_t len;
   void *src, *dest;
 
   /*
@@ -1687,14 +1687,14 @@ CDB___ham_get_cpage (dbc, mode)
  * If the flag is set to H_ISDUP, then we are talking about the
  * duplicate page, not the main page.
  *
- * PUBLIC: int CDB___ham_next_cpage __P((DBC *, db_pgno_t, int, u_int32_t));
+ * PUBLIC: int CDB___ham_next_cpage __P((DBC *, db_pgno_t, int, uint32_t));
  */
 int
 CDB___ham_next_cpage (dbc, pgno, dirty, flags)
      DBC *dbc;
      db_pgno_t pgno;
      int dirty;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB *dbp;
   HASH_CURSOR *hcp;
@@ -1741,7 +1741,7 @@ CDB___ham_lock_bucket (dbc, mode)
      db_lockmode_t mode;
 {
   HASH_CURSOR *hcp;
-  u_int32_t flags;
+  uint32_t flags;
   int ret;
 
   hcp = (HASH_CURSOR *) dbc->internal;
@@ -1764,16 +1764,16 @@ CDB___ham_lock_bucket (dbc, mode)
  *  represents.  The caller is responsible for freeing up duplicates
  *  or offpage entries that might be referenced by this pair.
  *
- * PUBLIC: void CDB___ham_dpair __P((DB *, PAGE *, u_int32_t));
+ * PUBLIC: void CDB___ham_dpair __P((DB *, PAGE *, uint32_t));
  */
 void
 CDB___ham_dpair (dbp, p, pndx)
      DB *dbp;
      PAGE *p;
-     u_int32_t pndx;
+     uint32_t pndx;
 {
   db_indx_t delta, n;
-  u_int8_t *dest, *src;
+  uint8_t *dest, *src;
 
   /*
    * Compute "delta", the amount we have to shift all of the
@@ -1793,7 +1793,7 @@ CDB___ham_dpair (dbp, p, pndx)
      * Move the data: src is the first occupied byte on
      * the page. (Length is delta.)
      */
-    src = (u_int8_t *) p + HOFFSET (p);
+    src = (uint8_t *) p + HOFFSET (p);
 
     /*
      * Destination is delta bytes beyond src.  This might

--- a/db/hash_rec.c
+++ b/db/hash_rec.c
@@ -84,7 +84,7 @@ CDB___ham_insdel_recover (dbenv, dbtp, lsnp, redo, info)
   DBC *dbc;
   DB_MPOOLFILE *mpf;
   PAGE *pagep;
-  u_int32_t op;
+  uint32_t op;
   int cmp_n, cmp_p, getmeta, ret;
 
   COMPQUIET (info, NULL);
@@ -137,7 +137,7 @@ CDB___ham_insdel_recover (dbenv, dbtp, lsnp, redo, info)
      * position.  That's a royal pain in the butt (because we do
      * not store item lengths on the page), but there's no choice.
      */
-    if (op != DELPAIR || argp->ndx == (u_int32_t) H_NUMPAIRS (pagep))
+    if (op != DELPAIR || argp->ndx == (uint32_t) H_NUMPAIRS (pagep))
     {
       CDB___ham_putitem (pagep, &argp->key,
                          !redo || PAIR_ISKEYBIG (argp->opcode) ?
@@ -407,7 +407,7 @@ CDB___ham_replace_recover (dbenv, dbtp, lsnp, redo, info)
   PAGE *pagep;
   int32_t grow;
   int change, cmp_n, cmp_p, getmeta, ret;
-  u_int8_t *hk;
+  uint8_t *hk;
 
   COMPQUIET (info, NULL);
 
@@ -848,7 +848,7 @@ CDB___ham_metagroup_recover (dbenv, dbtp, lsnp, redo, info)
    * pages; if it's not, then we simply allocated one new page.
    */
   groupgrow =
-    (u_int32_t) (1 << CDB___db_log2 (argp->bucket + 1)) == argp->bucket + 1;
+    (uint32_t) (1 << CDB___db_log2 (argp->bucket + 1)) == argp->bucket + 1;
 
   last_pgno = argp->pgno;
   if (groupgrow)
@@ -1050,7 +1050,7 @@ CDB___ham_free_pages (dbp, argp)
   DBMETA *mmeta;
   DB_MPOOLFILE *mpf;
   PAGE *pagep;
-  u_int32_t i;
+  uint32_t i;
   db_pgno_t last_free, pgno;
   int mod_meta, ret, t_ret;
 

--- a/db/hash_stat.c
+++ b/db/hash_stat.c
@@ -30,13 +30,13 @@ static int CDB___ham_stat_callback __P ((DB *, PAGE *, void *, int *));
  * CDB___ham_stat --
  *  Gather/print the hash statistics
  *
- * PUBLIC: int CDB___ham_stat __P((DB *, void *, void *(*)(size_t), u_int32_t));
+ * PUBLIC: int CDB___ham_stat __P((DB *, void *, void *(*)(size_t), uint32_t));
  */
 int
 CDB___ham_stat (dbp, spp, db_malloc, flags)
      DB *dbp;
      void *spp, *(*db_malloc) __P ((size_t));
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB_HASH_STAT *sp;
   HASH_CURSOR *hcp;
@@ -128,7 +128,7 @@ CDB___ham_traverse (dbp, dbc, mode, callback, cookie)
   HASH_CURSOR *hcp;
   HKEYDATA *hk;
   db_pgno_t pgno, opgno;
-  u_int32_t bucket;
+  uint32_t bucket;
   int did_put, i, ret;
 
   hcp = (HASH_CURSOR *) dbc->internal;

--- a/db/hash_upgrade.c
+++ b/db/hash_upgrade.c
@@ -74,10 +74,10 @@ CDB___ham_upgrade5 (dbp, swapped, real_name, fhp)
 {
   DB_ENV *dbenv;
   ssize_t n;
-  u_int32_t *o_spares, *n_spares, version;
-  u_int32_t fillf, maxb, nelem;
+  uint32_t *o_spares, *n_spares, version;
+  uint32_t fillf, maxb, nelem;
   int i, non_zero, ret;
-  u_int8_t nbuf[256], *new, obuf[256];
+  uint8_t nbuf[256], *new, obuf[256];
 
   dbenv = dbp->dbenv;
 
@@ -128,7 +128,7 @@ CDB___ham_upgrade5 (dbp, swapped, real_name, fhp)
   version = 6;
   if (swapped)
     M_32_SWAP (version);
-  memcpy (nbuf + 16, &version, sizeof (u_int32_t));
+  memcpy (nbuf + 16, &version, sizeof (uint32_t));
 
   /* Assign unused and type fields. */
   new = nbuf + 24;
@@ -149,9 +149,9 @@ CDB___ham_upgrade5 (dbp, swapped, real_name, fhp)
    * (that is, very large and positive), we'll die trying to dump and
    * load this database.  So, let's see if we can fix it here.
    */
-  memcpy (&nelem, nbuf + 72, sizeof (u_int32_t));
-  memcpy (&fillf, nbuf + 68, sizeof (u_int32_t));
-  memcpy (&maxb, nbuf + 56, sizeof (u_int32_t));
+  memcpy (&nelem, nbuf + 72, sizeof (uint32_t));
+  memcpy (&fillf, nbuf + 68, sizeof (uint32_t));
+  memcpy (&maxb, nbuf + 56, sizeof (uint32_t));
   if (swapped)
   {
     M_32_SWAP (nelem);
@@ -163,7 +163,7 @@ CDB___ham_upgrade5 (dbp, swapped, real_name, fhp)
       (fillf == 0 && nelem > 0x8000000))
   {
     nelem = 0;
-    memcpy (nbuf + 72, &nelem, sizeof (u_int32_t));
+    memcpy (nbuf + 72, &nelem, sizeof (uint32_t));
   }
 
   /*
@@ -173,8 +173,8 @@ CDB___ham_upgrade5 (dbp, swapped, real_name, fhp)
    * contains the page number of the first bucket in the next doubling
    * MINUS the bucket number of that bucket.
    */
-  o_spares = (u_int32_t *) (obuf + 60);
-  n_spares = (u_int32_t *) (nbuf + 80);
+  o_spares = (uint32_t *) (obuf + 60);
+  n_spares = (uint32_t *) (nbuf + 80);
   non_zero = 0;
   n_spares[0] = 1;
   for (i = 1; i < NCACHED; i++)

--- a/db/hash_verify.c
+++ b/db/hash_verify.c
@@ -27,12 +27,12 @@ static const char revid[] =
 #include "btree.h"
 #include "hash.h"
 
-static int __ham_dups_unsorted __P ((DB *, u_int8_t *, u_int32_t));
-static int __ham_vrfy_bucket __P ((DB *, VRFY_DBINFO *, HMETA *, u_int32_t,
-                                   u_int32_t));
+static int __ham_dups_unsorted __P ((DB *, uint8_t *, uint32_t));
+static int __ham_vrfy_bucket __P ((DB *, VRFY_DBINFO *, HMETA *, uint32_t,
+                                   uint32_t));
 static int __ham_vrfy_item __P ((DB *,
-                                 VRFY_DBINFO *, db_pgno_t, PAGE *, u_int32_t,
-                                 u_int32_t));
+                                 VRFY_DBINFO *, db_pgno_t, PAGE *, uint32_t,
+                                 uint32_t));
 
 /*
  * CDB___ham_vrfy_meta --
@@ -43,7 +43,7 @@ static int __ham_vrfy_item __P ((DB *,
  *  amount of state here is significant.
  *
  * PUBLIC: int CDB___ham_vrfy_meta __P((DB *, VRFY_DBINFO *, HMETA *,
- * PUBLIC:     db_pgno_t, u_int32_t));
+ * PUBLIC:     db_pgno_t, uint32_t));
  */
 int
 CDB___ham_vrfy_meta (dbp, vdp, m, pgno, flags)
@@ -51,13 +51,13 @@ CDB___ham_vrfy_meta (dbp, vdp, m, pgno, flags)
      VRFY_DBINFO *vdp;
      HMETA *m;
      db_pgno_t pgno;
-     u_int32_t flags;
+     uint32_t flags;
 {
   HASH *hashp;
   VRFY_PAGEINFO *pip;
   int i, ret, t_ret, isbad;
-  u_int32_t pwr, mbucket;
-  u_int32_t (*hfunc) __P ((const void *, u_int32_t));
+  uint32_t pwr, mbucket;
+  uint32_t (*hfunc) __P ((const void *, uint32_t));
 
   if ((ret = CDB___db_vrfy_getpageinfo (vdp, pgno, &pip)) != 0)
     return (ret);
@@ -189,7 +189,7 @@ err:if ((t_ret = CDB___db_vrfy_putpageinfo (vdp, pip)) != 0 && ret == 0)
  *  Verify hash page.
  *
  * PUBLIC: int CDB___ham_vrfy __P((DB *, VRFY_DBINFO *, PAGE *, db_pgno_t,
- * PUBLIC:     u_int32_t));
+ * PUBLIC:     uint32_t));
  */
 int
 CDB___ham_vrfy (dbp, vdp, h, pgno, flags)
@@ -197,7 +197,7 @@ CDB___ham_vrfy (dbp, vdp, h, pgno, flags)
      VRFY_DBINFO *vdp;
      PAGE *h;
      db_pgno_t pgno;
-     u_int32_t flags;
+     uint32_t flags;
 {
   VRFY_PAGEINFO *pip;
   db_indx_t ent, himark, inpend;
@@ -239,7 +239,7 @@ CDB___ham_vrfy (dbp, vdp, h, pgno, flags)
    * be unsafe to proceed.
    */
   for (ent = 0, himark = dbp->pgsize,
-       inpend = (u_int8_t *) h->inp - (u_int8_t *) h;
+       inpend = (uint8_t *) h->inp - (uint8_t *) h;
        ent < NUM_ENT (h); ent++)
     if (h->inp[ent] >= himark)
     {
@@ -280,7 +280,7 @@ __ham_vrfy_item (dbp, vdp, pgno, h, i, flags)
      VRFY_DBINFO *vdp;
      db_pgno_t pgno;
      PAGE *h;
-     u_int32_t i, flags;
+     uint32_t i, flags;
 {
   HOFFPAGE hop;
   HOFFDUP hod;
@@ -288,7 +288,7 @@ __ham_vrfy_item (dbp, vdp, pgno, h, i, flags)
   VRFY_PAGEINFO *pip;
   db_indx_t offset, len, dlen, elen;
   int ret, t_ret;
-  u_int8_t *databuf;
+  uint8_t *databuf;
 
   if ((ret = CDB___db_vrfy_getpageinfo (vdp, pgno, &pip)) != 0)
     return (ret);
@@ -406,14 +406,14 @@ err:if ((t_ret = CDB___db_vrfy_putpageinfo (vdp, pip)) != 0 && ret == 0)
  *  Verify the structure of a hash database.
  *
  * PUBLIC: int CDB___ham_vrfy_structure __P((DB *, VRFY_DBINFO *, db_pgno_t,
- * PUBLIC:     u_int32_t));
+ * PUBLIC:     uint32_t));
  */
 int
 CDB___ham_vrfy_structure (dbp, vdp, meta_pgno, flags)
      DB *dbp;
      VRFY_DBINFO *vdp;
      db_pgno_t meta_pgno;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB *pgset;
   HMETA *m;
@@ -421,7 +421,7 @@ CDB___ham_vrfy_structure (dbp, vdp, meta_pgno, flags)
   VRFY_PAGEINFO *pip;
   int isbad, p, ret, t_ret;
   db_pgno_t pgno;
-  u_int32_t bucket;
+  uint32_t bucket;
 
   ret = isbad = 0;
   h = NULL;
@@ -519,7 +519,7 @@ __ham_vrfy_bucket (dbp, vdp, m, bucket, flags)
      DB *dbp;
      VRFY_DBINFO *vdp;
      HMETA *m;
-     u_int32_t bucket, flags;
+     uint32_t bucket, flags;
 {
   HASH *hashp;
   VRFY_CHILDINFO *child;
@@ -527,7 +527,7 @@ __ham_vrfy_bucket (dbp, vdp, m, bucket, flags)
   int ret, t_ret, isbad, p;
   db_pgno_t pgno, next_pgno;
   DBC *cc;
-  u_int32_t (*hfunc) __P ((const void *, u_int32_t));
+  uint32_t (*hfunc) __P ((const void *, uint32_t));
 
   isbad = 0;
   pip = NULL;
@@ -715,24 +715,24 @@ err:if (cc != NULL && ((t_ret = CDB___db_vrfy_ccclose (cc)) != 0)
  *  Verify that all items on a given hash page hash correctly.
  *
  * PUBLIC: int CDB___ham_vrfy_hashing __P((DB *,
- * PUBLIC:     u_int32_t, HMETA *, u_int32_t, db_pgno_t, u_int32_t,
- * PUBLIC:     u_int32_t (*) __P((const void *, u_int32_t))));
+ * PUBLIC:     uint32_t, HMETA *, uint32_t, db_pgno_t, uint32_t,
+ * PUBLIC:     uint32_t (*) __P((const void *, uint32_t))));
  */
 int
 CDB___ham_vrfy_hashing (dbp, nentries, m, thisbucket, pgno, flags, hfunc)
      DB *dbp;
-     u_int32_t nentries;
+     uint32_t nentries;
      HMETA *m;
-     u_int32_t thisbucket;
+     uint32_t thisbucket;
      db_pgno_t pgno;
-     u_int32_t flags;
-u_int32_t (*hfunc) __P ((const void *, u_int32_t));
+     uint32_t flags;
+uint32_t (*hfunc) __P ((const void *, uint32_t));
 {
   DBT dbt;
   PAGE *h;
   db_indx_t i;
   int ret, t_ret, isbad;
-  u_int32_t hval, bucket;
+  uint32_t hval, bucket;
 
   ret = isbad = 0;
   memset (&dbt, 0, sizeof (DBT));
@@ -781,7 +781,7 @@ err:if (dbt.data != NULL)
  *  hash page.
  *
  * PUBLIC: int CDB___ham_salvage __P((DB *, VRFY_DBINFO *, db_pgno_t, PAGE *,
- * PUBLIC:     void *, int (*)(void *, const void *), u_int32_t));
+ * PUBLIC:     void *, int (*)(void *, const void *), uint32_t));
  */
 int
 CDB___ham_salvage (dbp, vdp, pgno, h, handle, callback, flags)
@@ -791,13 +791,13 @@ CDB___ham_salvage (dbp, vdp, pgno, h, handle, callback, flags)
      PAGE *h;
      void *handle;
      int (*callback) __P ((void *, const void *));
-     u_int32_t flags;
+     uint32_t flags;
 {
   DBT dbt, unkdbt;
   db_pgno_t dpgno;
   int ret, err_ret, t_ret;
-  u_int32_t himark, tlen;
-  u_int8_t *hk;
+  uint32_t himark, tlen;
+  uint8_t *hk;
   void *buf;
   db_indx_t dlen, len, i;
 
@@ -834,7 +834,7 @@ CDB___ham_salvage (dbp, vdp, pgno, h, handle, callback, flags)
     {
       hk = P_ENTRY (h, i);
       len = LEN_HKEYDATA (h, dbp->pgsize, i);
-      if ((u_int32_t) (hk + len - (u_int8_t *) h) > dbp->pgsize)
+      if ((uint32_t) (hk + len - (uint8_t *) h) > dbp->pgsize)
       {
         /*
          * Item is unsafely large;  either continue
@@ -843,7 +843,7 @@ CDB___ham_salvage (dbp, vdp, pgno, h, handle, callback, flags)
          */
         if (!LF_ISSET (DB_AGGRESSIVE))
           continue;
-        len = dbp->pgsize - (u_int32_t) (hk - (u_int8_t *) h);
+        len = dbp->pgsize - (uint32_t) (hk - (uint8_t *) h);
         err_ret = DB_VERIFY_BAD;
       }
       switch (HPAGE_PTYPE (hk))
@@ -956,7 +956,7 @@ CDB___ham_salvage (dbp, vdp, pgno, h, handle, callback, flags)
  *  Return the set of hash pages corresponding to the given
  *  known-good meta page.
  *
- * PUBLIC: int CDB___ham_meta2pgset __P((DB *, VRFY_DBINFO *, HMETA *, u_int32_t,
+ * PUBLIC: int CDB___ham_meta2pgset __P((DB *, VRFY_DBINFO *, HMETA *, uint32_t,
  * PUBLIC:     DB *));
  */
 int
@@ -964,12 +964,12 @@ CDB___ham_meta2pgset (dbp, vdp, hmeta, flags, pgset)
      DB *dbp;
      VRFY_DBINFO *vdp;
      HMETA *hmeta;
-     u_int32_t flags;
+     uint32_t flags;
      DB *pgset;
 {
   PAGE *h;
   db_pgno_t pgno;
-  u_int32_t bucket, totpgs;
+  uint32_t bucket, totpgs;
   int ret, val;
 
   /*
@@ -1050,8 +1050,8 @@ CDB___ham_meta2pgset (dbp, vdp, hmeta, flags, pgset)
 static int
 __ham_dups_unsorted (dbp, buf, len)
      DB *dbp;
-     u_int8_t *buf;
-     u_int32_t len;
+     uint8_t *buf;
+     uint32_t len;
 {
   DBT a, b;
   db_indx_t offset, dlen;

--- a/db/lock.c
+++ b/db/lock.c
@@ -26,15 +26,15 @@ static const char sccsid[] = "@(#)lock.c  11.8 (Sleepycat) 10/19/99";
 #include "txn.h"
 
 static int CDB___lock_checklocker __P ((DB_LOCKTAB *,
-                                        struct __db_lock *, u_int32_t,
-                                        u_int32_t, int *));
+                                        struct __db_lock *, uint32_t,
+                                        uint32_t, int *));
 static int CDB___lock_get_internal
-__P ((DB_LOCKTAB *, u_int32_t, u_int32_t, const DBT *, db_lockmode_t,
+__P ((DB_LOCKTAB *, uint32_t, uint32_t, const DBT *, db_lockmode_t,
       DB_LOCK *));
-static int CDB___lock_is_parent __P ((DB_LOCKTAB *, u_int32_t, DB_LOCKER *));
+static int CDB___lock_is_parent __P ((DB_LOCKTAB *, uint32_t, DB_LOCKER *));
 static int CDB___lock_put_internal __P ((DB_LOCKTAB *,
-                                         struct __db_lock *, u_int32_t,
-                                         u_int32_t));
+                                         struct __db_lock *, uint32_t,
+                                         uint32_t));
 static int CDB___lock_put_nolock __P ((DB_ENV *, DB_LOCK *, int *));
 static void CDB___lock_remove_waiter __P ((DB_LOCKOBJ *,
                                            struct __db_lock *, db_status_t));
@@ -46,7 +46,7 @@ static void CDB___lock_remove_waiter __P ((DB_LOCKOBJ *,
 int
 CDB_lock_id (dbenv, idp)
      DB_ENV *dbenv;
-     u_int32_t *idp;
+     uint32_t *idp;
 {
   DB_LOCKTAB *lt;
   DB_LOCKREGION *region;
@@ -92,7 +92,7 @@ CDB_lock_id (dbenv, idp)
 int
 CDB_lock_vec (dbenv, locker, flags, list, nlist, elistp)
      DB_ENV *dbenv;
-     u_int32_t locker, flags;
+     uint32_t locker, flags;
      int nlist;
      DB_LOCKREQ *list, **elistp;
 {
@@ -101,7 +101,7 @@ CDB_lock_vec (dbenv, locker, flags, list, nlist, elistp)
   DB_LOCKOBJ *sh_obj;
   DB_LOCKREGION *region;
   DB_LOCKTAB *lt;
-  u_int32_t lndx, ndx, pndx;
+  uint32_t lndx, ndx, pndx;
   int did_abort, i, ret, run_dd;
 
   PANIC_CHECK (dbenv);
@@ -219,7 +219,7 @@ CDB_lock_vec (dbenv, locker, flags, list, nlist, elistp)
            lp != NULL; lp = SH_LIST_FIRST (&sh_locker->heldby, __db_lock))
       {
         SH_LIST_REMOVE (lp, locker_links, __db_lock);
-        sh_obj = (DB_LOCKOBJ *) ((u_int8_t *) lp + lp->obj);
+        sh_obj = (DB_LOCKOBJ *) ((uint8_t *) lp + lp->obj);
         SHOBJECT_LOCK (lt, region, sh_obj, lndx);
         ret = CDB___lock_put_internal (lt,
                                        lp, lndx,
@@ -329,7 +329,7 @@ CDB_lock_vec (dbenv, locker, flags, list, nlist, elistp)
 int
 CDB_lock_get (dbenv, locker, flags, obj, lock_mode, lock)
      DB_ENV *dbenv;
-     u_int32_t locker, flags;
+     uint32_t locker, flags;
      const DBT *obj;
      db_lockmode_t lock_mode;
      DB_LOCK *lock;
@@ -358,7 +358,7 @@ CDB_lock_get (dbenv, locker, flags, obj, lock_mode, lock)
 static int
 CDB___lock_get_internal (lt, locker, flags, obj, lock_mode, lock)
      DB_LOCKTAB *lt;
-     u_int32_t locker, flags;
+     uint32_t locker, flags;
      const DBT *obj;
      db_lockmode_t lock_mode;
      DB_LOCK *lock;
@@ -368,7 +368,7 @@ CDB___lock_get_internal (lt, locker, flags, obj, lock_mode, lock)
   DB_LOCKER *sh_locker;
   DB_LOCKOBJ *sh_obj;
   DB_LOCKREGION *region;
-  u_int32_t locker_ndx;
+  uint32_t locker_ndx;
   int did_abort, freed, ihold, on_locker_list, no_dd, ret;
 
   no_dd = ret = 0;
@@ -379,7 +379,7 @@ CDB___lock_get_internal (lt, locker, flags, obj, lock_mode, lock)
   /*
    * Check that the lock mode is valid.
    */
-  if ((u_int32_t) lock_mode >= region->nmodes)
+  if ((uint32_t) lock_mode >= region->nmodes)
   {
     CDB___db_err (dbenv,
                   "CDB_lock_get: invalid lock mode %lu\n",
@@ -666,7 +666,7 @@ CDB___lock_put_nolock (dbenv, lock, runp)
   struct __db_lock *lockp;
   DB_LOCKREGION *region;
   DB_LOCKTAB *lt;
-  u_int32_t locker;
+  uint32_t locker;
   int ret;
 
   lt = dbenv->lk_handle;
@@ -708,14 +708,14 @@ CDB___lock_put_nolock (dbenv, lock, runp)
  * back to iwrite locks.
  *
  * PUBLIC: int CDB___lock_downgrade __P((DB_ENV *,
- * PUBLIC:     DB_LOCK *, db_lockmode_t, u_int32_t));
+ * PUBLIC:     DB_LOCK *, db_lockmode_t, uint32_t));
  */
 int
 CDB___lock_downgrade (dbenv, lock, new_mode, flags)
      DB_ENV *dbenv;
      DB_LOCK *lock;
      db_lockmode_t new_mode;
-     u_int32_t flags;
+     uint32_t flags;
 {
   struct __db_lock *lockp;
   DB_LOCKOBJ *obj;
@@ -744,7 +744,7 @@ CDB___lock_downgrade (dbenv, lock, new_mode, flags)
   lockp->mode = new_mode;
 
   /* Get the object associated with this lock. */
-  obj = (DB_LOCKOBJ *) ((u_int8_t *) lockp + lockp->obj);
+  obj = (DB_LOCKOBJ *) ((uint8_t *) lockp + lockp->obj);
   (void) CDB___lock_promote (lt, obj);
   OBJECT_UNLOCK (lt, lock->ndx);
 
@@ -760,8 +760,8 @@ static int
 CDB___lock_put_internal (lt, lockp, obj_ndx, flags)
      DB_LOCKTAB *lt;
      struct __db_lock *lockp;
-     u_int32_t obj_ndx;
-     u_int32_t flags;
+     uint32_t obj_ndx;
+     uint32_t flags;
 {
   DB_LOCKOBJ *sh_obj;
   DB_LOCKREGION *region;
@@ -802,7 +802,7 @@ CDB___lock_put_internal (lt, lockp, obj_ndx, flags)
   lockp->gen++;
 
   /* Get the object associated with this lock. */
-  sh_obj = (DB_LOCKOBJ *) ((u_int8_t *) lockp + lockp->obj);
+  sh_obj = (DB_LOCKOBJ *) ((uint8_t *) lockp + lockp->obj);
 
   /* Remove this lock from its holders/waitlist. */
   if (lockp->status != DB_LSTAT_HELD)
@@ -869,13 +869,13 @@ static int
 CDB___lock_checklocker (lt, lockp, locker, flags, freed)
      DB_LOCKTAB *lt;
      struct __db_lock *lockp;
-     u_int32_t locker, flags;
+     uint32_t locker, flags;
      int *freed;
 {
   DB_ENV *dbenv;
   DB_LOCKER *sh_locker;
   DB_LOCKREGION *region;
-  u_int32_t indx;
+  uint32_t indx;
   int ret;
 
   dbenv = lt->dbenv;
@@ -932,17 +932,17 @@ freelock:
  * CDB___lock_addfamilylocker
  *  Put a locker entry in for a child transaction.
  *
- * PUBLIC: int CDB___lock_addfamilylocker __P((DB_ENV *, u_int32_t, u_int32_t));
+ * PUBLIC: int CDB___lock_addfamilylocker __P((DB_ENV *, uint32_t, uint32_t));
  */
 int
 CDB___lock_addfamilylocker (dbenv, pid, id)
      DB_ENV *dbenv;
-     u_int32_t pid, id;
+     uint32_t pid, id;
 {
   DB_LOCKER *lockerp, *mlockerp;
   DB_LOCKREGION *region;
   DB_LOCKTAB *lt;
-  u_int32_t ndx;
+  uint32_t ndx;
   int ret;
 
   lt = dbenv->lk_handle;
@@ -1002,17 +1002,17 @@ err:
  *
  * This must be called without the locker bucket locked.
  *
- * PUBLIC: int CDB___lock_freefamilylocker  __P((DB_LOCKTAB *, u_int32_t));
+ * PUBLIC: int CDB___lock_freefamilylocker  __P((DB_LOCKTAB *, uint32_t));
  */
 int
 CDB___lock_freefamilylocker (lt, locker)
      DB_LOCKTAB *lt;
-     u_int32_t locker;
+     uint32_t locker;
 {
   DB_ENV *dbenv;
   DB_LOCKER *sh_locker;
   DB_LOCKREGION *region;
-  u_int32_t indx;
+  uint32_t indx;
   int ret;
 
   dbenv = lt->dbenv;
@@ -1055,14 +1055,14 @@ freelock:
  * This must be called with the locker bucket locked.
  *
  * PUBLIC: void CDB___lock_freelocker __P((DB_LOCKTAB *,
- * PUBLIC:     DB_LOCKREGION *, DB_LOCKER *, u_int32_t));
+ * PUBLIC:     DB_LOCKREGION *, DB_LOCKER *, uint32_t));
  */
 void
 CDB___lock_freelocker (lt, region, sh_locker, indx)
      DB_LOCKTAB *lt;
      DB_LOCKREGION *region;
      DB_LOCKER *sh_locker;
-     u_int32_t indx;
+     uint32_t indx;
 
 {
   HASHREMOVE_EL (lt->locker_tab, indx, __db_locker, links, sh_locker);
@@ -1081,12 +1081,12 @@ CDB___lock_freelocker (lt, region, sh_locker, indx)
  * This must be called with the locker bucket locked.
  *
  * PUBLIC: int CDB___lock_getlocker __P((DB_LOCKTAB *,
- * PUBLIC:     u_int32_t, u_int32_t, int, DB_LOCKER **));
+ * PUBLIC:     uint32_t, uint32_t, int, DB_LOCKER **));
  */
 int
 CDB___lock_getlocker (lt, locker, indx, create, retp)
      DB_LOCKTAB *lt;
-     u_int32_t locker, indx;
+     uint32_t locker, indx;
      int create;
      DB_LOCKER **retp;
 {
@@ -1144,13 +1144,13 @@ CDB___lock_getlocker (lt, locker, indx, create, retp)
  * This must be called with the object bucket locked.
  *
  * PUBLIC: int CDB___lock_getobj __P((DB_LOCKTAB *,
- * PUBLIC:     const DBT *, u_int32_t, int, DB_LOCKOBJ **));
+ * PUBLIC:     const DBT *, uint32_t, int, DB_LOCKOBJ **));
  */
 int
 CDB___lock_getobj (lt, obj, ndx, create, retp)
      DB_LOCKTAB *lt;
      const DBT *obj;
-     u_int32_t ndx;
+     uint32_t ndx;
      int create;
      DB_LOCKOBJ **retp;
 {
@@ -1218,7 +1218,7 @@ err:MEMORY_UNLOCK (lt);
 static int
 CDB___lock_is_parent (lt, locker, sh_locker)
      DB_LOCKTAB *lt;
-     u_int32_t locker;
+     uint32_t locker;
      DB_LOCKER *sh_locker;
 {
   DB_LOCKER *parent;
@@ -1344,8 +1344,8 @@ CDB___lock_printlock (lt, lp, ispgno)
 {
   DB_LOCKOBJ *lockobj;
   db_pgno_t pgno;
-  u_int32_t *fidp;
-  u_int8_t *ptr, type;
+  uint32_t *fidp;
+  uint8_t *ptr, type;
   const char *mode, *status;
 
   switch (lp->mode)
@@ -1402,14 +1402,14 @@ CDB___lock_printlock (lt, lp, ispgno)
   printf ("\t%lx\t%s\t%lu\t%s\t",
           (u_long) lp->holder, mode, (u_long) lp->refcount, status);
 
-  lockobj = (DB_LOCKOBJ *) ((u_int8_t *) lp + lp->obj);
+  lockobj = (DB_LOCKOBJ *) ((uint8_t *) lp + lp->obj);
   ptr = SH_DBT_PTR (&lockobj->lockobj);
   if (ispgno && lockobj->lockobj.size == sizeof (struct __db_ilock))
   {
     /* Assume this is a DBT lock. */
     memcpy (&pgno, ptr, sizeof (db_pgno_t));
-    fidp = (u_int32_t *) (ptr + sizeof (db_pgno_t));
-    type = *(u_int8_t *) (ptr + sizeof (db_pgno_t) + DB_FILE_ID_LEN);
+    fidp = (uint32_t *) (ptr + sizeof (db_pgno_t));
+    type = *(uint8_t *) (ptr + sizeof (db_pgno_t) + DB_FILE_ID_LEN);
     printf ("%s  %lu (%lu %lu %lu %lu %lu)\n",
             type == DB_PAGE_LOCK ? "page" : "record",
             (u_long) pgno,

--- a/db/lock.h
+++ b/db/lock.h
@@ -30,30 +30,30 @@
  */
 typedef struct __db_lockregion
 {
-  u_int32_t id;                 /* unique id generator */
-  u_int32_t need_dd;            /* flag for deadlock detector */
-  u_int32_t detect;             /* run dd on every conflict */
+  uint32_t id;                 /* unique id generator */
+  uint32_t need_dd;            /* flag for deadlock detector */
+  uint32_t detect;             /* run dd on every conflict */
   /* free lock header */
     SH_TAILQ_HEAD (__flock) free_locks;
   /* free obj header */
     SH_TAILQ_HEAD (__fobj) free_objs;
   /* free locker header */
     SH_TAILQ_HEAD (__flocker) free_lockers;
-  u_int32_t maxlocks;           /* maximum number of locks in table */
-  u_int32_t table_size;         /* size of hash table */
-  u_int32_t nmodes;             /* number of lock modes */
-  u_int32_t nlockers;           /* number of lockers */
-  u_int32_t maxnlockers;        /* maximum number of lockers */
+  uint32_t maxlocks;           /* maximum number of locks in table */
+  uint32_t table_size;         /* size of hash table */
+  uint32_t nmodes;             /* number of lock modes */
+  uint32_t nlockers;           /* number of lockers */
+  uint32_t maxnlockers;        /* maximum number of lockers */
   roff_t memlock_off;           /* offset of memory mutex */
   roff_t conf_off;              /* offset of conflicts array */
   roff_t obj_off;               /* offset of object hash table */
   roff_t osynch_off;            /* offset of the object mutex table */
   roff_t locker_off;            /* offset of locker hash table */
   roff_t lsynch_off;            /* offset of the locker mutex table */
-  u_int32_t nconflicts;         /* number of lock conflicts */
-  u_int32_t nrequests;          /* number of lock gets */
-  u_int32_t nreleases;          /* number of lock puts */
-  u_int32_t ndeadlocks;         /* number of deadlocks */
+  uint32_t nconflicts;         /* number of lock conflicts */
+  uint32_t nrequests;          /* number of lock gets */
+  uint32_t nreleases;          /* number of lock puts */
+  uint32_t ndeadlocks;         /* number of deadlocks */
 } DB_LOCKREGION;
 
 /*
@@ -62,11 +62,11 @@ typedef struct __db_lockregion
  */
 typedef struct __sh_dbt
 {
-  u_int32_t size;               /* Byte length. */
+  uint32_t size;               /* Byte length. */
   ssize_t off;                  /* Region offset. */
 } SH_DBT;
 
-#define SH_DBT_PTR(p)  ((void *)(((u_int8_t *)(p)) + (p)->off))
+#define SH_DBT_PTR(p)  ((void *)(((uint8_t *)(p)) + (p)->off))
 
 /*
  * Object structures;  these live in the object hash table.
@@ -81,7 +81,7 @@ typedef struct __db_lockobj
    * typical DB lock structures so that
    * we do not have to allocate them from
    * shalloc at run-time. */
-  u_int8_t objdata[sizeof (struct __db_ilock)];
+  uint8_t objdata[sizeof (struct __db_ilock)];
 } DB_LOCKOBJ;
 
 /*
@@ -89,8 +89,8 @@ typedef struct __db_lockobj
  */
 typedef struct __db_locker
 {
-  u_int32_t id;                 /* Locker id. */
-  u_int32_t dd_id;              /* Deadlock detector id. */
+  uint32_t id;                 /* Locker id. */
+  uint32_t dd_id;              /* Deadlock detector id. */
   size_t master_locker;         /* Locker of master transaction. */
   size_t parent_locker;         /* Parent of this child. */
     SH_LIST_HEAD (_child) child_locker; /* List of descendant txns;
@@ -103,7 +103,7 @@ typedef struct __db_locker
     SH_LIST_HEAD (_held) heldby;        /* Locks held by this locker. */
 
 #define DB_LOCKER_DELETED  0x0001
-  u_int32_t flags;
+  uint32_t flags;
 } DB_LOCKER;
 
 /*
@@ -127,7 +127,7 @@ typedef struct __db_locktab
   DB_ENV *dbenv;                /* Environment. */
   REGINFO reginfo;              /* Region information. */
   MUTEX *memlock;               /* Mutex to protect memory alloc. */
-  u_int8_t *conflicts;          /* Pointer to conflict matrix. */
+  uint8_t *conflicts;          /* Pointer to conflict matrix. */
   DB_HASHTAB *obj_tab;          /* Beginning of object hash table. */
   MUTEX *osynch_tab;            /* Object mutex table. */
   DB_HASHTAB *locker_tab;       /* Beginning of locker hash table. */
@@ -148,11 +148,11 @@ struct __db_lock
    */
   MUTEX mutex;
 
-  u_int32_t holder;             /* Who holds this lock. */
-  u_int32_t gen;                /* Generation count. */
+  uint32_t holder;             /* Who holds this lock. */
+  uint32_t gen;                /* Generation count. */
   SH_TAILQ_ENTRY links;         /* Free or holder/waiter list. */
   SH_LIST_ENTRY locker_links;   /* List of locks held by a locker. */
-  u_int32_t refcount;           /* Reference count the lock. */
+  uint32_t refcount;           /* Reference count the lock. */
   db_lockmode_t mode;           /* What sort of lock. */
   ssize_t obj;                  /* Relative offset of object struct. */
   roff_t txnoff;                /* Offset of holding transaction. */

--- a/db/lock_conflict.c
+++ b/db/lock_conflict.c
@@ -21,14 +21,14 @@ static const char sccsid[] = "@(#)lock_conflict.c  11.1 (Sleepycat) 7/25/99";
  * The conflict arrays are set up such that the row is the lock you
  * are holding and the column is the lock that is desired.
  */
-const u_int8_t CDB_db_rw_conflicts[] = {
+const uint8_t CDB_db_rw_conflicts[] = {
   /*    N   R   W */
   /*   N */ 0, 0, 0,
   /*   R */ 0, 0, 1,
   /*   W */ 0, 1, 1
 };
 
-const u_int8_t CDB_db_riw_conflicts[] = {
+const uint8_t CDB_db_riw_conflicts[] = {
   /*    N     S     X    IX    IS  SIX */
   /*   N */ 0, 0, 0, 0, 0, 0,
   /*   S */ 0, 0, 1, 1, 0, 1,

--- a/db/lock_deadlock.c
+++ b/db/lock_deadlock.c
@@ -26,7 +26,7 @@ static const char sccsid[] = "@(#)lock_deadlock.c  11.7 (Sleepycat) 10/19/99";
 #define  ISSET_MAP(M, N)  ((M)[(N) / 32] & (1 << (N) % 32))
 
 #define  CLEAR_MAP(M, N) {            \
-  u_int32_t __i;              \
+  uint32_t __i;              \
   for (__i = 0; __i < (N); __i++)          \
     (M)[__i] = 0;            \
 }
@@ -35,7 +35,7 @@ static const char sccsid[] = "@(#)lock_deadlock.c  11.7 (Sleepycat) 10/19/99";
 #define  CLR_MAP(M, B)  ((M)[(B) / 32] &= ~(1 << ((B) % 32)))
 
 #define  OR_MAP(D, S, N)  {            \
-  u_int32_t __i;              \
+  uint32_t __i;              \
   for (__i = 0; __i < (N); __i++)          \
     D[__i] |= S[__i];          \
 }
@@ -44,33 +44,33 @@ static const char sccsid[] = "@(#)lock_deadlock.c  11.7 (Sleepycat) 10/19/99";
 typedef struct
 {
   int valid;
-  u_int32_t id;
-  u_int32_t last_lock;
-  u_int32_t last_locker_id;
+  uint32_t id;
+  uint32_t last_lock;
+  uint32_t last_locker_id;
   db_pgno_t pgno;
 } locker_info;
 
 static int CDB___dd_abort __P ((DB_ENV *, locker_info *));
 static int CDB___dd_build
-__P ((DB_ENV *, u_int32_t **, u_int32_t *, locker_info **));
+__P ((DB_ENV *, uint32_t **, uint32_t *, locker_info **));
 static int CDB___dd_find
-__P ((u_int32_t *, locker_info *, u_int32_t, u_int32_t ***));
+__P ((uint32_t *, locker_info *, uint32_t, uint32_t ***));
 
 #ifdef DIAGNOSTIC
 static void __dd_debug
-__P ((DB_ENV *, locker_info *, u_int32_t *, u_int32_t));
+__P ((DB_ENV *, locker_info *, uint32_t *, uint32_t));
 #endif
 
 int
 CDB_lock_detect (dbenv, flags, atype, abortp)
      DB_ENV *dbenv;
-     u_int32_t flags, atype;
+     uint32_t flags, atype;
      int *abortp;
 {
   DB_LOCKREGION *region;
   DB_LOCKTAB *lt;
   locker_info *idmap;
-  u_int32_t *bitmap, **deadp, **free_me, i, killid, nentries, nlockers;
+  uint32_t *bitmap, **deadp, **free_me, i, killid, nentries, nlockers;
   int do_pass, ret;
 
   PANIC_CHECK (dbenv);
@@ -230,12 +230,12 @@ CDB_lock_detect (dbenv, flags, atype, abortp)
  * Utilities
  */
 
-#define DD_INVALID_ID  ((u_int32_t) -1)
+#define DD_INVALID_ID  ((uint32_t) -1)
 
 static int
 CDB___dd_build (dbenv, bmp, nlockers, idmap)
      DB_ENV *dbenv;
-     u_int32_t **bmp, *nlockers;
+     uint32_t **bmp, *nlockers;
      locker_info **idmap;
 {
   struct __db_lock *lp;
@@ -244,8 +244,8 @@ CDB___dd_build (dbenv, bmp, nlockers, idmap)
   DB_LOCKREGION *region;
   DB_LOCKTAB *lt;
   locker_info *id_array;
-  u_int32_t *bitmap, count, dd, *entryp, i, id, ndx, nentries, *tmpmap;
-  u_int8_t *pptr;
+  uint32_t *bitmap, count, dd, *entryp, i, id, ndx, nentries, *tmpmap;
+  uint8_t *pptr;
   int is_first, ret;
 
   lt = dbenv->lk_handle;
@@ -282,12 +282,12 @@ retry:count = region->nlockers;
    * reallocing if necessary because count grew by too much.
    */
   if ((ret = CDB___os_calloc ((size_t) count,
-                              sizeof (u_int32_t) * nentries, &bitmap)) != 0)
+                              sizeof (uint32_t) * nentries, &bitmap)) != 0)
     return (ret);
 
-  if ((ret = CDB___os_calloc (sizeof (u_int32_t), nentries, &tmpmap)) != 0)
+  if ((ret = CDB___os_calloc (sizeof (uint32_t), nentries, &tmpmap)) != 0)
   {
-    CDB___os_free (bitmap, sizeof (u_int32_t) * nentries);
+    CDB___os_free (bitmap, sizeof (uint32_t) * nentries);
     return (ret);
   }
 
@@ -295,8 +295,8 @@ retry:count = region->nlockers;
        CDB___os_calloc ((size_t) count, sizeof (locker_info),
                         &id_array)) != 0)
   {
-    CDB___os_free (bitmap, count * sizeof (u_int32_t) * nentries);
-    CDB___os_free (tmpmap, sizeof (u_int32_t) * nentries);
+    CDB___os_free (bitmap, count * sizeof (uint32_t) * nentries);
+    CDB___os_free (tmpmap, sizeof (uint32_t) * nentries);
     return (ret);
   }
 
@@ -306,8 +306,8 @@ retry:count = region->nlockers;
   MEMORY_LOCK (lt);
   if (region->nlockers > count)
   {
-    CDB___os_free (bitmap, count * sizeof (u_int32_t) * nentries);
-    CDB___os_free (tmpmap, sizeof (u_int32_t) * nentries);
+    CDB___os_free (bitmap, count * sizeof (uint32_t) * nentries);
+    CDB___os_free (tmpmap, sizeof (uint32_t) * nentries);
     CDB___os_free (id_array, count * sizeof (locker_info));
     goto retry;
   }
@@ -468,7 +468,7 @@ retry:count = region->nlockers;
     {
       id_array[id].last_locker_id = lockerp->id;
     get_lock:id_array[id].last_lock = R_OFFSET (&lt->reginfo, lp);
-      lo = (DB_LOCKOBJ *) ((u_int8_t *) lp + lp->obj);
+      lo = (DB_LOCKOBJ *) ((uint8_t *) lp + lp->obj);
       pptr = SH_DBT_PTR (&lo->lockobj);
       if (lo->lockobj.size >= sizeof (db_pgno_t))
         memcpy (&id_array[id].pgno, pptr, sizeof (db_pgno_t));
@@ -490,18 +490,18 @@ retry:count = region->nlockers;
   *nlockers = id;
   *idmap = id_array;
   *bmp = bitmap;
-  CDB___os_free (tmpmap, sizeof (u_int32_t) * nentries);
+  CDB___os_free (tmpmap, sizeof (uint32_t) * nentries);
   return (0);
 }
 
 static int
 CDB___dd_find (bmp, idmap, nlockers, deadp)
-     u_int32_t *bmp, nlockers;
+     uint32_t *bmp, nlockers;
      locker_info *idmap;
-     u_int32_t ***deadp;
+     uint32_t ***deadp;
 {
-  u_int32_t i, j, k, nentries, *mymap, *tmpmap;
-  u_int32_t **retp;
+  uint32_t i, j, k, nentries, *mymap, *tmpmap;
+  uint32_t **retp;
   int ndead, ndeadalloc, ret;
 
 #undef  INITIAL_DEAD_ALLOC
@@ -510,7 +510,7 @@ CDB___dd_find (bmp, idmap, nlockers, deadp)
   ndeadalloc = INITIAL_DEAD_ALLOC;
   ndead = 0;
   if ((ret =
-       CDB___os_malloc (ndeadalloc * sizeof (u_int32_t *), NULL, &retp)) != 0)
+       CDB___os_malloc (ndeadalloc * sizeof (uint32_t *), NULL, &retp)) != 0)
     return (ret);
 
   /*
@@ -541,7 +541,7 @@ CDB___dd_find (bmp, idmap, nlockers, deadp)
          * If the alloc fails, then simply return the
          * deadlocks that we already have.
          */
-        if (CDB___os_realloc (ndeadalloc * sizeof (u_int32_t),
+        if (CDB___os_realloc (ndeadalloc * sizeof (uint32_t),
                               NULL, &retp) != 0)
         {
           retp[ndead] = NULL;
@@ -573,7 +573,7 @@ CDB___dd_abort (dbenv, info)
   DB_LOCKOBJ *sh_obj;
   DB_LOCKREGION *region;
   DB_LOCKTAB *lt;
-  u_int32_t ndx;
+  uint32_t ndx;
   int ret;
 
   lt = dbenv->lk_handle;
@@ -612,7 +612,7 @@ CDB___dd_abort (dbenv, info)
     goto out;
   }
 
-  sh_obj = (DB_LOCKOBJ *) ((u_int8_t *) lockp + lockp->obj);
+  sh_obj = (DB_LOCKOBJ *) ((uint8_t *) lockp + lockp->obj);
   SH_LIST_REMOVE (lockp, locker_links, __db_lock);
   LOCKER_UNLOCK (lt, ndx);
 
@@ -642,9 +642,9 @@ static void
 __dd_debug (dbenv, idmap, bitmap, nlockers)
      DB_ENV *dbenv;
      locker_info *idmap;
-     u_int32_t *bitmap, nlockers;
+     uint32_t *bitmap, nlockers;
 {
-  u_int32_t i, j, *mymap, nentries;
+  uint32_t i, j, *mymap, nentries;
   int ret;
   char *msgbuf;
 

--- a/db/lock_ext.h
+++ b/db/lock_ext.h
@@ -2,15 +2,15 @@
 #ifndef _lock_ext_h_
 #define _lock_ext_h_
 int CDB___lock_downgrade __P ((DB_ENV *,
-                               DB_LOCK *, db_lockmode_t, u_int32_t));
-int CDB___lock_addfamilylocker __P ((DB_ENV *, u_int32_t, u_int32_t));
-int CDB___lock_freefamilylocker __P ((DB_LOCKTAB *, u_int32_t));
+                               DB_LOCK *, db_lockmode_t, uint32_t));
+int CDB___lock_addfamilylocker __P ((DB_ENV *, uint32_t, uint32_t));
+int CDB___lock_freefamilylocker __P ((DB_LOCKTAB *, uint32_t));
 void CDB___lock_freelocker __P ((DB_LOCKTAB *,
-                                 DB_LOCKREGION *, DB_LOCKER *, u_int32_t));
+                                 DB_LOCKREGION *, DB_LOCKER *, uint32_t));
 int CDB___lock_getlocker __P ((DB_LOCKTAB *,
-                               u_int32_t, u_int32_t, int, DB_LOCKER **));
+                               uint32_t, uint32_t, int, DB_LOCKER **));
 int CDB___lock_getobj __P ((DB_LOCKTAB *,
-                            const DBT *, u_int32_t, int, DB_LOCKOBJ **));
+                            const DBT *, uint32_t, int, DB_LOCKOBJ **));
 int CDB___lock_promote __P ((DB_LOCKTAB *, DB_LOCKOBJ *));
 void CDB___lock_printlock __P ((DB_LOCKTAB *, struct __db_lock *, int));
 void CDB___lock_dbenv_create __P ((DB_ENV *));
@@ -19,8 +19,8 @@ int CDB___lock_open __P ((DB_ENV *));
 int CDB___lock_close __P ((DB_ENV *));
 void CDB___lock_dump_region __P ((DB_ENV *, char *, FILE *));
 int CDB___lock_cmp __P ((const DBT *, DB_LOCKOBJ *));
-int CDB___lock_locker_cmp __P ((u_int32_t, DB_LOCKER *));
-u_int32_t CDB___lock_ohash __P ((const DBT *));
-u_int32_t CDB___lock_lhash __P ((DB_LOCKOBJ *));
-u_int32_t CDB___lock_locker_hash __P ((u_int32_t));
+int CDB___lock_locker_cmp __P ((uint32_t, DB_LOCKER *));
+uint32_t CDB___lock_ohash __P ((const DBT *));
+uint32_t CDB___lock_lhash __P ((DB_LOCKOBJ *));
+uint32_t CDB___lock_locker_hash __P ((uint32_t));
 #endif /* _lock_ext_h_ */

--- a/db/lock_region.c
+++ b/db/lock_region.c
@@ -28,16 +28,16 @@ static void CDB___lock_dump_object __P ((DB_LOCKTAB *, DB_LOCKOBJ *, FILE *));
 static const char *CDB___lock_dump_status __P ((db_status_t));
 static int CDB___lock_init __P ((DB_ENV *, DB_LOCKTAB *));
 static size_t CDB___lock_region_size __P ((DB_ENV *));
-static int CDB___lock_set_lk_conflicts __P ((DB_ENV *, u_int8_t *, int));
-static int CDB___lock_set_lk_detect __P ((DB_ENV *, u_int32_t));
-static int CDB___lock_set_lk_max __P ((DB_ENV *, u_int32_t));
+static int CDB___lock_set_lk_conflicts __P ((DB_ENV *, uint8_t *, int));
+static int CDB___lock_set_lk_detect __P ((DB_ENV *, uint32_t));
+static int CDB___lock_set_lk_max __P ((DB_ENV *, uint32_t));
 
 /*
  * This conflict array is used for concurrent db access (CDB).  It
  * uses the same locks as the db_rw_conflict array, but adds an IW
  * mode to be used for write cursors.
  */
-static u_int8_t const db_cdb_conflicts[] = {
+static uint8_t const db_cdb_conflicts[] = {
   /*    N   R   W  IW */
   /*    N */ 0, 0, 0, 0,
   /*    R */ 0, 0, 1, 0,
@@ -86,7 +86,7 @@ CDB___lock_dbenv_close (dbenv)
 static int
 CDB___lock_set_lk_conflicts (dbenv, lk_conflicts, lk_modes)
      DB_ENV *dbenv;
-     u_int8_t *lk_conflicts;
+     uint8_t *lk_conflicts;
      int lk_modes;
 {
   int ret;
@@ -115,7 +115,7 @@ CDB___lock_set_lk_conflicts (dbenv, lk_conflicts, lk_modes)
 static int
 CDB___lock_set_lk_detect (dbenv, lk_detect)
      DB_ENV *dbenv;
-     u_int32_t lk_detect;
+     uint32_t lk_detect;
 {
   ENV_ILLEGAL_AFTER_OPEN (dbenv, "set_lk_detect");
 
@@ -140,7 +140,7 @@ CDB___lock_set_lk_detect (dbenv, lk_detect)
 static int
 CDB___lock_set_lk_max (dbenv, lk_max)
      DB_ENV *dbenv;
-     u_int32_t lk_max;
+     uint32_t lk_max;
 {
   ENV_ILLEGAL_AFTER_OPEN (dbenv, "set_lk_max");
 
@@ -209,7 +209,7 @@ CDB___lock_open (dbenv)
 
   /* Set remaining pointers into region. */
   lt->memlock = (MUTEX *) R_ADDR (&lt->reginfo, region->memlock_off);
-  lt->conflicts = (u_int8_t *) R_ADDR (&lt->reginfo, region->conf_off);
+  lt->conflicts = (uint8_t *) R_ADDR (&lt->reginfo, region->conf_off);
   lt->obj_tab = (DB_HASHTAB *) R_ADDR (&lt->reginfo, region->obj_off);
   lt->osynch_tab = (MUTEX *) R_ADDR (&lt->reginfo, region->osynch_off);
   lt->locker_tab = (DB_HASHTAB *) R_ADDR (&lt->reginfo, region->locker_off);
@@ -240,7 +240,7 @@ CDB___lock_init (dbenv, lt)
      DB_ENV *dbenv;
      DB_LOCKTAB *lt;
 {
-  const u_int8_t *lk_conflicts;
+  const uint8_t *lk_conflicts;
   struct __db_lock *lp;
   DB_LOCKER *lidp;
   DB_LOCKOBJ *op;
@@ -248,8 +248,8 @@ CDB___lock_init (dbenv, lt)
 #ifdef FINE_GRAIN
   MUTEX *m;
 #endif
-  u_int32_t i, lk_modes, nelements;
-  u_int8_t *addr;
+  uint32_t i, lk_modes, nelements;
+  uint8_t *addr;
   int ret;
 
   if ((ret = CDB___db_shalloc (lt->reginfo.addr,
@@ -495,7 +495,7 @@ CDB___lock_dump_region (dbenv, area, fp)
   DB_LOCKOBJ *op;
   DB_LOCKREGION *lrp;
   DB_LOCKTAB *lt;
-  u_int32_t flags, i, j;
+  uint32_t flags, i, j;
   int label;
 
   /* Make it easy to call from the debugger. */
@@ -645,8 +645,8 @@ CDB___lock_dump_object (lt, op, fp)
      FILE *fp;
 {
   struct __db_lock *lp;
-  u_int32_t j;
-  u_int8_t *ptr;
+  uint32_t j;
+  uint8_t *ptr;
   u_int ch;
 
   ptr = SH_DBT_PTR (&op->lockobj);
@@ -704,7 +704,7 @@ CDB___lock_region_size (dbenv)
      DB_ENV *dbenv;
 {
   size_t retval;
-  u_int32_t i, nelements, nlocks;
+  uint32_t i, nelements, nlocks;
 
   nlocks = dbenv->lk_max;
   nelements = CDB___db_tablesize (dbenv->lk_max);

--- a/db/lock_util.c
+++ b/db/lock_util.c
@@ -46,11 +46,11 @@ CDB___lock_cmp (dbt, lock_obj)
 }
 
 /*
- * PUBLIC: int CDB___lock_locker_cmp __P((u_int32_t, DB_LOCKER *));
+ * PUBLIC: int CDB___lock_locker_cmp __P((uint32_t, DB_LOCKER *));
  */
 int
 CDB___lock_locker_cmp (locker, sh_locker)
-     u_int32_t locker;
+     uint32_t locker;
      DB_LOCKER *sh_locker;
 {
   return (locker == sh_locker->id);
@@ -77,10 +77,10 @@ CDB___lock_locker_cmp (locker, sh_locker)
  * we're coming through this code path.
  */
 #define FAST_HASH(P) {      \
-  u_int32_t __h;      \
-  u_int8_t *__cp, *__hp;    \
-  __hp = (u_int8_t *)&__h;  \
-  __cp = (u_int8_t *)(P);    \
+  uint32_t __h;      \
+  uint8_t *__cp, *__hp;    \
+  __hp = (uint8_t *)&__h;  \
+  __cp = (uint8_t *)(P);    \
   __hp[0] = __cp[0] ^ __cp[4];  \
   __hp[1] = __cp[1] ^ __cp[5];  \
   __hp[2] = __cp[2] ^ __cp[6];  \
@@ -91,9 +91,9 @@ CDB___lock_locker_cmp (locker, sh_locker)
 /*
  * CDB___lock_ohash --
  *
- * PUBLIC: u_int32_t CDB___lock_ohash __P((const DBT *));
+ * PUBLIC: uint32_t CDB___lock_ohash __P((const DBT *));
  */
-u_int32_t
+uint32_t
 CDB___lock_ohash (dbt)
      const DBT *dbt;
 {
@@ -106,9 +106,9 @@ CDB___lock_ohash (dbt)
 /*
  * CDB___lock_lhash --
  *
- * PUBLIC: u_int32_t CDB___lock_lhash __P((DB_LOCKOBJ *));
+ * PUBLIC: uint32_t CDB___lock_lhash __P((DB_LOCKOBJ *));
  */
-u_int32_t
+uint32_t
 CDB___lock_lhash (lock_obj)
      DB_LOCKOBJ *lock_obj;
 {
@@ -128,11 +128,11 @@ CDB___lock_lhash (lock_obj)
  *   Since these are simply 32-bit unsigned integers, just return
  *  the locker value.
  *
- * PUBLIC: u_int32_t CDB___lock_locker_hash __P((u_int32_t));
+ * PUBLIC: uint32_t CDB___lock_locker_hash __P((uint32_t));
  */
-u_int32_t
+uint32_t
 CDB___lock_locker_hash (locker)
-     u_int32_t locker;
+     uint32_t locker;
 {
   return (locker);
 }

--- a/db/log.c
+++ b/db/log.c
@@ -164,7 +164,7 @@ CDB___log_recover (dblp)
   DBT dbt;
   DB_LSN lsn;
   LOG *lp;
-  u_int32_t chk;
+  uint32_t chk;
   int cnt, found_checkpoint, ret;
 
   lp = dblp->reginfo.primary;
@@ -201,9 +201,9 @@ CDB___log_recover (dblp)
   found_checkpoint = 0;
   while (CDB___log_get (dblp, &lsn, &dbt, DB_NEXT, 1) == 0)
   {
-    if (dbt.size < sizeof (u_int32_t))
+    if (dbt.size < sizeof (uint32_t))
       continue;
-    memcpy (&chk, dbt.data, sizeof (u_int32_t));
+    memcpy (&chk, dbt.data, sizeof (uint32_t));
     if (chk == DB_txn_ckp)
     {
       lp->chkpt_lsn = lsn;
@@ -244,9 +244,9 @@ CDB___log_recover (dblp)
      */
     while (CDB___log_get (dblp, &lsn, &dbt, DB_NEXT, 1) == 0)
     {
-      if (dbt.size < sizeof (u_int32_t))
+      if (dbt.size < sizeof (uint32_t))
         continue;
-      memcpy (&chk, dbt.data, sizeof (u_int32_t));
+      memcpy (&chk, dbt.data, sizeof (uint32_t));
       if (chk == DB_txn_ckp)
       {
         lp->chkpt_lsn = lsn;
@@ -286,7 +286,7 @@ CDB___log_find (dblp, find_first, valp)
      DB_LOG *dblp;
      int find_first, *valp;
 {
-  u_int32_t clv, logval;
+  uint32_t clv, logval;
   int cnt, fcnt, ret;
   const char *dir;
   char **names, *p, *q;
@@ -360,12 +360,12 @@ CDB___log_find (dblp, find_first, valp)
  * log_valid --
  *  Validate a log file.
  *
- * PUBLIC: int CDB___log_valid __P((DB_LOG *, u_int32_t, int));
+ * PUBLIC: int CDB___log_valid __P((DB_LOG *, uint32_t, int));
  */
 int
 CDB___log_valid (dblp, number, set_persist)
      DB_LOG *dblp;
-     u_int32_t number;
+     uint32_t number;
      int set_persist;
 {
   DB_FH fh;

--- a/db/log.h
+++ b/db/log.h
@@ -44,8 +44,8 @@ typedef struct __log_persist LOGP;
 typedef struct __db_entry
 {
   DB *dbp;                      /* Associated DB structure. */
-  u_int32_t refcount;           /* Reference counted. */
-  u_int32_t count;              /* Number of ops on a deleted db. */
+  uint32_t refcount;           /* Reference counted. */
+  uint32_t count;              /* Number of ops on a deleted db. */
   int deleted;                  /* File was not found during open. */
 } DB_ENTRY;
 
@@ -67,7 +67,7 @@ struct __db_log
 
   DB_ENTRY *dbentry;            /* Recovery file-id mapping. */
 #define  DB_GROW_SIZE  64
-  u_int32_t dbentry_cnt;        /* Entries.  Grows by DB_GROW_SIZE. */
+  uint32_t dbentry_cnt;        /* Entries.  Grows by DB_GROW_SIZE. */
 
 /*
  * These fields are always accessed while the region lock is held, so they do
@@ -75,16 +75,16 @@ struct __db_log
  * when threads are not being used, i.e. most cursor operations are disallowed
  * on threaded logs.
  */
-  u_int32_t lfname;             /* Log file "name". */
+  uint32_t lfname;             /* Log file "name". */
   DB_FH lfh;                    /* Log file handle. */
 
   DB_LSN c_lsn;                 /* Cursor: current LSN. */
   DBT c_dbt;                    /* Cursor: return DBT structure. */
   DB_FH c_fh;                   /* Cursor: file handle. */
-  u_int32_t c_off;              /* Cursor: previous record offset. */
-  u_int32_t c_len;              /* Cursor: current record length. */
+  uint32_t c_off;              /* Cursor: previous record offset. */
+  uint32_t c_len;              /* Cursor: current record length. */
 
-  u_int8_t *bufp;               /* Region buffer. */
+  uint8_t *bufp;               /* Region buffer. */
 
 /* These fields are not protected. */
   DB_ENV *dbenv;                /* Reference to error information. */
@@ -106,7 +106,7 @@ struct __db_log
    * Currently used to hold:
    *  DBC_RECOVER  (a DBC flag)
    */
-  u_int32_t flags;
+  uint32_t flags;
 };
 
 /*
@@ -115,17 +115,17 @@ struct __db_log
  */
 struct __hdr
 {
-  u_int32_t prev;               /* Previous offset. */
-  u_int32_t cksum;              /* Current checksum. */
-  u_int32_t len;                /* Current length. */
+  uint32_t prev;               /* Previous offset. */
+  uint32_t cksum;              /* Current checksum. */
+  uint32_t len;                /* Current length. */
 };
 
 struct __log_persist
 {
-  u_int32_t magic;              /* DB_LOGMAGIC */
-  u_int32_t version;            /* DB_LOGVERSION */
+  uint32_t magic;              /* DB_LOGMAGIC */
+  uint32_t version;            /* DB_LOGVERSION */
 
-  u_int32_t lg_max;             /* Maximum file size. */
+  uint32_t lg_max;             /* Maximum file size. */
   int mode;                     /* Log file mode. */
 };
 
@@ -152,9 +152,9 @@ struct __log
    */
   DB_LSN s_lsn;                 /* LSN of the last sync. */
 
-  u_int32_t len;                /* Length of the last record. */
+  uint32_t len;                /* Length of the last record. */
 
-  u_int32_t w_off;              /* Current write offset in the file. */
+  uint32_t w_off;              /* Current write offset in the file. */
 
   DB_LSN chkpt_lsn;             /* LSN of the last checkpoint. */
   time_t chkpt;                 /* Time of the last checkpoint. */
@@ -171,7 +171,7 @@ struct __log
   size_t b_off;                 /* Current offset in the buffer. */
 
   roff_t buffer_off;            /* Log buffer offset. */
-  u_int32_t buffer_size;        /* Log buffer size. */
+  uint32_t buffer_size;        /* Log buffer size. */
 };
 
 /*
@@ -182,13 +182,13 @@ struct __fname
 {
   SH_TAILQ_ENTRY q;             /* File name queue. */
 
-  u_int16_t ref;                /* Reference count. */
+  uint16_t ref;                /* Reference count. */
 
   int32_t id;                   /* Logging file id. */
   DBTYPE s_type;                /* Saved DB type. */
 
   roff_t name_off;              /* Name offset. */
-  u_int8_t ufid[DB_FILE_ID_LEN];        /* Unique file id. */
+  uint8_t ufid[DB_FILE_ID_LEN];        /* Unique file id. */
 };
 
 /* File open/close register log record opcodes. */

--- a/db/log_archive.c
+++ b/db/log_archive.c
@@ -45,13 +45,13 @@ int
 CDB_log_archive (dbenv, listp, flags, db_malloc)
      DB_ENV *dbenv;
      char ***listp;
-     u_int32_t flags;
+     uint32_t flags;
      void *(*db_malloc) __P ((size_t));
 {
   DBT rec;
   DB_LOG *dblp;
   DB_LSN stable_lsn;
-  u_int32_t fnum;
+  uint32_t fnum;
   int array_size, n, ret;
   char **array, **arrayp, *name, *p, *pref, buf[MAXPATHLEN];
 
@@ -219,7 +219,7 @@ CDB___build_data (dbenv, pref, listp, db_malloc)
   DB_LOG *dblp;
   DB_LSN lsn;
   __log_register_args *argp;
-  u_int32_t rectype;
+  uint32_t rectype;
   int array_size, last, n, nxt, ret;
   char **array, **arrayp, *p, *real_name;
 

--- a/db/log_auto.c
+++ b/db/log_auto.c
@@ -22,19 +22,19 @@ CDB___log_register_log (dbenv, txnid, ret_lsnp, flags,
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
-     u_int32_t opcode;
+     uint32_t flags;
+     uint32_t opcode;
      const DBT *name;
      const DBT *uid;
-     u_int32_t id;
+     uint32_t id;
      DBTYPE ftype;
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t zero;
-  u_int32_t rectype, txn_num;
+  uint32_t zero;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -50,8 +50,8 @@ CDB___log_register_log (dbenv, txnid, ret_lsnp, flags,
     lsnp = &txnid->last_lsn;
   logrec.size = sizeof (rectype) + sizeof (txn_num) + sizeof (DB_LSN)
     + sizeof (opcode)
-    + sizeof (u_int32_t) + (name == NULL ? 0 : name->size)
-    + sizeof (u_int32_t) + (uid == NULL ? 0 : uid->size)
+    + sizeof (uint32_t) + (name == NULL ? 0 : name->size)
+    + sizeof (uint32_t) + (uid == NULL ? 0 : uid->size)
     + sizeof (id) + sizeof (ftype);
   if ((ret = CDB___os_malloc (logrec.size, NULL, &logrec.data)) != 0)
     return (ret);
@@ -68,8 +68,8 @@ CDB___log_register_log (dbenv, txnid, ret_lsnp, flags,
   if (name == NULL)
   {
     zero = 0;
-    memcpy (bp, &zero, sizeof (u_int32_t));
-    bp += sizeof (u_int32_t);
+    memcpy (bp, &zero, sizeof (uint32_t));
+    bp += sizeof (uint32_t);
   }
   else
   {
@@ -81,8 +81,8 @@ CDB___log_register_log (dbenv, txnid, ret_lsnp, flags,
   if (uid == NULL)
   {
     zero = 0;
-    memcpy (bp, &zero, sizeof (u_int32_t));
-    bp += sizeof (u_int32_t);
+    memcpy (bp, &zero, sizeof (uint32_t));
+    bp += sizeof (uint32_t);
   }
   else
   {
@@ -95,7 +95,7 @@ CDB___log_register_log (dbenv, txnid, ret_lsnp, flags,
   bp += sizeof (id);
   memcpy (bp, &ftype, sizeof (ftype));
   bp += sizeof (ftype);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB___log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -112,7 +112,7 @@ CDB___log_register_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __log_register_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -133,7 +133,7 @@ CDB___log_register_print (notused1, dbtp, lsnp, notused2, notused3)
   printf ("\tname: ");
   for (i = 0; i < argp->name.size; i++)
   {
-    ch = ((u_int8_t *) argp->name.data)[i];
+    ch = ((uint8_t *) argp->name.data)[i];
     if (isprint (ch) || ch == 0xa)
       putchar (ch);
     else
@@ -143,7 +143,7 @@ CDB___log_register_print (notused1, dbtp, lsnp, notused2, notused3)
   printf ("\tuid: ");
   for (i = 0; i < argp->uid.size; i++)
   {
-    ch = ((u_int8_t *) argp->uid.data)[i];
+    ch = ((uint8_t *) argp->uid.data)[i];
     if (isprint (ch) || ch == 0xa)
       putchar (ch);
     else
@@ -163,7 +163,7 @@ CDB___log_register_read (recbuf, argpp)
      __log_register_args **argpp;
 {
   __log_register_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__log_register_args) +
@@ -181,13 +181,13 @@ CDB___log_register_read (recbuf, argpp)
   memcpy (&argp->opcode, bp, sizeof (argp->opcode));
   bp += sizeof (argp->opcode);
   memset (&argp->name, 0, sizeof (argp->name));
-  memcpy (&argp->name.size, bp, sizeof (u_int32_t));
-  bp += sizeof (u_int32_t);
+  memcpy (&argp->name.size, bp, sizeof (uint32_t));
+  bp += sizeof (uint32_t);
   argp->name.data = bp;
   bp += argp->name.size;
   memset (&argp->uid, 0, sizeof (argp->uid));
-  memcpy (&argp->uid.size, bp, sizeof (u_int32_t));
-  bp += sizeof (u_int32_t);
+  memcpy (&argp->uid.size, bp, sizeof (uint32_t));
+  bp += sizeof (uint32_t);
   argp->uid.data = bp;
   bp += argp->uid.size;
   memcpy (&argp->id, bp, sizeof (argp->id));

--- a/db/log_auto.h
+++ b/db/log_auto.h
@@ -7,19 +7,19 @@
 
 typedef struct _log_register_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
-  u_int32_t opcode;
+  uint32_t opcode;
   DBT name;
   DBT uid;
-  u_int32_t id;
+  uint32_t id;
   DBTYPE ftype;
 } __log_register_args;
 
 int CDB___log_register_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, u_int32_t, const DBT *,
-      const DBT *, u_int32_t, DBTYPE));
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, uint32_t, const DBT *,
+      const DBT *, uint32_t, DBTYPE));
 int CDB___log_register_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___log_register_read __P ((void *, __log_register_args **));
 int CDB___log_init_print __P ((DB_ENV *));

--- a/db/log_ext.h
+++ b/db/log_ext.h
@@ -3,17 +3,17 @@
 #define _log_ext_h_
 int CDB___log_open __P ((DB_ENV *));
 int CDB___log_find __P ((DB_LOG *, int, int *));
-int CDB___log_valid __P ((DB_LOG *, u_int32_t, int));
+int CDB___log_valid __P ((DB_LOG *, uint32_t, int));
 int CDB___log_close __P ((DB_ENV *));
 int CDB___log_init_recover __P ((DB_ENV *));
 int CDB___log_findckp __P ((DB_ENV *, DB_LSN *));
-int CDB___log_get __P ((DB_LOG *, DB_LSN *, DBT *, u_int32_t, int));
+int CDB___log_get __P ((DB_LOG *, DB_LSN *, DBT *, uint32_t, int));
 void CDB___log_dbenv_create __P ((DB_ENV *));
-int CDB___log_put __P ((DB_ENV *, DB_LSN *, const DBT *, u_int32_t));
-int CDB___log_name __P ((DB_LOG *, u_int32_t, char **, DB_FH *, u_int32_t));
+int CDB___log_put __P ((DB_ENV *, DB_LSN *, const DBT *, uint32_t));
+int CDB___log_name __P ((DB_LOG *, uint32_t, char **, DB_FH *, uint32_t));
 int CDB___log_register_recover __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
-int CDB___log_add_logid __P ((DB_LOG *, DB *, u_int32_t));
+int CDB___log_add_logid __P ((DB_LOG *, DB *, uint32_t));
 int CDB___db_fileid_to_db __P ((DB_ENV *, DB **, int32_t, int));
 void CDB___log_close_files __P ((DB_ENV *));
-void CDB___log_rem_logid __P ((DB_LOG *, u_int32_t));
+void CDB___log_rem_logid __P ((DB_LOG *, uint32_t));
 #endif /* _log_ext_h_ */

--- a/db/log_get.c
+++ b/db/log_get.c
@@ -36,7 +36,7 @@ CDB_log_get (dbenv, alsn, dbt, flags)
      DB_ENV *dbenv;
      DB_LSN *alsn;
      DBT *dbt;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB_LOG *dblp;
   int ret;
@@ -90,14 +90,14 @@ CDB_log_get (dbenv, alsn, dbt, flags)
  * CDB___log_get --
  *  Get a log record; internal version.
  *
- * PUBLIC: int CDB___log_get __P((DB_LOG *, DB_LSN *, DBT *, u_int32_t, int));
+ * PUBLIC: int CDB___log_get __P((DB_LOG *, DB_LSN *, DBT *, uint32_t, int));
  */
 int
 CDB___log_get (dblp, alsn, dbt, flags, silent)
      DB_LOG *dblp;
      DB_LSN *alsn;
      DBT *dbt;
-     u_int32_t flags;
+     uint32_t flags;
      int silent;
 {
   DB_LSN nlsn;
@@ -109,7 +109,7 @@ CDB___log_get (dblp, alsn, dbt, flags, silent)
   char *np, *tbuf;
   const char *fail;
   void *shortp;
-  u_int8_t *p;
+  uint8_t *p;
 
   lp = dblp->reginfo.primary;
   fail = np = tbuf = NULL;
@@ -263,7 +263,7 @@ CDB___log_get (dblp, alsn, dbt, flags, silent)
       goto corrupt;
 
     /* Get the rest of the header from the in-memory buffer. */
-    memcpy ((u_int8_t *) & hdr + nr, dblp->bufp, sizeof (HDR) - nr);
+    memcpy ((uint8_t *) & hdr + nr, dblp->bufp, sizeof (HDR) - nr);
     shortp = dblp->bufp + (sizeof (HDR) - nr);
   }
 
@@ -283,7 +283,7 @@ CDB___log_get (dblp, alsn, dbt, flags, silent)
   /* If we've already moved to the in-memory buffer, fill from there. */
   if (shortp != NULL)
   {
-    if (lp->b_off < ((u_int8_t *) shortp - dblp->bufp) + len)
+    if (lp->b_off < ((uint8_t *) shortp - dblp->bufp) + len)
       goto corrupt;
     if ((ret = CDB___db_retcopy (NULL, dbt, shortp, len,
                                  &dblp->c_dbt.data, &dblp->c_dbt.ulen)) != 0)
@@ -329,7 +329,7 @@ CDB___log_get (dblp, alsn, dbt, flags, silent)
       goto corrupt;
 
     /* Get the rest of the record from the in-memory buffer. */
-    memcpy ((u_int8_t *) tbuf + nr, dblp->bufp, len - nr);
+    memcpy ((uint8_t *) tbuf + nr, dblp->bufp, len - nr);
   }
 
   /* Copy the record into the user's DBT. */

--- a/db/log_method.c
+++ b/db/log_method.c
@@ -26,8 +26,8 @@ static const char sccsid[] = "@(#)log_method.c  11.3 (Sleepycat) 8/11/99";
 #include "db_int.h"
 #include "log.h"
 
-static int CDB___log_set_lg_max __P ((DB_ENV *, u_int32_t));
-static int CDB___log_set_lg_bsize __P ((DB_ENV *, u_int32_t));
+static int CDB___log_set_lg_max __P ((DB_ENV *, uint32_t));
+static int CDB___log_set_lg_bsize __P ((DB_ENV *, uint32_t));
 
 /*
  * CDB___log_dbenv_create --
@@ -53,7 +53,7 @@ CDB___log_dbenv_create (dbenv)
 static int
 CDB___log_set_lg_bsize (dbenv, lg_bsize)
      DB_ENV *dbenv;
-     u_int32_t lg_bsize;
+     uint32_t lg_bsize;
 {
   ENV_ILLEGAL_AFTER_OPEN (dbenv, "set_lg_bsize");
 
@@ -75,7 +75,7 @@ CDB___log_set_lg_bsize (dbenv, lg_bsize)
 static int
 CDB___log_set_lg_max (dbenv, lg_max)
      DB_ENV *dbenv;
-     u_int32_t lg_max;
+     uint32_t lg_max;
 {
   ENV_ILLEGAL_AFTER_OPEN (dbenv, "set_lg_max");
 

--- a/db/log_put.c
+++ b/db/log_put.c
@@ -39,11 +39,11 @@ static const char sccsid[] = "@(#)CDB_log_put.c  11.4 (Sleepycat) 11/10/99";
 #include "log.h"
 #include "hash.h"
 
-static int CDB___log_fill __P ((DB_LOG *, DB_LSN *, void *, u_int32_t));
+static int CDB___log_fill __P ((DB_LOG *, DB_LSN *, void *, uint32_t));
 static int CDB___log_flush __P ((DB_LOG *, const DB_LSN *));
 static int CDB___log_newfh __P ((DB_LOG *));
-static int CDB___log_putr __P ((DB_LOG *, DB_LSN *, const DBT *, u_int32_t));
-static int CDB___log_write __P ((DB_LOG *, void *, u_int32_t));
+static int CDB___log_putr __P ((DB_LOG *, DB_LSN *, const DBT *, uint32_t));
+static int CDB___log_write __P ((DB_LOG *, void *, uint32_t));
 
 /*
  * CDB_log_put --
@@ -54,7 +54,7 @@ CDB_log_put (dbenv, lsn, dbt, flags)
      DB_ENV *dbenv;
      DB_LSN *lsn;
      const DBT *dbt;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB_LOG *dblp;
   int ret;
@@ -78,21 +78,21 @@ CDB_log_put (dbenv, lsn, dbt, flags)
  * CDB___log_put --
  *  Write a log record; internal version.
  *
- * PUBLIC: int CDB___log_put __P((DB_ENV *, DB_LSN *, const DBT *, u_int32_t));
+ * PUBLIC: int CDB___log_put __P((DB_ENV *, DB_LSN *, const DBT *, uint32_t));
  */
 int
 CDB___log_put (dbenv, lsn, dbt, flags)
      DB_ENV *dbenv;
      DB_LSN *lsn;
      const DBT *dbt;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DBT fid_dbt, t;
   DB_LOG *dblp;
   DB_LSN r_unused;
   FNAME *fnp;
   LOG *lp;
-  u_int32_t lastoff;
+  uint32_t lastoff;
   int ret;
 
   dblp = dbenv->lg_handle;
@@ -226,7 +226,7 @@ CDB___log_putr (dblp, lsn, dbt, prev)
      DB_LOG *dblp;
      DB_LSN *lsn;
      const DBT *dbt;
-     u_int32_t prev;
+     uint32_t prev;
 {
   HDR hdr;
   LOG *lp;
@@ -396,10 +396,10 @@ CDB___log_fill (dblp, lsn, addr, len)
      DB_LOG *dblp;
      DB_LSN *lsn;
      void *addr;
-     u_int32_t len;
+     uint32_t len;
 {
   LOG *lp;
-  u_int32_t bsize, nrec;
+  uint32_t bsize, nrec;
   size_t nw, remain;
   int ret;
 
@@ -426,7 +426,7 @@ CDB___log_fill (dblp, lsn, addr, len)
       nrec = len / bsize;
       if ((ret = CDB___log_write (dblp, addr, nrec * bsize)) != 0)
         return (ret);
-      addr = (u_int8_t *) addr + nrec * bsize;
+      addr = (uint8_t *) addr + nrec * bsize;
       len -= nrec * bsize;
       ++lp->stat.st_wcount_fill;
       continue;
@@ -436,7 +436,7 @@ CDB___log_fill (dblp, lsn, addr, len)
     remain = bsize - lp->b_off;
     nw = remain > len ? len : remain;
     memcpy (dblp->bufp + lp->b_off, addr, nw);
-    addr = (u_int8_t *) addr + nw;
+    addr = (uint8_t *) addr + nw;
     len -= nw;
     lp->b_off += nw;
 
@@ -460,7 +460,7 @@ static int
 CDB___log_write (dblp, addr, len)
      DB_LOG *dblp;
      void *addr;
-     u_int32_t len;
+     uint32_t len;
 {
   LOG *lp;
   ssize_t nw;
@@ -579,12 +579,12 @@ CDB___log_newfh (dblp)
  *  Return the log name for a particular file, and optionally open it.
  *
  * PUBLIC: int CDB___log_name __P((DB_LOG *,
- * PUBLIC:     u_int32_t, char **, DB_FH *, u_int32_t));
+ * PUBLIC:     uint32_t, char **, DB_FH *, uint32_t));
  */
 int
 CDB___log_name (dblp, filenumber, namep, fhp, flags)
      DB_LOG *dblp;
-     u_int32_t filenumber, flags;
+     uint32_t filenumber, flags;
      char **namep;
      DB_FH *fhp;
 {

--- a/db/log_rec.c
+++ b/db/log_rec.c
@@ -54,7 +54,7 @@ static const char sccsid[] = "@(#)log_rec.c  11.16 (Sleepycat) 10/19/99";
 #include "db_ext.h"
 
 static int CDB___log_do_open
-__P ((DB_LOG *, u_int8_t *, char *, DBTYPE, u_int32_t));
+__P ((DB_LOG *, uint8_t *, char *, DBTYPE, uint32_t));
 static int CDB___log_lid_to_fname __P ((DB_LOG *, int32_t, FNAME **));
 static int CDB___log_open_file __P ((DB_LOG *, __log_register_args *));
 
@@ -228,14 +228,14 @@ CDB___log_open_file (lp, argp)
 static int
 CDB___log_do_open (lp, uid, name, ftype, ndx)
      DB_LOG *lp;
-     u_int8_t *uid;
+     uint8_t *uid;
      char *name;
      DBTYPE ftype;
-     u_int32_t ndx;
+     uint32_t ndx;
 {
   DB *dbp;
   int ret;
-  u_int8_t zeroid[DB_FILE_ID_LEN];
+  uint8_t zeroid[DB_FILE_ID_LEN];
 
   if ((ret = CDB_db_create (&dbp, lp->dbenv, 0)) != 0)
     return (ret);
@@ -263,15 +263,15 @@ CDB___log_do_open (lp, uid, name, ftype, ndx)
  * CDB___log_add_logid --
  *  Adds a DB entry to the log's DB entry table.
  *
- * PUBLIC: int CDB___log_add_logid __P((DB_LOG *, DB *, u_int32_t));
+ * PUBLIC: int CDB___log_add_logid __P((DB_LOG *, DB *, uint32_t));
  */
 int
 CDB___log_add_logid (logp, dbp, ndx)
      DB_LOG *logp;
      DB *dbp;
-     u_int32_t ndx;
+     uint32_t ndx;
 {
-  u_int32_t i;
+  uint32_t i;
   int ret;
 
   ret = 0;
@@ -345,7 +345,7 @@ CDB___db_fileid_to_db (dbenv, dbpp, ndx, inc)
    * by a process that does not necessarily have the file open, so we
    * we must open the file explicitly.
    */
-  if ((u_int32_t) ndx >= logp->dbentry_cnt ||
+  if ((uint32_t) ndx >= logp->dbentry_cnt ||
       (!logp->dbentry[ndx].deleted && logp->dbentry[ndx].dbp == NULL))
   {
     if (CDB___log_lid_to_fname (logp, ndx, &fname) != 0)
@@ -411,7 +411,7 @@ CDB___log_close_files (dbenv)
 {
   DB_ENTRY *dbe;
   DB_LOG *logp;
-  u_int32_t i;
+  uint32_t i;
 
   logp = dbenv->lg_handle;
   MUTEX_THREAD_LOCK (logp->mutexp);
@@ -432,12 +432,12 @@ CDB___log_close_files (dbenv)
 }
 
 /*
- * PUBLIC: void CDB___log_rem_logid __P((DB_LOG *, u_int32_t));
+ * PUBLIC: void CDB___log_rem_logid __P((DB_LOG *, uint32_t));
  */
 void
 CDB___log_rem_logid (logp, ndx)
      DB_LOG *logp;
-     u_int32_t ndx;
+     uint32_t ndx;
 {
   MUTEX_THREAD_LOCK (logp->mutexp);
   if (--logp->dbentry[ndx].refcount == 0)

--- a/db/mp.h
+++ b/db/mp.h
@@ -95,7 +95,7 @@ struct __db_mpoolfile
 
   DB_FH fh;                     /* Underlying file handle. */
 
-  u_int32_t ref;                /* Reference count. */
+  uint32_t ref;                /* Reference count. */
 
   /*
    * !!!
@@ -107,7 +107,7 @@ struct __db_mpoolfile
    * the race between the seek and write of the file descriptor) will
    * block any other put/get calls using this DB_MPOOLFILE structure.
    */
-  u_int32_t pinref;             /* Pinned block reference count. */
+  uint32_t pinref;             /* Pinned block reference count. */
 
   /*
    * !!!
@@ -128,7 +128,7 @@ struct __db_mpoolfile
 #define  MP_UPGRADE  0x02       /* File descriptor is readwrite. */
 #define  MP_UPGRADE_FAIL  0x04  /* Upgrade wasn't possible. */
 #define  MP_CMPR    0x08        /* Transparent I/O compression. */
-  u_int32_t flags;
+  uint32_t flags;
 
   CMPR_CONTEXT cmpr_context;    /* Shared compression information */
 
@@ -177,13 +177,13 @@ struct __mpool
    */
   MUTEX sync_mutex;             /* Checkpoint lock. */
   DB_LSN lsn;                   /* Maximum checkpoint LSN. */
-  u_int32_t lsn_cnt;            /* Checkpoint buffers left to write. */
+  uint32_t lsn_cnt;            /* Checkpoint buffers left to write. */
 
-  u_int32_t nc_reg;             /* Number of underlying REGIONS. */
+  uint32_t nc_reg;             /* Number of underlying REGIONS. */
   roff_t c_regids;              /* Array of underlying REGION Ids. */
 
 #define  MP_LSN_RETRY  0x01     /* Retry all BH_WRITE buffers. */
-  u_int32_t flags;
+  uint32_t flags;
 
   /* HACK!! */
   /* a pointers allocated for this structure is (erroneously?) used */
@@ -222,7 +222,7 @@ struct __mpoolfile
   int ftype;                    /* File type. */
 
   int32_t lsn_off;              /* Page's LSN offset. */
-  u_int32_t clear_len;          /* Bytes to clear on page create. */
+  uint32_t clear_len;          /* Bytes to clear on page create. */
 
   roff_t path_off;              /* File name location. */
   roff_t fileid_off;            /* File identification location. */
@@ -230,7 +230,7 @@ struct __mpoolfile
   roff_t pgcookie_len;          /* Pgin/pgout cookie length. */
   roff_t pgcookie_off;          /* Pgin/pgout cookie location. */
 
-  u_int32_t lsn_cnt;            /* Checkpoint buffers left to write. */
+  uint32_t lsn_cnt;            /* Checkpoint buffers left to write. */
 
   db_pgno_t last_pgno;          /* Last page in the file. */
   db_pgno_t orig_last_pgno;     /* Original last page in the file. */
@@ -238,7 +238,7 @@ struct __mpoolfile
 #define  MP_CAN_MMAP  0x01      /* If the file can be mmap'd. */
 #define  MP_REMOVED  0x02       /* Backing file has been removed. */
 #define  MP_TEMP    0x04        /* Backing file is a temporary. */
-  u_int32_t flags;
+  uint32_t flags;
 
   DB_MPOOL_FSTAT stat;          /* Per-file mpool statistics. */
 };
@@ -274,7 +274,7 @@ struct __cmpr
 #define DB_CMPR_CHAIN     0x04  /* More data in next page. */
 #define DB_CMPR_FREE    0x08    /* Not in use. */
 
-  u_int16_t flags;
+  uint16_t flags;
 
   /* 
    * Filled if DB_CMPR_CHAIN set
@@ -303,7 +303,7 @@ struct __bh
 {
   MUTEX mutex;                  /* Buffer thread/process lock. */
 
-  u_int16_t ref;                /* Reference count. */
+  uint16_t ref;                /* Reference count. */
 
 #define  BH_CALLPGIN  0x001     /* Page needs to be reworked... */
 #define  BH_DIRTY  0x002        /* Page was modified. */
@@ -314,7 +314,7 @@ struct __bh
 #define  BH_CMPR    0x040       /* Chain contains valid data. */
 #define  BH_CMPR_POOL  0x080    /* Chain allocated in pool. */
 #define  BH_CMPR_OS  0x100      /* Chain allocate with malloc. */
-  u_int16_t flags;
+  uint16_t flags;
 
   db_pgno_t *chain;             /* Compression chain. */
 
@@ -330,7 +330,7 @@ struct __bh
    * and other structures into it, and expect to be able to access them
    * directly.  (We guarantee size_t alignment in the documentation too.)
    */
-  u_int8_t buf[1];              /* Variable length data. */
+  uint8_t buf[1];              /* Variable length data. */
 };
 
 #include "mp_ext.h"

--- a/db/mp_alloc.c
+++ b/db/mp_alloc.c
@@ -53,7 +53,7 @@ CDB___memp_alloc (dbmp, memreg, mfp, len, offsetp, retp)
    * before free-ing and re-allocating buffers.
    */
   if (mfp != NULL)
-    len = (sizeof (BH) - sizeof (u_int8_t)) + mfp->stat.st_pagesize;
+    len = (sizeof (BH) - sizeof (uint8_t)) + mfp->stat.st_pagesize;
 
   nomore = 0;
 alloc:if ((ret =

--- a/db/mp_cmpr.c
+++ b/db/mp_cmpr.c
@@ -218,7 +218,7 @@ CDB___memp_cmpr_read (dbmfp, bhp, db_io, niop)
   CMPR cmpr;
   int ret;
   int chain = 0;
-  u_int8_t *buffcmpr = 0;
+  uint8_t *buffcmpr = 0;
   int buffcmpr_length = 0;
   int chain_length = 0;
   db_pgno_t first_pgno = db_io->pgno;
@@ -427,10 +427,10 @@ CDB___memp_cmpr_write (dbmfp, bhp, db_io, niop)
   int chain_length = 0;
   int first_nonreused_chain_pos = 0;
   int ret;
-  u_int8_t *buffcmpr = 0;
-  u_int8_t *buffp;
+  uint8_t *buffcmpr = 0;
+  uint8_t *buffp;
   unsigned int buffcmpr_length;
-  u_int8_t *orig_buff = db_io->buf;
+  uint8_t *orig_buff = db_io->buf;
   DB_ENV *dbenv = dbmfp->dbmp->dbenv;
   DB_CMPR_INFO *cmpr_info = dbenv->mp_cmpr_info;
 
@@ -647,14 +647,14 @@ err:
  * CDB___memp_cmpr_inflate --
  *  Decompress buffer
  *
- * PUBLIC: int CDB___memp_cmpr_inflate __P((const u_int8_t *, int, u_int8_t *, int, void *));
+ * PUBLIC: int CDB___memp_cmpr_inflate __P((const uint8_t *, int, uint8_t *, int, void *));
  */
 int
 CDB___memp_cmpr_inflate (inbuff, inbuff_length, outbuff, outbuff_length,
                          user_data)
-     const u_int8_t *inbuff;
+     const uint8_t *inbuff;
      int inbuff_length;
-     u_int8_t *outbuff;
+     uint8_t *outbuff;
      int outbuff_length;
      void *user_data;
 {
@@ -693,14 +693,14 @@ CDB___memp_cmpr_inflate (inbuff, inbuff_length, outbuff, outbuff_length,
  * CDB___memp_cmpr_deflate --
  *  Compress buffer
  *
- * PUBLIC: int CDB___memp_cmpr_deflate __P((const u_int8_t *, int, u_int8_t **, int*, void *));
+ * PUBLIC: int CDB___memp_cmpr_deflate __P((const uint8_t *, int, uint8_t **, int*, void *));
  */
 int
 CDB___memp_cmpr_deflate (inbuff, inbuff_length, outbuffp, outbuff_lengthp,
                          user_data)
-     const u_int8_t *inbuff;
+     const uint8_t *inbuff;
      int inbuff_length;
-     u_int8_t **outbuffp;
+     uint8_t **outbuffp;
      int *outbuff_lengthp;
      void *user_data;
 {
@@ -710,7 +710,7 @@ CDB___memp_cmpr_deflate (inbuff, inbuff_length, outbuffp, outbuff_lengthp,
   int off = 0;
   int freesp = 0;
   z_stream c_stream;
-  u_int8_t *outbuff;
+  uint8_t *outbuff;
 
   /*
    * Z_FINISH can be used immediately after deflateInit if all the compression
@@ -852,13 +852,13 @@ err:
  * __memp_cmpr_pagesize --
  *  Compute compressed page size
  *
- * PUBLIC: u_int8_t CDB___memp_cmpr_coefficient __P((DB_ENV *dbenv));
+ * PUBLIC: uint8_t CDB___memp_cmpr_coefficient __P((DB_ENV *dbenv));
  */
-u_int8_t
+uint8_t
 CDB___memp_cmpr_coefficient (dbenv)
      DB_ENV *dbenv;
 {
-  u_int8_t ret = 0;
+  uint8_t ret = 0;
 
   if (!dbenv || !dbenv->mp_cmpr_info)
   {

--- a/db/mp_ext.h
+++ b/db/mp_ext.h
@@ -9,7 +9,7 @@ int CDB___memp_pgwrite __P ((DB_MPOOL *, DB_MPOOLFILE *, BH *, int *, int *));
 int CDB___memp_pg __P ((DB_MPOOLFILE *, BH *, int));
 void CDB___memp_bhfree __P ((DB_MPOOL *, BH *, int));
 int CDB___memp_fopen __P ((DB_MPOOL *, MPOOLFILE *, const char *,
-                           u_int32_t, int, size_t, int, DB_MPOOL_FINFO *,
+                           uint32_t, int, size_t, int, DB_MPOOL_FINFO *,
                            DB_MPOOLFILE **));
 int CDB___memp_fremove __P ((DB_MPOOLFILE *));
 char *CDB___memp_fn __P ((DB_MPOOLFILE *));
@@ -23,10 +23,10 @@ int CDB___memp_cmpr __P ((DB_MPOOLFILE *, BH *, DB_IO *, int, ssize_t *));
 int CDB___memp_cmpr_read __P ((DB_MPOOLFILE *, BH *, DB_IO *, ssize_t *));
 int CDB___memp_cmpr_write __P ((DB_MPOOLFILE *, BH *, DB_IO *, ssize_t *));
 int CDB___memp_cmpr_inflate
-__P ((const u_int8_t *, int, u_int8_t *, int, void *));
+__P ((const uint8_t *, int, uint8_t *, int, void *));
 int CDB___memp_cmpr_deflate
-__P ((const u_int8_t *, int, u_int8_t **, int *, void *));
-u_int8_t CDB___memp_cmpr_coefficient __P ((DB_ENV * dbenv));
+__P ((const uint8_t *, int, uint8_t **, int *, void *));
+uint8_t CDB___memp_cmpr_coefficient __P ((DB_ENV * dbenv));
 int CDB___memp_cmpr_open
 __P ((DB_ENV *, const char *, int, int, CMPR_CONTEXT *));
 int CDB___memp_cmpr_close __P ((CMPR_CONTEXT *));

--- a/db/mp_fget.c
+++ b/db/mp_fget.c
@@ -34,7 +34,7 @@ int
 CDB_memp_fget (dbmfp, pgnoaddr, flags, addrp)
      DB_MPOOLFILE *dbmfp;
      db_pgno_t *pgnoaddr;
-     u_int32_t flags;
+     uint32_t flags;
      void *addrp;
 {
   BH *bhp;
@@ -45,7 +45,7 @@ CDB_memp_fget (dbmfp, pgnoaddr, flags, addrp)
   MPOOL *mp;
   MPOOLFILE *mfp;
   size_t n_bucket, n_cache, mf_offset;
-  u_int32_t st_hsearch;
+  uint32_t st_hsearch;
   int b_incr, first, ret;
 
   dbmp = dbmfp->dbmp;

--- a/db/mp_fopen.c
+++ b/db/mp_fopen.c
@@ -34,7 +34,7 @@ int
 CDB_memp_fopen (dbenv, path, flags, mode, pagesize, finfop, retp)
      DB_ENV *dbenv;
      const char *path;
-     u_int32_t flags;
+     uint32_t flags;
      int mode;
      size_t pagesize;
      DB_MPOOL_FINFO *finfop;
@@ -81,7 +81,7 @@ CDB_memp_fopen (dbenv, path, flags, mode, pagesize, finfop, retp)
  *  Open a backing file for the memory pool; internal version.
  *
  * PUBLIC: int CDB___memp_fopen __P((DB_MPOOL *, MPOOLFILE *, const char *,
- * PUBLIC:    u_int32_t, int, size_t, int, DB_MPOOL_FINFO *, DB_MPOOLFILE **));
+ * PUBLIC:    uint32_t, int, size_t, int, DB_MPOOL_FINFO *, DB_MPOOLFILE **));
  */
 int
 CDB___memp_fopen (dbmp, mfp, path, flags, mode, pagesize, needlock, finfop,
@@ -89,7 +89,7 @@ CDB___memp_fopen (dbmp, mfp, path, flags, mode, pagesize, needlock, finfop,
      DB_MPOOL *dbmp;
      MPOOLFILE *mfp;
      const char *path;
-     u_int32_t flags;
+     uint32_t flags;
      int mode, needlock;
      size_t pagesize;
      DB_MPOOL_FINFO *finfop;
@@ -100,9 +100,9 @@ CDB___memp_fopen (dbmp, mfp, path, flags, mode, pagesize, needlock, finfop,
   DB_MPOOL_FINFO finfo;
   db_pgno_t last_pgno;
   size_t maxmap;
-  u_int32_t mbytes, bytes, oflags;
+  uint32_t mbytes, bytes, oflags;
   int ret;
-  u_int8_t idbuf[DB_FILE_ID_LEN];
+  uint8_t idbuf[DB_FILE_ID_LEN];
   char *rpath;
 
   dbenv = dbmp->dbenv;

--- a/db/mp_fput.c
+++ b/db/mp_fput.c
@@ -28,7 +28,7 @@ int
 CDB_memp_fput (dbmfp, pgaddr, flags)
      DB_MPOOLFILE *dbmfp;
      void *pgaddr;
-     u_int32_t flags;
+     uint32_t flags;
 {
   BH *bhp;
   DB_ENV *dbenv;
@@ -79,14 +79,14 @@ CDB_memp_fput (dbmfp, pgaddr, flags)
    * region.
    */
   if (dbmfp->addr != NULL && pgaddr >= dbmfp->addr &&
-      (u_int8_t *) pgaddr <= (u_int8_t *) dbmfp->addr + dbmfp->len)
+      (uint8_t *) pgaddr <= (uint8_t *) dbmfp->addr + dbmfp->len)
   {
     R_UNLOCK (dbenv, &dbmp->reginfo);
     return (0);
   }
 
   /* Convert the page address to a buffer header. */
-  bhp = (BH *) ((u_int8_t *) pgaddr - SSZA (BH, buf));
+  bhp = (BH *) ((uint8_t *) pgaddr - SSZA (BH, buf));
 
   /* Convert the buffer header to a cache. */
   mc = BH_TO_CACHE (dbmp, bhp);

--- a/db/mp_fset.c
+++ b/db/mp_fset.c
@@ -28,7 +28,7 @@ int
 CDB_memp_fset (dbmfp, pgaddr, flags)
      DB_MPOOLFILE *dbmfp;
      void *pgaddr;
-     u_int32_t flags;
+     uint32_t flags;
 {
   BH *bhp;
   DB_ENV *dbenv;
@@ -63,7 +63,7 @@ CDB_memp_fset (dbmfp, pgaddr, flags)
   }
 
   /* Convert the page address to a buffer header. */
-  bhp = (BH *) ((u_int8_t *) pgaddr - SSZA (BH, buf));
+  bhp = (BH *) ((uint8_t *) pgaddr - SSZA (BH, buf));
 
   /* Convert the buffer header to a cache. */
   mc = BH_TO_CACHE (dbmp, bhp);

--- a/db/mp_method.c
+++ b/db/mp_method.c
@@ -19,7 +19,7 @@ static const char sccsid[] = "@(#)mp_method.c  11.2 (Sleepycat) 10/6/99";
 #include "mp.h"
 
 static int CDB___memp_set_cachesize
-__P ((DB_ENV *, u_int32_t, u_int32_t, int));
+__P ((DB_ENV *, uint32_t, uint32_t, int));
 static int CDB___memp_set_mp_mmapsize __P ((DB_ENV *, size_t));
 
 /*
@@ -53,7 +53,7 @@ CDB___memp_dbenv_create (dbenv)
 static int
 CDB___memp_set_cachesize (dbenv, gbytes, bytes, ncache)
      DB_ENV *dbenv;
-     u_int32_t gbytes, bytes;
+     uint32_t gbytes, bytes;
      int ncache;
 {
   ENV_ILLEGAL_AFTER_OPEN (dbenv, "set_cachesize");

--- a/db/mp_stat.c
+++ b/db/mp_stat.c
@@ -30,7 +30,7 @@ static const char sccsid[] = "@(#)mp_stat.c  11.4 (Sleepycat) 9/18/99";
 #include "mp.h"
 
 static void CDB___memp_dumpcache
-__P ((DB_MPOOL *, REGINFO *, size_t *, FILE *, u_int32_t));
+__P ((DB_MPOOL *, REGINFO *, size_t *, FILE *, uint32_t));
 static void CDB___memp_pbh __P ((DB_MPOOL *, BH *, size_t *, FILE *));
 
 /*
@@ -51,7 +51,7 @@ CDB_memp_stat (dbenv, gspp, fspp, db_malloc)
   MPOOL *mp;
   MPOOLFILE *mfp;
   size_t len, nlen;
-  u_int32_t i;
+  uint32_t i;
   int ret;
   char *name;
 
@@ -148,7 +148,7 @@ CDB_memp_stat (dbenv, gspp, fspp, db_malloc)
         return (ret);
       **tfsp = mfp->stat;
       (*tfsp)->file_name = (char *)
-        (u_int8_t *) * tfsp + sizeof (DB_MPOOL_FSTAT);
+        (uint8_t *) * tfsp + sizeof (DB_MPOOL_FSTAT);
       memcpy ((*tfsp)->file_name, name, nlen + 1);
 
       /*
@@ -200,9 +200,9 @@ CDB___memp_dump_region (dbenv, area, fp)
   MPOOL *mp;
   MPOOLFILE *mfp;
   size_t fmap[FMAP_ENTRIES + 1];
-  u_int32_t i, flags;
+  uint32_t i, flags;
   int cnt;
-  u_int8_t *p;
+  uint8_t *p;
 
   dbmp = dbenv->mp_handle;
 
@@ -295,7 +295,7 @@ CDB___memp_dumpcache (dbmp, reginfo, fmap, fp, flags)
      REGINFO *reginfo;
      size_t *fmap;
      FILE *fp;
-     u_int32_t flags;
+     uint32_t flags;
 {
   BH *bhp;
   DB_HASHTAB *dbht;

--- a/db/mp_sync.c
+++ b/db/mp_sync.c
@@ -23,7 +23,7 @@ static const char sccsid[] = "@(#)mp_sync.c  11.10 (Sleepycat) 10/29/99";
 
 static int CDB___bhcmp __P ((const void *, const void *));
 static int CDB___memp_fsync __P ((DB_MPOOLFILE *));
-static int CDB___memp_sballoc __P ((DB_ENV *, BH ***, u_int32_t *));
+static int CDB___memp_sballoc __P ((DB_ENV *, BH ***, uint32_t *));
 
 /*
  * CDB_memp_sync --
@@ -40,7 +40,7 @@ CDB_memp_sync (dbenv, lsnp)
   MCACHE *mc;
   MPOOL *mp;
   MPOOLFILE *mfp;
-  u_int32_t ar_cnt, i, ndirty;
+  uint32_t ar_cnt, i, ndirty;
   int ret, retry_done, retry_need, wrote;
 
   PANIC_CHECK (dbenv);
@@ -401,7 +401,7 @@ CDB___memp_fsync (dbmfp)
   MCACHE *mc;
   MPOOL *mp;
   size_t mf_offset;
-  u_int32_t ar_cnt, i, ndirty;
+  uint32_t ar_cnt, i, ndirty;
   int incomplete, ret, retry_done, retry_need, wrote;
 
   dbmp = dbmfp->dbmp;
@@ -570,12 +570,12 @@ static int
 CDB___memp_sballoc (dbenv, bharrayp, ndirtyp)
      DB_ENV *dbenv;
      BH ***bharrayp;
-     u_int32_t *ndirtyp;
+     uint32_t *ndirtyp;
 {
   DB_MPOOL *dbmp;
   MCACHE *mc;
   MPOOL *mp;
-  u_int32_t i, nclean, ndirty, maxpin;
+  uint32_t i, nclean, ndirty, maxpin;
   int ret;
 
   dbmp = dbenv->mp_handle;

--- a/db/mp_trickle.c
+++ b/db/mp_trickle.c
@@ -34,7 +34,7 @@ CDB_memp_trickle (dbenv, pct, nwrotep)
 {
   DB_MPOOL *dbmp;
   MPOOL *mp;
-  u_int32_t i;
+  uint32_t i;
   int ret;
 
   PANIC_CHECK (dbenv);

--- a/db/mut_fcntl.c
+++ b/db/mut_fcntl.c
@@ -29,13 +29,13 @@ static const char sccsid[] = "@(#)mut_fcntl.c  11.1 (Sleepycat) 7/25/99";
  * CDB___db_fcntl_mutex_init --
  *  Initialize a DB mutex structure.
  *
- * PUBLIC: int CDB___db_fcntl_mutex_init __P((DB_ENV *, MUTEX *, u_int32_t));
+ * PUBLIC: int CDB___db_fcntl_mutex_init __P((DB_ENV *, MUTEX *, uint32_t));
  */
 int
 CDB___db_fcntl_mutex_init (dbenv, mutexp, offset)
      DB_ENV *dbenv;
      MUTEX *mutexp;
-     u_int32_t offset;
+     uint32_t offset;
 {
   memset (mutexp, 0, sizeof (*mutexp));
 
@@ -99,7 +99,7 @@ CDB___db_fcntl_mutex_lock (mutexp, fhp)
     if (mutexp->pid == 0)
     {
       locked = 1;
-      mutexp->pid = (u_int32_t) getpid ();
+      mutexp->pid = (uint32_t) getpid ();
     }
 
     /* Release the kernel lock. */

--- a/db/mut_pthread.c
+++ b/db/mut_pthread.c
@@ -52,13 +52,13 @@ static const char sccsid[] = "@(#)mut_pthread.c  11.15 (Sleepycat) 11/9/99";
  * CDB___db_pthread_mutex_init --
  *  Initialize a MUTEX.
  *
- * PUBLIC: int CDB___db_pthread_mutex_init __P((DB_ENV *, MUTEX *, u_int32_t));
+ * PUBLIC: int CDB___db_pthread_mutex_init __P((DB_ENV *, MUTEX *, uint32_t));
  */
 int
 CDB___db_pthread_mutex_init (dbenv, mutexp, flags)
      DB_ENV *dbenv;
      MUTEX *mutexp;
-     u_int32_t flags;
+     uint32_t flags;
 {
   int ret;
 
@@ -187,7 +187,7 @@ int
 CDB___db_pthread_mutex_lock (mutexp)
      MUTEX *mutexp;
 {
-  u_int32_t nspins;
+  uint32_t nspins;
   int ret, waited;
 
   if (!DB_GLOBAL (db_mutexlocks) || F_ISSET (mutexp, MUTEX_IGNORE))
@@ -230,7 +230,7 @@ CDB___db_pthread_mutex_lock (mutexp)
       ++mutexp->mutex_set_nowait;
 
 #ifdef DIAGNOSTIC
-    mutexp->locked = (u_int32_t) pthread_self ();
+    mutexp->locked = (uint32_t) pthread_self ();
 #else
     mutexp->locked = 1;
 #endif
@@ -251,7 +251,7 @@ CDB___db_pthread_mutex_lock (mutexp)
                        sizeof (msgbuf), MSG1, (u_long) mutexp->locked);
       (void) write (STDERR_FILENO, msgbuf, strlen (msgbuf));
     }
-    mutexp->locked = (u_int32_t) pthread_self ();
+    mutexp->locked = (uint32_t) pthread_self ();
 #else
     mutexp->locked = 1;
 #endif

--- a/db/mut_tas.c
+++ b/db/mut_tas.c
@@ -61,13 +61,13 @@ static const char sccsid[] = "@(#)mut_tas.c  11.4 (Sleepycat) 10/1/99";
  * CDB___db_tas_mutex_init --
  *  Initialize a MUTEX.
  *
- * PUBLIC: int CDB___db_tas_mutex_init __P((DB_ENV *, MUTEX *, u_int32_t));
+ * PUBLIC: int CDB___db_tas_mutex_init __P((DB_ENV *, MUTEX *, uint32_t));
  */
 int
 CDB___db_tas_mutex_init (dbenv, mutexp, flags)
      DB_ENV *dbenv;
      MUTEX *mutexp;
-     u_int32_t flags;
+     uint32_t flags;
 {
   memset (mutexp, 0, sizeof (*mutexp));
 
@@ -129,7 +129,7 @@ loop:                          /* Attempt to acquire the resource for N spins. *
                        sizeof (msgbuf), MSG1, (u_long) mutexp->locked);
       (void) write (STDERR_FILENO, msgbuf, strlen (msgbuf));
     }
-    mutexp->locked = (u_int32_t) getpid ();
+    mutexp->locked = (uint32_t) getpid ();
 #endif
     if (ms == 1)
       ++mutexp->mutex_set_nowait;

--- a/db/mutex.h
+++ b/db/mutex.h
@@ -234,7 +234,7 @@ typedef unsigned char tsl_t;
  * ALPHA/gcc assembly.
  *********************************************************************/
 #ifdef HAVE_MUTEX_ALPHA_GCC_ASSEMBLY
-typedef u_int32_t tsl_t;
+typedef uint32_t tsl_t;
 
 #define  MUTEX_ALIGN  4
 #endif
@@ -243,7 +243,7 @@ typedef u_int32_t tsl_t;
  * HPPA/gcc assembly.
  *********************************************************************/
 #ifdef HAVE_MUTEX_HPPA_GCC_ASSEMBLY
-typedef u_int32_t tsl_t;
+typedef uint32_t tsl_t;
 
 #define  MUTEX_ALIGN  16
 #endif
@@ -307,16 +307,16 @@ struct __mutex_t
 #else
   tsl_t tas;                    /* Test and set. */
 #endif
-  u_int32_t spins;              /* Spins before block. */
-  u_int32_t locked;             /* !0 if locked. */
+  uint32_t spins;              /* Spins before block. */
+  uint32_t locked;             /* !0 if locked. */
 #else
-  u_int32_t off;                /* Byte offset to lock. */
-  u_int32_t pid;                /* Lock holder: 0 or process pid. */
+  uint32_t off;                /* Byte offset to lock. */
+  uint32_t pid;                /* Lock holder: 0 or process pid. */
 #endif
-  u_int32_t mutex_set_wait;     /* Granted after wait. */
-  u_int32_t mutex_set_nowait;   /* Granted without waiting. */
+  uint32_t mutex_set_wait;     /* Granted after wait. */
+  uint32_t mutex_set_nowait;   /* Granted without waiting. */
 
-  u_int8_t flags;               /* MUTEX_XXX */
+  uint8_t flags;               /* MUTEX_XXX */
 };
 
 /* Redirect calls to the correct functions. */

--- a/db/mutex_ext.h
+++ b/db/mutex_ext.h
@@ -1,13 +1,13 @@
 /* DO NOT EDIT: automatically built by dist/distrib. */
 #ifndef _mutex_ext_h_
 #define _mutex_ext_h_
-int CDB___db_fcntl_mutex_init __P ((DB_ENV *, MUTEX *, u_int32_t));
+int CDB___db_fcntl_mutex_init __P ((DB_ENV *, MUTEX *, uint32_t));
 int CDB___db_fcntl_mutex_lock __P ((MUTEX *, DB_FH *));
 int CDB___db_fcntl_mutex_unlock __P ((MUTEX *));
-int CDB___db_pthread_mutex_init __P ((DB_ENV *, MUTEX *, u_int32_t));
+int CDB___db_pthread_mutex_init __P ((DB_ENV *, MUTEX *, uint32_t));
 int CDB___db_pthread_mutex_lock __P ((MUTEX *));
 int CDB___db_pthread_mutex_unlock __P ((MUTEX *));
-int CDB___db_tas_mutex_init __P ((DB_ENV *, MUTEX *, u_int32_t));
+int CDB___db_tas_mutex_init __P ((DB_ENV *, MUTEX *, uint32_t));
 int CDB___db_tas_mutex_lock __P ((MUTEX *));
 int CDB___db_tas_mutex_unlock __P ((MUTEX *));
 int CDB___db_mutex_alloc __P ((DB_ENV *, REGINFO *, MUTEX **));

--- a/db/os.h
+++ b/db/os.h
@@ -21,11 +21,11 @@ struct __fh_t
 #endif
   int fd;                       /* POSIX file descriptor. */
 
-  u_int32_t log_size;           /* XXX: Log file size. */
+  uint32_t log_size;           /* XXX: Log file size. */
 
 #define  DB_FH_NOSYNC  0x01     /* Handle doesn't need to be sync'd. */
 #define  DB_FH_VALID  0x02      /* Handle is valid. */
-  u_int8_t flags;
+  uint8_t flags;
 };
 
 /*
@@ -40,6 +40,6 @@ typedef struct __io_t
   MUTEX *mutexp;                /* Mutex to lock. */
   size_t pagesize;              /* Page size. */
   db_pgno_t pgno;               /* Page number. */
-  u_int8_t *buf;                /* Buffer. */
+  uint8_t *buf;                /* Buffer. */
   size_t bytes;                 /* Bytes read/written. */
 } DB_IO;

--- a/db/os_alloc.c
+++ b/db/os_alloc.c
@@ -199,7 +199,7 @@ CDB___os_realloc (size, db_realloc, storep)
   }
 
 #ifdef DIAGNOSTIC
-  ((u_int8_t *) p)[size - 1] = CLEAR_BYTE;      /* Initialize guard byte. */
+  ((uint8_t *) p)[size - 1] = CLEAR_BYTE;      /* Initialize guard byte. */
 #endif
 
   *(void **) storep = p;
@@ -225,7 +225,7 @@ CDB___os_free (ptr, size)
      * Check that the guard byte (one past the end of the memory) is
      * still CLEAR_BYTE.
      */
-    if (((u_int8_t *) ptr)[size] != CLEAR_BYTE)
+    if (((uint8_t *) ptr)[size] != CLEAR_BYTE)
       __os_guard ();
 
     /* Clear memory. */
@@ -261,7 +261,7 @@ CDB___os_freestr (ptr)
    * Check that the guard byte (one past the end of the memory) is
    * still CLEAR_BYTE.
    */
-  if (((u_int8_t *) ptr)[size] != CLEAR_BYTE)
+  if (((uint8_t *) ptr)[size] != CLEAR_BYTE)
     __os_guard ();
 
   /* Clear memory. */
@@ -313,7 +313,7 @@ __os_guard ()
  *  some compilers optimize to use instructions that require alignment.
  *  It's a compiler bug, but it's a pretty common one.
  *
- *  Casting the memcpy arguments to (u_int8_t *) appears to work most
+ *  Casting the memcpy arguments to (uint8_t *) appears to work most
  *  of the time, but we've seen examples where it wasn't sufficient
  *  and there's nothing in ANSI C that requires it.
  *

--- a/db/os_ext.h
+++ b/db/os_ext.h
@@ -13,7 +13,7 @@ int CDB___os_dirlist __P ((const char *, char ***, int *));
 void CDB___os_dirfree __P ((char **, int));
 int CDB___os_get_errno __P ((void));
 void CDB___os_set_errno __P ((int));
-int CDB___os_fileid __P ((DB_ENV *, const char *, int, u_int8_t *));
+int CDB___os_fileid __P ((DB_ENV *, const char *, int, uint8_t *));
 int CDB___os_finit __P ((DB_FH *, size_t, int));
 int CDB___os_fpinit __P ((DB_FH *, db_pgno_t, int, int));
 int CDB___os_fsync __P ((DB_FH *));
@@ -24,9 +24,9 @@ int CDB___os_r_sysdetach __P ((DB_ENV *, REGINFO *, int));
 int CDB___os_mapfile __P ((DB_ENV *, char *, DB_FH *, size_t, int, void **));
 int CDB___os_unmapfile __P ((DB_ENV *, void *, size_t));
 void CDB___os_dbenv_create __P ((DB_ENV *));
-u_int32_t CDB___db_oflags __P ((int));
+uint32_t CDB___db_oflags __P ((int));
 int CDB___db_omode __P ((const char *));
-int CDB___os_open __P ((const char *, u_int32_t, int, DB_FH *));
+int CDB___os_open __P ((const char *, uint32_t, int, DB_FH *));
 int CDB___os_r_attach __P ((DB_ENV *, REGINFO *, REGION *));
 int CDB___os_r_detach __P ((DB_ENV *, REGINFO *, int));
 int CDB___os_rename __P ((const char *, const char *));
@@ -36,14 +36,14 @@ int CDB___os_io __P ((DB_IO *, int, ssize_t *));
 int CDB___os_read __P ((DB_FH *, void *, size_t, ssize_t *));
 int CDB___os_write __P ((DB_FH *, void *, size_t, ssize_t *));
 int CDB___os_seek
-__P ((DB_FH *, size_t, db_pgno_t, u_int32_t, int, DB_OS_SEEK));
+__P ((DB_FH *, size_t, db_pgno_t, uint32_t, int, DB_OS_SEEK));
 int CDB___os_sleep __P ((u_long, u_long));
 int CDB___os_spin __P ((void));
 void CDB___os_yield __P ((u_long));
 int CDB___os_exists __P ((const char *, int *));
 int CDB___os_ioinfo __P ((const char *,
-                          DB_FH *, u_int32_t *, u_int32_t *, u_int32_t *));
-int CDB___os_tmpdir __P ((DB_ENV *, u_int32_t));
+                          DB_FH *, uint32_t *, uint32_t *, uint32_t *));
+int CDB___os_tmpdir __P ((DB_ENV *, uint32_t));
 int CDB___os_unlink __P ((const char *));
 #if defined(_WIN32)
 int __os_win32_errno __P ((void));

--- a/db/os_fid.c
+++ b/db/os_fid.c
@@ -35,19 +35,19 @@ static const char sccsid[] = "@(#)os_fid.c  11.1 (Sleepycat) 7/25/99";
  * CDB___os_fileid --
  *  Return a unique identifier for a file.
  *
- * PUBLIC: int CDB___os_fileid __P((DB_ENV *, const char *, int, u_int8_t *));
+ * PUBLIC: int CDB___os_fileid __P((DB_ENV *, const char *, int, uint8_t *));
  */
 int
 CDB___os_fileid (dbenv, fname, timestamp, fidp)
      DB_ENV *dbenv;
      const char *fname;
      int timestamp;
-     u_int8_t *fidp;
+     uint8_t *fidp;
 {
   struct stat sb;
   size_t i;
-  u_int32_t tmp;
-  u_int8_t *p;
+  uint32_t tmp;
+  uint8_t *p;
 
   /* Clear the buffer. */
   memset (fidp, 0, DB_FILE_ID_LEN);
@@ -82,12 +82,12 @@ CDB___os_fileid (dbenv, fname, timestamp, fidp)
    * get the same 32-bit values if we truncate any returned 64-bit value
    * to a 32-bit value.
    */
-  tmp = (u_int32_t) sb.st_ino;
-  for (p = (u_int8_t *) & tmp, i = sizeof (u_int32_t); i > 0; --i)
+  tmp = (uint32_t) sb.st_ino;
+  for (p = (uint8_t *) & tmp, i = sizeof (uint32_t); i > 0; --i)
     *fidp++ = *p++;
 
-  tmp = (u_int32_t) sb.st_dev;
-  for (p = (u_int8_t *) & tmp, i = sizeof (u_int32_t); i > 0; --i)
+  tmp = (uint32_t) sb.st_dev;
+  for (p = (uint8_t *) & tmp, i = sizeof (uint32_t); i > 0; --i)
     *fidp++ = *p++;
 
   if (timestamp)
@@ -97,8 +97,8 @@ CDB___os_fileid (dbenv, fname, timestamp, fidp)
      * so convert the returned time_t to a (potentially) smaller
      * fixed-size type.
      */
-    tmp = (u_int32_t) time (NULL);
-    for (p = (u_int8_t *) & tmp, i = sizeof (u_int32_t); i > 0; --i)
+    tmp = (uint32_t) time (NULL);
+    for (p = (uint8_t *) & tmp, i = sizeof (uint32_t); i > 0; --i)
       *fidp++ = *p++;
   }
 

--- a/db/os_finit.c
+++ b/db/os_finit.c
@@ -35,7 +35,7 @@ CDB___os_finit (fhp, size, zerofill)
   db_pgno_t pages;
   size_t i;
   ssize_t nw;
-  u_int32_t relative;
+  uint32_t relative;
   int ret;
   char buf[OS_VMPAGESIZE];
 

--- a/db/os_jump.h
+++ b/db/os_jump.h
@@ -17,14 +17,14 @@ struct __db_jumptab
   void (*j_free) __P ((void *));
   int (*j_fsync) __P ((int));
   int (*j_ioinfo) __P ((const char *,
-                        int, u_int32_t *, u_int32_t *, u_int32_t *));
+                        int, uint32_t *, uint32_t *, uint32_t *));
   void *(*j_malloc) __P ((size_t));
   int (*j_map) __P ((char *, size_t, int, int, void **));
   int (*j_open) __P ((const char *, int, ...));
     ssize_t (*j_read) __P ((int, void *, size_t));
   void *(*j_realloc) __P ((void *, size_t));
   int (*j_rename) __P ((const char *, const char *));
-  int (*j_seek) __P ((int, size_t, db_pgno_t, u_int32_t, int, int));
+  int (*j_seek) __P ((int, size_t, db_pgno_t, uint32_t, int, int));
   int (*j_sleep) __P ((u_long, u_long));
   int (*j_unlink) __P ((const char *));
   int (*j_unmap) __P ((void *, size_t));

--- a/db/os_method.c
+++ b/db/os_method.c
@@ -30,9 +30,9 @@ __P ((DB_ENV *, int (*)(const char *, int *)));
 static int CDB___os_set_func_free __P ((DB_ENV *, void (*)(void *)));
 static int CDB___os_set_func_fsync __P ((DB_ENV *, int (*)(int)));
 static int CDB___os_set_func_ioinfo __P ((DB_ENV *, int (*)(const char *,
-                                                            int, u_int32_t *,
-                                                            u_int32_t *,
-                                                            u_int32_t *)));
+                                                            int, uint32_t *,
+                                                            uint32_t *,
+                                                            uint32_t *)));
 static int CDB___os_set_func_malloc __P ((DB_ENV *, void *(*)(size_t)));
 static int CDB___os_set_func_map __P ((DB_ENV *,
                                        int (*)(char *, size_t, int, int,
@@ -46,7 +46,7 @@ __P ((DB_ENV *, void *(*)(void *, size_t)));
 static int CDB___os_set_func_rename
 __P ((DB_ENV *, int (*)(const char *, const char *)));
 static int CDB___os_set_func_seek
-__P ((DB_ENV *, int (*)(int, size_t, db_pgno_t, u_int32_t, int, int)));
+__P ((DB_ENV *, int (*)(int, size_t, db_pgno_t, uint32_t, int, int)));
 static int CDB___os_set_func_sleep __P ((DB_ENV *, int (*)(u_long, u_long)));
 static int CDB___os_set_func_unlink __P ((DB_ENV *, int (*)(const char *)));
 static int CDB___os_set_func_unmap __P ((DB_ENV *, int (*)(void *, size_t)));
@@ -156,7 +156,7 @@ static int
 CDB___os_set_func_ioinfo (dbenv, func_ioinfo)
      DB_ENV *dbenv;
      int (*func_ioinfo)
-  __P ((const char *, int, u_int32_t *, u_int32_t *, u_int32_t *));
+  __P ((const char *, int, uint32_t *, uint32_t *, uint32_t *));
 {
   ENV_ILLEGAL_AFTER_OPEN (dbenv, "set_func_ioinfo");
 
@@ -233,7 +233,7 @@ CDB___os_set_func_rename (dbenv, func_rename)
 static int
 CDB___os_set_func_seek (dbenv, func_seek)
      DB_ENV *dbenv;
-     int (*func_seek) __P ((int, size_t, db_pgno_t, u_int32_t, int, int));
+     int (*func_seek) __P ((int, size_t, db_pgno_t, uint32_t, int, int));
 {
   ENV_ILLEGAL_AFTER_OPEN (dbenv, "set_func_seek");
 

--- a/db/os_oflags.c
+++ b/db/os_oflags.c
@@ -24,13 +24,13 @@ static const char sccsid[] = "@(#)os_oflags.c  11.1 (Sleepycat) 7/25/99";
  * CDB___db_oflags --
  *  Convert open(2) flags to DB flags.
  *
- * PUBLIC: u_int32_t CDB___db_oflags __P((int));
+ * PUBLIC: uint32_t CDB___db_oflags __P((int));
  */
-u_int32_t
+uint32_t
 CDB___db_oflags (oflags)
      int oflags;
 {
-  u_int32_t dbflags;
+  uint32_t dbflags;
 
   /*
    * XXX

--- a/db/os_open.c
+++ b/db/os_open.c
@@ -24,12 +24,12 @@ static const char sccsid[] = "@(#)os_open.c  11.1 (Sleepycat) 7/25/99";
  * CDB___os_open --
  *  Open a file.
  *
- * PUBLIC: int CDB___os_open __P((const char *, u_int32_t, int, DB_FH *));
+ * PUBLIC: int CDB___os_open __P((const char *, uint32_t, int, DB_FH *));
  */
 int
 CDB___os_open (name, flags, mode, fhp)
      const char *name;
-     u_int32_t flags;
+     uint32_t flags;
      int mode;
      DB_FH *fhp;
 {

--- a/db/os_rw.c
+++ b/db/os_rw.c
@@ -114,7 +114,7 @@ CDB___os_read (fhp, addr, len, nrp)
 {
   size_t offset;
   ssize_t nr;
-  u_int8_t *taddr;
+  uint8_t *taddr;
 
 
   /* HACK to debug where the O_BINARY mode of the file gets fouled up */
@@ -135,7 +135,7 @@ CDB___os_read (fhp, addr, len, nrp)
     if (nr == 0)
       break;
   }
-  *nrp = taddr - (u_int8_t *) addr;
+  *nrp = taddr - (uint8_t *) addr;
   return (0);
 }
 
@@ -154,7 +154,7 @@ CDB___os_write (fhp, addr, len, nwp)
 {
   size_t offset;
   ssize_t nw;
-  u_int8_t *taddr;
+  uint8_t *taddr;
 
   /* HACK to debug where the O_BINARY mode of the file gets fouled up */
   /*

--- a/db/os_seek.c
+++ b/db/os_seek.c
@@ -32,14 +32,14 @@ static const char sccsid[] = "@(#)os_seek.c  11.3 (Sleepycat) 10/29/99";
  *  Seek to a page/byte offset in the file.
  *
  * PUBLIC: int CDB___os_seek
- * PUBLIC:     __P((DB_FH *, size_t, db_pgno_t, u_int32_t, int, DB_OS_SEEK));
+ * PUBLIC:     __P((DB_FH *, size_t, db_pgno_t, uint32_t, int, DB_OS_SEEK));
  */
 int
 CDB___os_seek (fhp, pgsize, pageno, relative, isrewind, db_whence)
      DB_FH *fhp;
      size_t pgsize;
      db_pgno_t pageno;
-     u_int32_t relative;
+     uint32_t relative;
      int isrewind;
      DB_OS_SEEK db_whence;
 {

--- a/db/os_stat.c
+++ b/db/os_stat.c
@@ -57,13 +57,13 @@ CDB___os_exists (path, isdirp)
  *  to replace.
  *
  * PUBLIC: int CDB___os_ioinfo __P((const char *,
- * PUBLIC:    DB_FH *, u_int32_t *, u_int32_t *, u_int32_t *));
+ * PUBLIC:    DB_FH *, uint32_t *, uint32_t *, uint32_t *));
  */
 int
 CDB___os_ioinfo (path, fhp, mbytesp, bytesp, iosizep)
      const char *path;
      DB_FH *fhp;
-     u_int32_t *mbytesp, *bytesp, *iosizep;
+     uint32_t *mbytesp, *bytesp, *iosizep;
 {
   struct stat sb;
 

--- a/db/os_tmpdir.c
+++ b/db/os_tmpdir.c
@@ -31,12 +31,12 @@ static const char sccsid[] = "@(#)os_tmpdir.c  11.1 (Sleepycat) 7/25/99";
  * The order of items in the list structure and the order of checks in
  * the environment are documented.
  *
- * PUBLIC: int CDB___os_tmpdir __P((DB_ENV *, u_int32_t));
+ * PUBLIC: int CDB___os_tmpdir __P((DB_ENV *, uint32_t));
  */
 int
 CDB___os_tmpdir (dbenv, flags)
      DB_ENV *dbenv;
-     u_int32_t flags;
+     uint32_t flags;
 {
   /*
    * !!!

--- a/db/qam.c
+++ b/db/qam.c
@@ -27,12 +27,12 @@ static const char sccsid[] = "@(#)qam.c  11.23 (Sleepycat) 10/26/99";
 #include "mp.h"
 
 static int CDB___qam_c_close __P ((DBC *));
-static int CDB___qam_c_del __P ((DBC *, u_int32_t));
-static int CDB___qam_c_get __P ((DBC *, DBT *, DBT *, u_int32_t));
-static int CDB___qam_c_put __P ((DBC *, DBT *, DBT *, u_int32_t));
+static int CDB___qam_c_del __P ((DBC *, uint32_t));
+static int CDB___qam_c_get __P ((DBC *, DBT *, DBT *, uint32_t));
+static int CDB___qam_c_put __P ((DBC *, DBT *, DBT *, uint32_t));
 static int CDB___qam_getno __P ((DB *, const DBT *, db_recno_t *));
 static int CDB___qam_i_delete __P ((DBC *));
-static int CDB___qam_i_put __P ((DBC *, DBT *, u_int32_t));
+static int CDB___qam_i_put __P ((DBC *, DBT *, uint32_t));
 static int CDB___qam_nrecs __P ((DBC *, db_recno_t *, db_recno_t *));
 static int CDB___qam_position
 __P ((DBC *, db_recno_t *, db_lockmode_t, db_recno_t, int *));
@@ -142,13 +142,13 @@ CDB___qam_position (dbc, recnop, lock_mode, start, exactp)
  *   pagep must be write locked
  *
  * PUBLIC: int CDB___qam_pitem
- * PUBLIC:     __P((DBC *,  QPAGE *, u_int32_t, db_recno_t, DBT *));
+ * PUBLIC:     __P((DBC *,  QPAGE *, uint32_t, db_recno_t, DBT *));
  */
 int
 CDB___qam_pitem (dbc, pagep, indx, recno, data)
      DBC *dbc;
      QPAGE *pagep;
-     u_int32_t indx;
+     uint32_t indx;
      db_recno_t recno;
      DBT *data;
 {
@@ -156,8 +156,8 @@ CDB___qam_pitem (dbc, pagep, indx, recno, data)
   DBT olddata, pdata, *datap;
   QAMDATA *qp;
   QUEUE *t;
-  u_int32_t size;
-  u_int8_t *dest, *p;
+  uint32_t size;
+  uint8_t *dest, *p;
   int alloced, ret;
 
   alloced = ret = 0;
@@ -260,7 +260,7 @@ static int
 CDB___qam_c_put (dbc, key, data, flags)
      DBC *dbc;
      DBT *key, *data;
-     u_int32_t flags;
+     uint32_t flags;
 {
   QUEUE_CURSOR *cp;
   DB_LOCK lock;
@@ -298,7 +298,7 @@ static int
 CDB___qam_i_put (dbc, data, flags)
      DBC *dbc;
      DBT *data;
-     u_int32_t flags;
+     uint32_t flags;
 {
   QUEUE_CURSOR *cp;
   DB *dbp;
@@ -306,7 +306,7 @@ CDB___qam_i_put (dbc, data, flags)
   QMETA *meta;
   db_pgno_t pg;
   db_recno_t new_cur, new_first;
-  u_int32_t opcode;
+  uint32_t opcode;
   int exact, ret, t_ret;
 
   dbp = dbc->dbp;
@@ -428,14 +428,14 @@ CDB___qam_i_put (dbc, data, flags)
  *  If we are doing anything but appending, just call qam_c_put to do the
  *  work.  Otherwise we fast path things here.
  *
- * PUBLIC: int CDB___qam_put __P((DB *, DB_TXN *, DBT *, DBT *, u_int32_t));
+ * PUBLIC: int CDB___qam_put __P((DB *, DB_TXN *, DBT *, DBT *, uint32_t));
  */
 int
 CDB___qam_put (dbp, txn, key, data, flags)
      DB *dbp;
      DB_TXN *txn;
      DBT *key, *data;
-     u_int32_t flags;
+     uint32_t flags;
 {
   QUEUE_CURSOR *cp;
   DBC *dbc;
@@ -659,14 +659,14 @@ err:if (F_ISSET (dbp->dbenv, DB_ENV_CDB) && F_ISSET (dbc, DBC_WRITECURSOR))
  * CDB___qam_delete --
  *  Queue db->del function.
  *
- * PUBLIC: int CDB___qam_delete __P((DB *, DB_TXN *, DBT *, u_int32_t));
+ * PUBLIC: int CDB___qam_delete __P((DB *, DB_TXN *, DBT *, uint32_t));
  */
 int
 CDB___qam_delete (dbp, txn, key, flags)
      DB *dbp;
      DB_TXN *txn;
      DBT *key;
-     u_int32_t flags;
+     uint32_t flags;
 {
   QUEUE_CURSOR *cp;
   DBC *dbc;
@@ -714,7 +714,7 @@ err:if ((t_ret = dbc->c_close (dbc)) != 0 && ret == 0)
 static int
 CDB___qam_c_del (dbc, flags)
      DBC *dbc;
-     u_int32_t flags;
+     uint32_t flags;
 {
   QUEUE_CURSOR *cp;
   DB *dbp;
@@ -748,7 +748,7 @@ static int
 CDB___qam_c_get (dbc_orig, key, data, flags)
      DBC *dbc_orig;
      DBT *key, *data;
-     u_int32_t flags;
+     uint32_t flags;
 {
   QUEUE_CURSOR *cp, *orig;
   DB *dbp;

--- a/db/qam.h
+++ b/db/qam.h
@@ -12,10 +12,10 @@
  */
 typedef struct _qamdata
 {
-  u_int8_t flags;               /* 00: delete bit. */
+  uint8_t flags;               /* 00: delete bit. */
 #define QAM_VALID  0x01
 #define QAM_SET    0x02
-  u_int8_t data[1];             /* Record. */
+  uint8_t data[1];             /* Record. */
 } QAMDATA;
 
 struct __queue;
@@ -36,7 +36,7 @@ struct __qcursor
   DB_LOCK lock;                 /* Cursor lock. */
   db_lockmode_t lock_mode;      /* Lock mode. */
 
-  u_int32_t flags;
+  uint32_t flags;
 };
 
 /*
@@ -48,8 +48,8 @@ struct __queue
   db_pgno_t q_root;             /* Database root page. */
 
   int re_pad;                   /* Fixed-length padding byte. */
-  u_int32_t re_len;             /* Length for fixed-length records. */
-  u_int32_t rec_page;           /* records per page */
+  uint32_t re_len;             /* Length for fixed-length records. */
+  uint32_t rec_page;           /* records per page */
 };
 
 /*
@@ -68,9 +68,9 @@ struct __queue
  *   physical record number, less the logical pno times records/page
  */
 #define CALC_QAM_RECNO_PER_PAGE(dbp)         \
-  (((dbp)->pgsize - ALIGN(sizeof(QPAGE), sizeof(u_int32_t))) / \
+  (((dbp)->pgsize - ALIGN(sizeof(QPAGE), sizeof(uint32_t))) / \
   ALIGN(((QUEUE *)(dbp)->q_internal)->re_len +    \
-  sizeof(QAMDATA) - sizeof ((QAMDATA *)0)->data, sizeof(u_int32_t)))
+  sizeof(QAMDATA) - sizeof ((QAMDATA *)0)->data, sizeof(uint32_t)))
 
 #define QAM_RECNO_PER_PAGE(dbp)  (((QUEUE*)(dbp)->q_internal)->rec_page)
 
@@ -85,9 +85,9 @@ struct __queue
 
 #define QAM_GET_RECORD(dbp, page, index)      \
   ((QAMDATA *) ((char *)(page) +        \
-    ALIGN(sizeof(QPAGE), sizeof(u_int32_t)) +  \
+    ALIGN(sizeof(QPAGE), sizeof(uint32_t)) +  \
   (ALIGN(sizeof(QAMDATA) - sizeof ((QAMDATA *)0)->data +   \
-  ((QUEUE *)(dbp)->q_internal)->re_len, sizeof (u_int32_t)) * index)))
+  ((QUEUE *)(dbp)->q_internal)->re_len, sizeof (uint32_t)) * index)))
 
 /*
  * Log opcodes for the mvptr routine.

--- a/db/qam_auto.c
+++ b/db/qam_auto.c
@@ -21,15 +21,15 @@ CDB___qam_inc_log (dbenv, txnid, ret_lsnp, flags, fileid, lsn)
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
+     uint32_t flags;
      int32_t fileid;
      DB_LSN *lsn;
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t rectype, txn_num;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -62,7 +62,7 @@ CDB___qam_inc_log (dbenv, txnid, ret_lsnp, flags, fileid, lsn)
   else
     memset (bp, 0, sizeof (*lsn));
   bp += sizeof (*lsn);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -79,7 +79,7 @@ CDB___qam_inc_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __qam_inc_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -111,7 +111,7 @@ CDB___qam_inc_read (recbuf, argpp)
      __qam_inc_args **argpp;
 {
   __qam_inc_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__qam_inc_args) +
@@ -139,15 +139,15 @@ CDB___qam_incfirst_log (dbenv, txnid, ret_lsnp, flags, fileid, recno)
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
+     uint32_t flags;
      int32_t fileid;
      db_recno_t recno;
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t rectype, txn_num;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -177,7 +177,7 @@ CDB___qam_incfirst_log (dbenv, txnid, ret_lsnp, flags, fileid, recno)
   bp += sizeof (fileid);
   memcpy (bp, &recno, sizeof (recno));
   bp += sizeof (recno);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -194,7 +194,7 @@ CDB___qam_incfirst_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __qam_incfirst_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -225,7 +225,7 @@ CDB___qam_incfirst_read (recbuf, argpp)
      __qam_incfirst_args **argpp;
 {
   __qam_incfirst_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__qam_incfirst_args) +
@@ -255,8 +255,8 @@ CDB___qam_mvptr_log (dbenv, txnid, ret_lsnp, flags,
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
-     u_int32_t opcode;
+     uint32_t flags;
+     uint32_t opcode;
      int32_t fileid;
      db_recno_t old_first;
      db_recno_t new_first;
@@ -266,9 +266,9 @@ CDB___qam_mvptr_log (dbenv, txnid, ret_lsnp, flags,
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t rectype, txn_num;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -315,7 +315,7 @@ CDB___qam_mvptr_log (dbenv, txnid, ret_lsnp, flags,
   else
     memset (bp, 0, sizeof (*metalsn));
   bp += sizeof (*metalsn);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -332,7 +332,7 @@ CDB___qam_mvptr_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __qam_mvptr_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -369,7 +369,7 @@ CDB___qam_mvptr_read (recbuf, argpp)
      __qam_mvptr_args **argpp;
 {
   __qam_mvptr_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__qam_mvptr_args) +
@@ -408,18 +408,18 @@ CDB___qam_del_log (dbenv, txnid, ret_lsnp, flags,
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
+     uint32_t flags;
      int32_t fileid;
      DB_LSN *lsn;
      db_pgno_t pgno;
-     u_int32_t indx;
+     uint32_t indx;
      db_recno_t recno;
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t rectype, txn_num;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -459,7 +459,7 @@ CDB___qam_del_log (dbenv, txnid, ret_lsnp, flags,
   bp += sizeof (indx);
   memcpy (bp, &recno, sizeof (recno));
   bp += sizeof (recno);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -476,7 +476,7 @@ CDB___qam_del_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __qam_del_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -511,7 +511,7 @@ CDB___qam_del_read (recbuf, argpp)
      __qam_del_args **argpp;
 {
   __qam_del_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__qam_del_args) +
@@ -546,22 +546,22 @@ CDB___qam_add_log (dbenv, txnid, ret_lsnp, flags,
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
+     uint32_t flags;
      int32_t fileid;
      DB_LSN *lsn;
      db_pgno_t pgno;
-     u_int32_t indx;
+     uint32_t indx;
      db_recno_t recno;
      const DBT *data;
-     u_int32_t vflag;
+     uint32_t vflag;
      const DBT *olddata;
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t zero;
-  u_int32_t rectype, txn_num;
+  uint32_t zero;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -581,9 +581,9 @@ CDB___qam_add_log (dbenv, txnid, ret_lsnp, flags,
     + sizeof (pgno)
     + sizeof (indx)
     + sizeof (recno)
-    + sizeof (u_int32_t) + (data == NULL ? 0 : data->size)
+    + sizeof (uint32_t) + (data == NULL ? 0 : data->size)
     + sizeof (vflag)
-    + sizeof (u_int32_t) + (olddata == NULL ? 0 : olddata->size);
+    + sizeof (uint32_t) + (olddata == NULL ? 0 : olddata->size);
   if ((ret = CDB___os_malloc (logrec.size, NULL, &logrec.data)) != 0)
     return (ret);
 
@@ -610,8 +610,8 @@ CDB___qam_add_log (dbenv, txnid, ret_lsnp, flags,
   if (data == NULL)
   {
     zero = 0;
-    memcpy (bp, &zero, sizeof (u_int32_t));
-    bp += sizeof (u_int32_t);
+    memcpy (bp, &zero, sizeof (uint32_t));
+    bp += sizeof (uint32_t);
   }
   else
   {
@@ -625,8 +625,8 @@ CDB___qam_add_log (dbenv, txnid, ret_lsnp, flags,
   if (olddata == NULL)
   {
     zero = 0;
-    memcpy (bp, &zero, sizeof (u_int32_t));
-    bp += sizeof (u_int32_t);
+    memcpy (bp, &zero, sizeof (uint32_t));
+    bp += sizeof (uint32_t);
   }
   else
   {
@@ -635,7 +635,7 @@ CDB___qam_add_log (dbenv, txnid, ret_lsnp, flags,
     memcpy (bp, olddata->data, olddata->size);
     bp += olddata->size;
   }
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -652,7 +652,7 @@ CDB___qam_add_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __qam_add_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -679,7 +679,7 @@ CDB___qam_add_print (notused1, dbtp, lsnp, notused2, notused3)
   printf ("\tdata: ");
   for (i = 0; i < argp->data.size; i++)
   {
-    ch = ((u_int8_t *) argp->data.data)[i];
+    ch = ((uint8_t *) argp->data.data)[i];
     if (isprint (ch) || ch == 0xa)
       putchar (ch);
     else
@@ -690,7 +690,7 @@ CDB___qam_add_print (notused1, dbtp, lsnp, notused2, notused3)
   printf ("\tolddata: ");
   for (i = 0; i < argp->olddata.size; i++)
   {
-    ch = ((u_int8_t *) argp->olddata.data)[i];
+    ch = ((uint8_t *) argp->olddata.data)[i];
     if (isprint (ch) || ch == 0xa)
       putchar (ch);
     else
@@ -708,7 +708,7 @@ CDB___qam_add_read (recbuf, argpp)
      __qam_add_args **argpp;
 {
   __qam_add_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__qam_add_args) +
@@ -734,15 +734,15 @@ CDB___qam_add_read (recbuf, argpp)
   memcpy (&argp->recno, bp, sizeof (argp->recno));
   bp += sizeof (argp->recno);
   memset (&argp->data, 0, sizeof (argp->data));
-  memcpy (&argp->data.size, bp, sizeof (u_int32_t));
-  bp += sizeof (u_int32_t);
+  memcpy (&argp->data.size, bp, sizeof (uint32_t));
+  bp += sizeof (uint32_t);
   argp->data.data = bp;
   bp += argp->data.size;
   memcpy (&argp->vflag, bp, sizeof (argp->vflag));
   bp += sizeof (argp->vflag);
   memset (&argp->olddata, 0, sizeof (argp->olddata));
-  memcpy (&argp->olddata.size, bp, sizeof (u_int32_t));
-  bp += sizeof (u_int32_t);
+  memcpy (&argp->olddata.size, bp, sizeof (uint32_t));
+  bp += sizeof (uint32_t);
   argp->olddata.data = bp;
   bp += argp->olddata.size;
   *argpp = argp;

--- a/db/qam_auto.h
+++ b/db/qam_auto.h
@@ -7,7 +7,7 @@
 
 typedef struct _qam_inc_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
   int32_t fileid;
@@ -15,7 +15,7 @@ typedef struct _qam_inc_args
 } __qam_inc_args;
 
 int CDB___qam_inc_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, int32_t, DB_LSN *));
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, int32_t, DB_LSN *));
 int CDB___qam_inc_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___qam_inc_read __P ((void *, __qam_inc_args **));
 
@@ -23,7 +23,7 @@ int CDB___qam_inc_read __P ((void *, __qam_inc_args **));
 
 typedef struct _qam_incfirst_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
   int32_t fileid;
@@ -31,7 +31,7 @@ typedef struct _qam_incfirst_args
 } __qam_incfirst_args;
 
 int CDB___qam_incfirst_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, int32_t, db_recno_t));
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, int32_t, db_recno_t));
 int CDB___qam_incfirst_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___qam_incfirst_read __P ((void *, __qam_incfirst_args **));
 
@@ -39,10 +39,10 @@ int CDB___qam_incfirst_read __P ((void *, __qam_incfirst_args **));
 
 typedef struct _qam_mvptr_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
-  u_int32_t opcode;
+  uint32_t opcode;
   int32_t fileid;
   db_recno_t old_first;
   db_recno_t new_first;
@@ -52,7 +52,7 @@ typedef struct _qam_mvptr_args
 } __qam_mvptr_args;
 
 int CDB___qam_mvptr_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, u_int32_t, int32_t, db_recno_t,
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, uint32_t, int32_t, db_recno_t,
       db_recno_t, db_recno_t, db_recno_t, DB_LSN *));
 int CDB___qam_mvptr_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___qam_mvptr_read __P ((void *, __qam_mvptr_args **));
@@ -61,19 +61,19 @@ int CDB___qam_mvptr_read __P ((void *, __qam_mvptr_args **));
 
 typedef struct _qam_del_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
   int32_t fileid;
   DB_LSN lsn;
   db_pgno_t pgno;
-  u_int32_t indx;
+  uint32_t indx;
   db_recno_t recno;
 } __qam_del_args;
 
 int CDB___qam_del_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, int32_t, DB_LSN *, db_pgno_t,
-      u_int32_t, db_recno_t));
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, int32_t, DB_LSN *, db_pgno_t,
+      uint32_t, db_recno_t));
 int CDB___qam_del_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___qam_del_read __P ((void *, __qam_del_args **));
 
@@ -81,22 +81,22 @@ int CDB___qam_del_read __P ((void *, __qam_del_args **));
 
 typedef struct _qam_add_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
   int32_t fileid;
   DB_LSN lsn;
   db_pgno_t pgno;
-  u_int32_t indx;
+  uint32_t indx;
   db_recno_t recno;
   DBT data;
-  u_int32_t vflag;
+  uint32_t vflag;
   DBT olddata;
 } __qam_add_args;
 
 int CDB___qam_add_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, int32_t, DB_LSN *, db_pgno_t,
-      u_int32_t, db_recno_t, const DBT *, u_int32_t, const DBT *));
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, int32_t, DB_LSN *, db_pgno_t,
+      uint32_t, db_recno_t, const DBT *, uint32_t, const DBT *));
 int CDB___qam_add_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___qam_add_read __P ((void *, __qam_add_args **));
 int CDB___qam_init_print __P ((DB_ENV *));

--- a/db/qam_conv.c
+++ b/db/qam_conv.c
@@ -31,11 +31,11 @@ int
 CDB___qam_mswap (pg)
      PAGE *pg;
 {
-  u_int8_t *p;
+  uint8_t *p;
 
   CDB___db_metaswap (pg);
 
-  p = (u_int8_t *) pg + sizeof (DBMETA);
+  p = (uint8_t *) pg + sizeof (DBMETA);
 
   SWAP32 (p);                   /* start */
   SWAP32 (p);                   /* first_recno */

--- a/db/qam_ext.h
+++ b/db/qam_ext.h
@@ -1,9 +1,9 @@
 /* DO NOT EDIT: automatically built by dist/distrib. */
 #ifndef _qam_ext_h_
 #define _qam_ext_h_
-int CDB___qam_pitem __P ((DBC *, QPAGE *, u_int32_t, db_recno_t, DBT *));
-int CDB___qam_put __P ((DB *, DB_TXN *, DBT *, DBT *, u_int32_t));
-int CDB___qam_delete __P ((DB *, DB_TXN *, DBT *, u_int32_t));
+int CDB___qam_pitem __P ((DBC *, QPAGE *, uint32_t, db_recno_t, DBT *));
+int CDB___qam_put __P ((DB *, DB_TXN *, DBT *, DBT *, uint32_t));
+int CDB___qam_delete __P ((DB *, DB_TXN *, DBT *, uint32_t));
 int CDB___qam_c_dup __P ((DBC *, DBC *));
 int CDB___qam_c_init __P ((DBC *));
 int CDB___qam_init_recover __P ((DB_ENV *));
@@ -18,5 +18,5 @@ int CDB___qam_incfirst_recover __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___qam_mvptr_recover __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___qam_del_recover __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___qam_add_recover __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
-int CDB___qam_stat __P ((DB *, void *, void *(*)(size_t), u_int32_t));
+int CDB___qam_stat __P ((DB *, void *, void *(*)(size_t), uint32_t));
 #endif /* _qam_ext_h_ */

--- a/db/qam_open.c
+++ b/db/qam_open.c
@@ -157,7 +157,7 @@ CDB___qam_metachk (dbp, name, qmeta)
      QMETA *qmeta;
 {
   DB_ENV *dbenv;
-  u_int32_t vers;
+  uint32_t vers;
   int ret;
 
   dbenv = dbp->dbenv;

--- a/db/qam_stat.c
+++ b/db/qam_stat.c
@@ -28,14 +28,14 @@ static const char sccsid[] = "@(#)qam_stat.c  11.4 (Sleepycat) 8/19/99";
  * CDB___qam_stat --
  *  Gather/print the qam statistics
  *
- * PUBLIC: int CDB___qam_stat __P((DB *, void *, void *(*)(size_t), u_int32_t));
+ * PUBLIC: int CDB___qam_stat __P((DB *, void *, void *(*)(size_t), uint32_t));
  */
 int
 CDB___qam_stat (dbp, spp, db_malloc, flags)
      DB *dbp;
      void *spp;
      void *(*db_malloc) __P ((size_t));
-     u_int32_t flags;
+     uint32_t flags;
 {
   QUEUE *t;
   DBC *dbc;

--- a/db/qam_upgrade.c
+++ b/db/qam_upgrade.c
@@ -30,13 +30,13 @@ static const char revid[] =
  * CDB___qam_31_qammeta --
  *  Upgrade the database from version 1 to version 2.
  *
- * PUBLIC: int CDB___qam_31_qammeta __P((DB *, char *, u_int8_t *));
+ * PUBLIC: int CDB___qam_31_qammeta __P((DB *, char *, uint8_t *));
  */
 int
 CDB___qam_31_qammeta (dbp, real_name, buf)
      DB *dbp;
      char *real_name;
-     u_int8_t *buf;
+     uint8_t *buf;
 {
   QMETA31 *newmeta;
   QMETA30 *oldmeta;

--- a/db/qam_verify.c
+++ b/db/qam_verify.c
@@ -28,7 +28,7 @@ static const char revid[] =
  *  Verify the queue-specific part of a metadata page.
  *
  * PUBLIC: int CDB___qam_vrfy_meta __P((DB *, VRFY_DBINFO *, QMETA *,
- * PUBLIC:     db_pgno_t, u_int32_t));
+ * PUBLIC:     db_pgno_t, uint32_t));
  */
 int
 CDB___qam_vrfy_meta (dbp, vdp, meta, pgno, flags)
@@ -36,7 +36,7 @@ CDB___qam_vrfy_meta (dbp, vdp, meta, pgno, flags)
      VRFY_DBINFO *vdp;
      QMETA *meta;
      db_pgno_t pgno;
-     u_int32_t flags;
+     uint32_t flags;
 {
   VRFY_PAGEINFO *pip;
   int isbad, ret, t_ret;
@@ -81,7 +81,7 @@ CDB___qam_vrfy_meta (dbp, vdp, meta, pgno, flags)
    * re_len:  If this is bad, we can't safely verify queue data pages, so
    * return DB_VERIFY_FATAL
    */
-  if (ALIGN (meta->re_len + sizeof (QAMDATA) - 1, sizeof (u_int32_t)) *
+  if (ALIGN (meta->re_len + sizeof (QAMDATA) - 1, sizeof (uint32_t)) *
       meta->rec_page + sizeof (QPAGE) > dbp->pgsize)
   {
     EPRINT ((dbp->dbenv,
@@ -106,7 +106,7 @@ err:if ((t_ret = CDB___db_vrfy_putpageinfo (vdp, pip)) != 0 && ret == 0)
  *  Verify a queue data page.
  *
  * PUBLIC: int CDB___qam_vrfy_data __P((DB *, VRFY_DBINFO *, QPAGE *,
- * PUBLIC:     db_pgno_t, u_int32_t));
+ * PUBLIC:     db_pgno_t, uint32_t));
  */
 int
 CDB___qam_vrfy_data (dbp, vdp, h, pgno, flags)
@@ -114,13 +114,13 @@ CDB___qam_vrfy_data (dbp, vdp, h, pgno, flags)
      VRFY_DBINFO *vdp;
      QPAGE *h;
      db_pgno_t pgno;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB fakedb;
   struct __queue fakeq;
   QAMDATA *qp;
   db_recno_t i;
-  u_int8_t qflags;
+  uint8_t qflags;
 
   /*
    * Not much to do here, except make sure that flags are reasonable.
@@ -135,7 +135,7 @@ CDB___qam_vrfy_data (dbp, vdp, h, pgno, flags)
   for (i = 0; i < vdp->rec_page; i++)
   {
     qp = QAM_GET_RECORD (&fakedb, h, i);
-    if ((u_int8_t *) qp >= (u_int8_t *) h + dbp->pgsize)
+    if ((uint8_t *) qp >= (uint8_t *) h + dbp->pgsize)
     {
       EPRINT ((dbp->dbenv,
                "Queue record %lu extends past end of page %lu", i, pgno));
@@ -159,13 +159,13 @@ CDB___qam_vrfy_data (dbp, vdp, h, pgno, flags)
  * CDB___qam_vrfy_structure --
  *  Verify a queue database structure, such as it is.
  *
- * PUBLIC: int CDB___qam_vrfy_structure __P((DB *, VRFY_DBINFO *, u_int32_t));
+ * PUBLIC: int CDB___qam_vrfy_structure __P((DB *, VRFY_DBINFO *, uint32_t));
  */
 int
 CDB___qam_vrfy_structure (dbp, vdp, flags)
      DB *dbp;
      VRFY_DBINFO *vdp;
-     u_int32_t flags;
+     uint32_t flags;
 {
   VRFY_PAGEINFO *pip;
   db_pgno_t i;

--- a/db/region.h
+++ b/db/region.h
@@ -108,7 +108,7 @@
  * split 100Gb memory pools into that many different regions.  It's typedef'd
  * so it won't be too painful to upgrade.
  */
-typedef u_int32_t roff_t;
+typedef uint32_t roff_t;
 
 /*
  * Nothing can live at region offset 0, because, in all cases, that's where
@@ -158,7 +158,7 @@ typedef struct __db_reg_env
    * it to determine if the memory has been zeroed since it was last used.
    */
 #define  DB_REGION_MAGIC  0x120897
-  u_int32_t magic;              /* Valid region magic number. */
+  uint32_t magic;              /* Valid region magic number. */
 
   int panic;                    /* Environment is dead. */
 
@@ -169,7 +169,7 @@ typedef struct __db_reg_env
   /* List of regions. */
     SH_LIST_HEAD (__db_regionh) regionq;
 
-  u_int32_t refcnt;             /* References to the environment. */
+  uint32_t refcnt;             /* References to the environment. */
 
   size_t pad;                   /* Guarantee that following memory is
                                  * size_t aligned.  This is necessary
@@ -194,7 +194,7 @@ typedef struct __db_region
    * in both the environment and each shared region, as Windows/95 uses
    * it to determine if the memory has been zeroed since it was last used.
    */
-  u_int32_t magic;
+  uint32_t magic;
 
   SH_LIST_ENTRY q;              /* Linked list of REGIONs. */
 
@@ -214,7 +214,7 @@ typedef struct __db_region
   int id;                       /* Region id. */
 
 #define  REG_DEAD  0x01         /* Region may be corrupted. */
-  u_int32_t flags;
+  uint32_t flags;
 } REGION;
 
 /*
@@ -237,7 +237,7 @@ struct __db_reginfo_t
 
 #define  REGION_CREATE    0x01  /* Caller created region. */
 #define  REGION_CREATE_OK  0x02 /* Caller willing to create region. */
-  u_int32_t flags;
+  uint32_t flags;
 };
 
 /*
@@ -246,12 +246,12 @@ struct __db_reginfo_t
  *
  * !!!
  * R_OFFSET should really be returning a ptrdiff_t, but that's not yet
- * portable.  We use u_int32_t, which restricts regions to 4Gb in size.
+ * portable.  We use uint32_t, which restricts regions to 4Gb in size.
  */
 #define  R_ADDR(base, offset)            \
-  ((void *)((u_int8_t *)((base)->addr) + offset))
+  ((void *)((uint8_t *)((base)->addr) + offset))
 #define  R_OFFSET(base, p)            \
-  ((u_int32_t)((u_int8_t *)(p) - (u_int8_t *)(base)->addr))
+  ((uint32_t)((uint8_t *)(p) - (uint8_t *)(base)->addr))
 
 /*
  * R_LOCK  Lock/unlock a region.

--- a/db/shqueue.h
+++ b/db/shqueue.h
@@ -45,24 +45,24 @@ struct {                \
  */
 
 #define SH_LIST_FIRSTP(head, type)          \
-  ((struct type *)(((u_int8_t *)(head)) + (head)->slh_first))
+  ((struct type *)(((uint8_t *)(head)) + (head)->slh_first))
 
 #define SH_LIST_FIRST(head, type)          \
   ((head)->slh_first == -1 ? NULL :        \
-  ((struct type *)(((u_int8_t *)(head)) + (head)->slh_first)))
+  ((struct type *)(((uint8_t *)(head)) + (head)->slh_first)))
 
 #define SH_LIST_NEXTP(elm, field, type)          \
-  ((struct type *)(((u_int8_t *)(elm)) + (elm)->field.sle_next))
+  ((struct type *)(((uint8_t *)(elm)) + (elm)->field.sle_next))
 
 #define SH_LIST_NEXT(elm, field, type)          \
   ((elm)->field.sle_next == -1 ? NULL :         \
-  ((struct type *)(((u_int8_t *)(elm)) + (elm)->field.sle_next)))
+  ((struct type *)(((uint8_t *)(elm)) + (elm)->field.sle_next)))
 
 #define SH_LIST_PREV(elm, field)          \
-  ((ssize_t *)(((u_int8_t *)(elm)) + (elm)->field.sle_prev))
+  ((ssize_t *)(((uint8_t *)(elm)) + (elm)->field.sle_prev))
 
 #define SH_PTR_TO_OFF(src, dest)          \
-  ((ssize_t)(((u_int8_t *)(dest)) - ((u_int8_t *)(src))))
+  ((ssize_t)(((uint8_t *)(dest)) - ((uint8_t *)(src))))
 
 #define  SH_LIST_END(head)      NULL
 
@@ -128,22 +128,22 @@ struct {                \
  * Shared tail queue functions.
  */
 #define SH_TAILQ_FIRSTP(head, type)          \
-  ((struct type *)((u_int8_t *)(head) + (head)->stqh_first))
+  ((struct type *)((uint8_t *)(head) + (head)->stqh_first))
 
 #define SH_TAILQ_FIRST(head, type)          \
   ((head)->stqh_first == -1 ? NULL : SH_TAILQ_FIRSTP(head, type))
 
 #define SH_TAILQ_NEXTP(elm, field, type)        \
-  ((struct type *)((u_int8_t *)(elm) + (elm)->field.stqe_next))
+  ((struct type *)((uint8_t *)(elm) + (elm)->field.stqe_next))
 
 #define SH_TAILQ_NEXT(elm, field, type)          \
   ((elm)->field.stqe_next == -1 ? NULL : SH_TAILQ_NEXTP(elm, field, type))
 
 #define SH_TAILQ_PREVP(elm, field)          \
-  ((ssize_t *)((u_int8_t *)(elm) + (elm)->field.stqe_prev))
+  ((ssize_t *)((uint8_t *)(elm) + (elm)->field.stqe_prev))
 
 #define SH_TAILQ_LAST(head)            \
-  ((ssize_t *)(((u_int8_t *)(head)) + (head)->stqh_last))
+  ((ssize_t *)(((uint8_t *)(head)) + (head)->stqh_last))
 
 #define SH_TAILQ_NEXT_TO_PREV(elm, field)        \
   (-(elm)->field.stqe_next + SH_PTR_TO_OFF(elm, &(elm)->field.stqe_next))
@@ -234,27 +234,27 @@ struct {                \
  * Shared circular queue functions.
  */
 #define SH_CIRCLEQ_FIRSTP(head, type)          \
-  ((struct type *)(((u_int8_t *)(head)) + (head)->scqh_first))
+  ((struct type *)(((uint8_t *)(head)) + (head)->scqh_first))
 
 #define SH_CIRCLEQ_FIRST(head, type)          \
   ((head)->scqh_first == -1 ?           \
   (void *)head : SH_CIRCLEQ_FIRSTP(head, type))
 
 #define SH_CIRCLEQ_LASTP(head, type)          \
-  ((struct type *)(((u_int8_t *)(head)) + (head)->scqh_last))
+  ((struct type *)(((uint8_t *)(head)) + (head)->scqh_last))
 
 #define SH_CIRCLEQ_LAST(head, type)          \
   ((head)->scqh_last == -1 ? (void *)head : SH_CIRCLEQ_LASTP(head, type))
 
 #define SH_CIRCLEQ_NEXTP(elm, field, type)        \
-  ((struct type *)(((u_int8_t *)(elm)) + (elm)->field.scqe_next))
+  ((struct type *)(((uint8_t *)(elm)) + (elm)->field.scqe_next))
 
 #define SH_CIRCLEQ_NEXT(head, elm, field, type)        \
   ((elm)->field.scqe_next == SH_PTR_TO_OFF(elm, head) ?    \
       (void *)head : SH_CIRCLEQ_NEXTP(elm, field, type))
 
 #define SH_CIRCLEQ_PREVP(elm, field, type)        \
-  ((struct type *)(((u_int8_t *)(elm)) + (elm)->field.scqe_prev))
+  ((struct type *)(((uint8_t *)(elm)) + (elm)->field.scqe_prev))
 
 #define SH_CIRCLEQ_PREV(head, elm, field, type)        \
   ((elm)->field.scqe_prev == SH_PTR_TO_OFF(elm, head) ?    \

--- a/db/txn.c
+++ b/db/txn.c
@@ -101,7 +101,7 @@ int
 CDB_txn_begin (dbenv, parent, txnpp, flags)
      DB_ENV *dbenv;
      DB_TXN *parent, **txnpp;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB_TXN *txn;
   int ret;
@@ -180,7 +180,7 @@ CDB___txn_begin (txn)
   DB_TXNREGION *region;
   TXN_DETAIL *td;
   size_t off;
-  u_int32_t id;
+  uint32_t id;
   int ret;
 
   mgr = txn->mgrp;
@@ -275,7 +275,7 @@ err2:return (ret);
 int
 CDB_txn_commit (txnp, flags)
      DB_TXN *txnp;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB_ENV *dbenv;
   DB_TXN *kids;
@@ -422,7 +422,7 @@ CDB_txn_prepare (txnp)
 /*
  * Return the transaction ID associated with a particular transaction
  */
-u_int32_t
+uint32_t
 CDB_txn_id (txnp)
      DB_TXN *txnp;
 {
@@ -645,7 +645,7 @@ CDB___txn_undo (txnp)
 int
 CDB_txn_checkpoint (dbenv, kbytes, minutes)
      DB_ENV *dbenv;
-     u_int32_t kbytes, minutes;
+     uint32_t kbytes, minutes;
 {
   DB_LOG *dblp;
   DB_LSN ckp_lsn, sync_lsn, last_ckp;
@@ -654,7 +654,7 @@ CDB_txn_checkpoint (dbenv, kbytes, minutes)
   LOG *lp;
   TXN_DETAIL *txnp;
   time_t last_ckp_time, now;
-  u_int32_t kbytes_written;
+  uint32_t kbytes_written;
   int ret;
 
   PANIC_CHECK (dbenv);
@@ -688,7 +688,7 @@ CDB_txn_checkpoint (dbenv, kbytes, minutes)
       lp->stat.st_wc_mbytes * 1024 + lp->stat.st_wc_bytes / 1024;
     ckp_lsn = lp->lsn;
     R_UNLOCK (dbenv, &dblp->reginfo);
-    if (kbytes_written >= (u_int32_t) kbytes)
+    if (kbytes_written >= (uint32_t) kbytes)
       goto do_ckp;
   }
 

--- a/db/txn.h
+++ b/db/txn.h
@@ -33,7 +33,7 @@ struct __db_txn
   DB_TXNMGR *mgrp;              /* Pointer to transaction manager. */
   DB_TXN *parent;               /* Pointer to transaction's parent. */
   DB_LSN last_lsn;              /* Lsn of last log write. */
-  u_int32_t txnid;              /* Unique transaction id. */
+  uint32_t txnid;              /* Unique transaction id. */
   roff_t off;                   /* Detail structure within region. */
     TAILQ_ENTRY (__db_txn) links;       /* Links transactions off manager. */
     TAILQ_HEAD (__kids, __db_txn) kids; /* Child transactions. */
@@ -45,7 +45,7 @@ struct __db_txn
 #define  TXN_NOSYNC  0x08       /* Do not sync on prepare and commit. */
 #define  TXN_NOWAIT  0x10       /* Do not wait on locks. */
 #define  TXN_SYNC  0x20         /* Sync on prepare and commit. */
-  u_int32_t flags;
+  uint32_t flags;
 };
 
 /*
@@ -55,7 +55,7 @@ typedef char DB_XID[XIDDATASIZE];
 
 typedef struct __txn_detail
 {
-  u_int32_t txnid;              /* current transaction id
+  uint32_t txnid;              /* current transaction id
                                    used to link free list also */
   DB_LSN last_lsn;              /* last lsn written for this txn */
   DB_LSN begin_lsn;             /* lsn of begin record */
@@ -66,7 +66,7 @@ typedef struct __txn_detail
 #define  TXN_ABORTED    2
 #define  TXN_PREPARED    3
 #define  TXN_COMMITTED    4
-  u_int32_t status;             /* status of the transaction */
+  uint32_t status;             /* status of the transaction */
 
   SH_TAILQ_ENTRY links;         /* free/active list */
 
@@ -76,15 +76,15 @@ typedef struct __txn_detail
 #define  TXN_XA_PREPARED    4
 #define  TXN_XA_STARTED    5
 #define  TXN_XA_SUSPENDED  6
-  u_int32_t xa_status;          /* XA status */
+  uint32_t xa_status;          /* XA status */
 
   /*
    * XID (xid_t) structure: because these fields are logged, the
    * sizes have to be explicit.
    */
   DB_XID xid;                   /* XA global transaction id */
-  u_int32_t bqual;              /* bqual_length from XID */
-  u_int32_t gtrid;              /* gtrid_length from XID */
+  uint32_t bqual;              /* bqual_length from XID */
+  uint32_t gtrid;              /* gtrid_length from XID */
   int32_t format;               /* XA format */
 } TXN_DETAIL;
 
@@ -123,18 +123,18 @@ struct __db_txnmgr
  */
 struct __db_txnregion
 {
-  u_int32_t maxtxns;            /* maximum number of active TXNs */
-  u_int32_t last_txnid;         /* last transaction id given out */
+  uint32_t maxtxns;            /* maximum number of active TXNs */
+  uint32_t last_txnid;         /* last transaction id given out */
   DB_LSN pending_ckp;           /* last checkpoint did not finish */
   DB_LSN last_ckp;              /* lsn of the last checkpoint */
   time_t time_ckp;              /* time of last checkpoint */
-  u_int32_t logtype;            /* type of logging */
-  u_int32_t locktype;           /* lock type */
-  u_int32_t naborts;            /* number of aborted TXNs */
-  u_int32_t ncommits;           /* number of committed TXNs */
-  u_int32_t nbegins;            /* number of begun TXNs */
-  u_int32_t nactive;            /* number of active TXNs */
-  u_int32_t maxnactive;         /* maximum number of active TXNs */
+  uint32_t logtype;            /* type of logging */
+  uint32_t locktype;           /* lock type */
+  uint32_t naborts;            /* number of aborted TXNs */
+  uint32_t ncommits;           /* number of committed TXNs */
+  uint32_t nbegins;            /* number of begun TXNs */
+  uint32_t nactive;            /* number of active TXNs */
+  uint32_t maxnactive;         /* maximum number of active TXNs */
   /* active TXN list */
     SH_TAILQ_HEAD (__active) active_txn;
 };

--- a/db/txn_auto.c
+++ b/db/txn_auto.c
@@ -20,14 +20,14 @@ CDB___txn_regop_log (dbenv, txnid, ret_lsnp, flags, opcode)
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
-     u_int32_t opcode;
+     uint32_t flags;
+     uint32_t opcode;
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t rectype, txn_num;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -55,7 +55,7 @@ CDB___txn_regop_log (dbenv, txnid, ret_lsnp, flags, opcode)
   bp += sizeof (DB_LSN);
   memcpy (bp, &opcode, sizeof (opcode));
   bp += sizeof (opcode);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -72,7 +72,7 @@ CDB___txn_regop_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __txn_regop_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -102,7 +102,7 @@ CDB___txn_regop_read (recbuf, argpp)
      __txn_regop_args **argpp;
 {
   __txn_regop_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__txn_regop_args) +
@@ -128,15 +128,15 @@ CDB___txn_ckp_log (dbenv, txnid, ret_lsnp, flags, ckp_lsn, last_ckp)
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
+     uint32_t flags;
      DB_LSN *ckp_lsn;
      DB_LSN *last_ckp;
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t rectype, txn_num;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -172,7 +172,7 @@ CDB___txn_ckp_log (dbenv, txnid, ret_lsnp, flags, ckp_lsn, last_ckp)
   else
     memset (bp, 0, sizeof (*last_ckp));
   bp += sizeof (*last_ckp);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -189,7 +189,7 @@ CDB___txn_ckp_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __txn_ckp_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -222,7 +222,7 @@ CDB___txn_ckp_read (recbuf, argpp)
      __txn_ckp_args **argpp;
 {
   __txn_ckp_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__txn_ckp_args) +
@@ -251,19 +251,19 @@ CDB___txn_xa_regop_log (dbenv, txnid, ret_lsnp, flags,
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
-     u_int32_t opcode;
+     uint32_t flags;
+     uint32_t opcode;
      const DBT *xid;
      int32_t formatID;
-     u_int32_t gtrid;
-     u_int32_t bqual;
+     uint32_t gtrid;
+     uint32_t bqual;
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t zero;
-  u_int32_t rectype, txn_num;
+  uint32_t zero;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -279,7 +279,7 @@ CDB___txn_xa_regop_log (dbenv, txnid, ret_lsnp, flags,
     lsnp = &txnid->last_lsn;
   logrec.size = sizeof (rectype) + sizeof (txn_num) + sizeof (DB_LSN)
     + sizeof (opcode)
-    + sizeof (u_int32_t) + (xid == NULL ? 0 : xid->size)
+    + sizeof (uint32_t) + (xid == NULL ? 0 : xid->size)
     + sizeof (formatID) + sizeof (gtrid) + sizeof (bqual);
   if ((ret = CDB___os_malloc (logrec.size, NULL, &logrec.data)) != 0)
     return (ret);
@@ -296,8 +296,8 @@ CDB___txn_xa_regop_log (dbenv, txnid, ret_lsnp, flags,
   if (xid == NULL)
   {
     zero = 0;
-    memcpy (bp, &zero, sizeof (u_int32_t));
-    bp += sizeof (u_int32_t);
+    memcpy (bp, &zero, sizeof (uint32_t));
+    bp += sizeof (uint32_t);
   }
   else
   {
@@ -312,7 +312,7 @@ CDB___txn_xa_regop_log (dbenv, txnid, ret_lsnp, flags,
   bp += sizeof (gtrid);
   memcpy (bp, &bqual, sizeof (bqual));
   bp += sizeof (bqual);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -329,7 +329,7 @@ CDB___txn_xa_regop_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __txn_xa_regop_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -351,7 +351,7 @@ CDB___txn_xa_regop_print (notused1, dbtp, lsnp, notused2, notused3)
   printf ("\txid: ");
   for (i = 0; i < argp->xid.size; i++)
   {
-    ch = ((u_int8_t *) argp->xid.data)[i];
+    ch = ((uint8_t *) argp->xid.data)[i];
     if (isprint (ch) || ch == 0xa)
       putchar (ch);
     else
@@ -372,7 +372,7 @@ CDB___txn_xa_regop_read (recbuf, argpp)
      __txn_xa_regop_args **argpp;
 {
   __txn_xa_regop_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__txn_xa_regop_args) +
@@ -390,8 +390,8 @@ CDB___txn_xa_regop_read (recbuf, argpp)
   memcpy (&argp->opcode, bp, sizeof (argp->opcode));
   bp += sizeof (argp->opcode);
   memset (&argp->xid, 0, sizeof (argp->xid));
-  memcpy (&argp->xid.size, bp, sizeof (u_int32_t));
-  bp += sizeof (u_int32_t);
+  memcpy (&argp->xid.size, bp, sizeof (uint32_t));
+  bp += sizeof (uint32_t);
   argp->xid.data = bp;
   bp += argp->xid.size;
   memcpy (&argp->formatID, bp, sizeof (argp->formatID));
@@ -409,15 +409,15 @@ CDB___txn_child_log (dbenv, txnid, ret_lsnp, flags, opcode, parent)
      DB_ENV *dbenv;
      DB_TXN *txnid;
      DB_LSN *ret_lsnp;
-     u_int32_t flags;
-     u_int32_t opcode;
-     u_int32_t parent;
+     uint32_t flags;
+     uint32_t opcode;
+     uint32_t parent;
 {
   DBT logrec;
   DB_LSN *lsnp, null_lsn;
-  u_int32_t rectype, txn_num;
+  uint32_t rectype, txn_num;
   int ret;
-  u_int8_t *bp;
+  uint8_t *bp;
 
   if (txnid != NULL &&
       TAILQ_FIRST (&txnid->kids) != NULL && CDB___txn_activekids (txnid) != 0)
@@ -447,7 +447,7 @@ CDB___txn_child_log (dbenv, txnid, ret_lsnp, flags, opcode, parent)
   bp += sizeof (opcode);
   memcpy (bp, &parent, sizeof (parent));
   bp += sizeof (parent);
-  DB_ASSERT ((u_int32_t) (bp - (u_int8_t *) logrec.data) == logrec.size);
+  DB_ASSERT ((uint32_t) (bp - (uint8_t *) logrec.data) == logrec.size);
   ret = CDB_log_put (dbenv, ret_lsnp, (DBT *) & logrec, flags);
   if (txnid != NULL)
     txnid->last_lsn = *ret_lsnp;
@@ -464,7 +464,7 @@ CDB___txn_child_print (notused1, dbtp, lsnp, notused2, notused3)
      void *notused3;
 {
   __txn_child_args *argp;
-  u_int32_t i;
+  uint32_t i;
   u_int ch;
   int ret;
 
@@ -495,7 +495,7 @@ CDB___txn_child_read (recbuf, argpp)
      __txn_child_args **argpp;
 {
   __txn_child_args *argp;
-  u_int8_t *bp;
+  uint8_t *bp;
   int ret;
 
   ret = CDB___os_malloc (sizeof (__txn_child_args) +

--- a/db/txn_auto.h
+++ b/db/txn_auto.h
@@ -7,14 +7,14 @@
 
 typedef struct _txn_regop_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
-  u_int32_t opcode;
+  uint32_t opcode;
 } __txn_regop_args;
 
 int CDB___txn_regop_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, u_int32_t));
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, uint32_t));
 int CDB___txn_regop_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___txn_regop_read __P ((void *, __txn_regop_args **));
 
@@ -22,7 +22,7 @@ int CDB___txn_regop_read __P ((void *, __txn_regop_args **));
 
 typedef struct _txn_ckp_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
   DB_LSN ckp_lsn;
@@ -30,7 +30,7 @@ typedef struct _txn_ckp_args
 } __txn_ckp_args;
 
 int CDB___txn_ckp_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, DB_LSN *, DB_LSN *));
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, DB_LSN *, DB_LSN *));
 int CDB___txn_ckp_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___txn_ckp_read __P ((void *, __txn_ckp_args **));
 
@@ -38,19 +38,19 @@ int CDB___txn_ckp_read __P ((void *, __txn_ckp_args **));
 
 typedef struct _txn_xa_regop_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
-  u_int32_t opcode;
+  uint32_t opcode;
   DBT xid;
   int32_t formatID;
-  u_int32_t gtrid;
-  u_int32_t bqual;
+  uint32_t gtrid;
+  uint32_t bqual;
 } __txn_xa_regop_args;
 
 int CDB___txn_xa_regop_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, u_int32_t, const DBT *,
-      int32_t, u_int32_t, u_int32_t));
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, uint32_t, const DBT *,
+      int32_t, uint32_t, uint32_t));
 int CDB___txn_xa_regop_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___txn_xa_regop_read __P ((void *, __txn_xa_regop_args **));
 
@@ -58,15 +58,15 @@ int CDB___txn_xa_regop_read __P ((void *, __txn_xa_regop_args **));
 
 typedef struct _txn_child_args
 {
-  u_int32_t type;
+  uint32_t type;
   DB_TXN *txnid;
   DB_LSN prev_lsn;
-  u_int32_t opcode;
-  u_int32_t parent;
+  uint32_t opcode;
+  uint32_t parent;
 } __txn_child_args;
 
 int CDB___txn_child_log
-__P ((DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, u_int32_t, u_int32_t));
+__P ((DB_ENV *, DB_TXN *, DB_LSN *, uint32_t, uint32_t, uint32_t));
 int CDB___txn_child_print __P ((DB_ENV *, DBT *, DB_LSN *, int, void *));
 int CDB___txn_child_read __P ((void *, __txn_child_args **));
 int CDB___txn_init_print __P ((DB_ENV *));

--- a/db/txn_region.c
+++ b/db/txn_region.c
@@ -34,7 +34,7 @@ static const char sccsid[] = "@(#)txn_region.c  11.4 (Sleepycat) 9/20/99";
 #include "db_am.h"
 
 static int CDB___txn_init __P ((DB_ENV *, DB_TXNMGR *));
-static int CDB___txn_set_tx_max __P ((DB_ENV *, u_int32_t));
+static int CDB___txn_set_tx_max __P ((DB_ENV *, uint32_t));
 static int CDB___txn_set_tx_recover
 __P ((DB_ENV *, int (*)(DB_ENV *, DBT *, DB_LSN *, int, void *)));
 
@@ -61,7 +61,7 @@ CDB___txn_dbenv_create (dbenv)
 static int
 CDB___txn_set_tx_max (dbenv, tx_max)
      DB_ENV *dbenv;
-     u_int32_t tx_max;
+     uint32_t tx_max;
 {
   ENV_ILLEGAL_AFTER_OPEN (dbenv, "set_tx_max");
 
@@ -262,7 +262,7 @@ CDB_txn_stat (dbenv, statp, db_malloc)
   DB_TXN_STAT *stats;
   TXN_DETAIL *txnp;
   size_t nbytes;
-  u_int32_t nactive, ndx;
+  uint32_t nactive, ndx;
   int ret, slop;
 
   PANIC_CHECK (dbenv);

--- a/db/xa.c
+++ b/db/xa.c
@@ -416,7 +416,7 @@ CDB___db_xa_recover (xids, count, rmid, flags)
   DB_LOG *log;
   XID *xidp;
   int err, ret;
-  u_int32_t rectype, txnid;
+  uint32_t rectype, txnid;
 
   ret = 0;
   xidp = xids;
@@ -481,7 +481,7 @@ CDB___db_xa_recover (xids, count, rmid, flags)
     if (rectype != DB_txn_xa_regop && rectype != DB_txn_regop)
       continue;
 
-    memcpy (&txnid, (u_int8_t *) data.data + sizeof (rectype),
+    memcpy (&txnid, (uint8_t *) data.data + sizeof (rectype),
             sizeof (txnid));
     err = CDB___db_txnlist_find (log->xa_info, txnid);
     switch (rectype)

--- a/db/xa_db.c
+++ b/db/xa_db.c
@@ -19,19 +19,19 @@ static const char sccsid[] = "@(#)xa_db.c  11.4 (Sleepycat) 9/15/99";
 #include "xa.h"
 #include "xa_ext.h"
 
-static int CDB___xa_close __P ((DB *, u_int32_t));
-static int CDB___xa_cursor __P ((DB *, DB_TXN *, DBC **, u_int32_t));
-static int CDB___xa_del __P ((DB *, DB_TXN *, DBT *, u_int32_t));
-static int CDB___xa_get __P ((DB *, DB_TXN *, DBT *, DBT *, u_int32_t));
-static int CDB___xa_put __P ((DB *, DB_TXN *, DBT *, DBT *, u_int32_t));
+static int CDB___xa_close __P ((DB *, uint32_t));
+static int CDB___xa_cursor __P ((DB *, DB_TXN *, DBC **, uint32_t));
+static int CDB___xa_del __P ((DB *, DB_TXN *, DBT *, uint32_t));
+static int CDB___xa_get __P ((DB *, DB_TXN *, DBT *, DBT *, uint32_t));
+static int CDB___xa_put __P ((DB *, DB_TXN *, DBT *, DBT *, uint32_t));
 
 typedef struct __xa_methods
 {
-  int (*close) __P ((DB *, u_int32_t));
-  int (*cursor) __P ((DB *, DB_TXN *, DBC **, u_int32_t));
-  int (*del) __P ((DB *, DB_TXN *, DBT *, u_int32_t));
-  int (*get) __P ((DB *, DB_TXN *, DBT *, DBT *, u_int32_t));
-  int (*put) __P ((DB *, DB_TXN *, DBT *, DBT *, u_int32_t));
+  int (*close) __P ((DB *, uint32_t));
+  int (*cursor) __P ((DB *, DB_TXN *, DBC **, uint32_t));
+  int (*del) __P ((DB *, DB_TXN *, DBT *, uint32_t));
+  int (*get) __P ((DB *, DB_TXN *, DBT *, DBT *, uint32_t));
+  int (*put) __P ((DB *, DB_TXN *, DBT *, DBT *, uint32_t));
 } XA_METHODS;
 
 /*
@@ -74,7 +74,7 @@ CDB___xa_cursor (dbp, txn, dbcp, flags)
      DB *dbp;
      DB_TXN *txn;
      DBC **dbcp;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB_TXN *t;
 
@@ -88,7 +88,7 @@ CDB___xa_del (dbp, txn, key, flags)
      DB *dbp;
      DB_TXN *txn;
      DBT *key;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB_TXN *t;
 
@@ -100,9 +100,9 @@ CDB___xa_del (dbp, txn, key, flags)
 static int
 CDB___xa_close (dbp, flags)
      DB *dbp;
-     u_int32_t flags;
+     uint32_t flags;
 {
-  int (*real_close) __P ((DB *, u_int32_t));
+  int (*real_close) __P ((DB *, uint32_t));
 
   real_close = ((XA_METHODS *) dbp->xa_internal)->close;
 
@@ -117,7 +117,7 @@ CDB___xa_get (dbp, txn, key, data, flags)
      DB *dbp;
      DB_TXN *txn;
      DBT *key, *data;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB_TXN *t;
 
@@ -131,7 +131,7 @@ CDB___xa_put (dbp, txn, key, data, flags)
      DB *dbp;
      DB_TXN *txn;
      DBT *key, *data;
-     u_int32_t flags;
+     uint32_t flags;
 {
   DB_TXN *t;
 

--- a/hldb/hldb_dump.cc
+++ b/hldb/hldb_dump.cc
@@ -75,7 +75,7 @@ main (int argc, char *argv[])
   char *dopt, *home, *subname;
   int compress = 0;
   int wordlist = 0;
-  u_int32_t cachesize = 0;
+  uint32_t cachesize = 0;
   Configuration *config = 0;
 
   dbp = NULL;
@@ -273,7 +273,7 @@ main (int argc, char *argv[])
 int
 db_init (char *home, int Nflag)
 {
-  u_int32_t flags;
+  uint32_t flags;
   int ret;
 
   /* Optionally turn mutexes off. */

--- a/hldb/hldb_load.cc
+++ b/hldb/hldb_load.cc
@@ -56,7 +56,7 @@ int dbt_rprint __P ((DBT *));
 int dbt_rrecno __P ((DBT *));
 int digitize __P ((int, int *));
 int linetorn __P ((char *, db_recno_t *));
-int load __P ((char *, DBTYPE, char **, int, u_int32_t, int, int));
+int load __P ((char *, DBTYPE, char **, int, uint32_t, int, int));
 int main __P ((int, char *[]));
 void onint __P ((int));
 int rheader __P ((DB *, DBTYPE *, char **, int *, int *));
@@ -79,8 +79,8 @@ main (int argc, char *argv[])
   extern char *optarg;
   extern int optind;
   DBTYPE dbtype;
-  u_int32_t cachesize = 0;
-  u_int32_t db_nooverwrite;
+  uint32_t cachesize = 0;
+  uint32_t db_nooverwrite;
   int ch, e_close, exitval, no_header, ret;
   char **clist, **clp, *home;
   int compress = 0;
@@ -241,7 +241,7 @@ main (int argc, char *argv[])
  */
 int
 load (char *name, DBTYPE argtype, char **clist, int no_header,
-      u_int32_t db_nooverwrite, int compress, int wordlist)
+      uint32_t db_nooverwrite, int compress, int wordlist)
 {
   DB *dbp;
   DBT key, rkey, data, *readp, *writep;
@@ -476,7 +476,7 @@ done:rval = 0;
 int
 db_init (char *home)
 {
-  u_int32_t flags;
+  uint32_t flags;
   int ret;
 
   /* We may be loading into a live environment.  Try and join. */
@@ -759,8 +759,8 @@ badfmt:
 int
 dbt_rprint (DBT * dbtp)
 {
-  u_int32_t len;
-  u_int8_t *p;
+  uint32_t len;
+  uint8_t *p;
   int c1, c2, e, escape, first;
   char buf[32];
 
@@ -768,7 +768,7 @@ dbt_rprint (DBT * dbtp)
 
   first = 1;
   e = escape = 0;
-  for (p = (u_int8_t *) dbtp->data, len = 0; (c1 = getchar ()) != '\n';)
+  for (p = (uint8_t *) dbtp->data, len = 0; (c1 = getchar ()) != '\n';)
   {
     if (c1 == EOF)
     {
@@ -829,7 +829,7 @@ dbt_rprint (DBT * dbtp)
         dbenv->err (dbenv, ENOMEM, NULL);
         return (1);
       }
-      p = (u_int8_t *) dbtp->data + len;
+      p = (uint8_t *) dbtp->data + len;
     }
     ++len;
     *p++ = c1;
@@ -846,8 +846,8 @@ dbt_rprint (DBT * dbtp)
 int
 dbt_rdump (DBT * dbtp)
 {
-  u_int32_t len;
-  u_int8_t *p;
+  uint32_t len;
+  uint8_t *p;
   int c1, c2, e, first;
   char buf[32];
 
@@ -855,7 +855,7 @@ dbt_rdump (DBT * dbtp)
 
   first = 1;
   e = 0;
-  for (p = (u_int8_t *) dbtp->data, len = 0; (c1 = getchar ()) != '\n';)
+  for (p = (uint8_t *) dbtp->data, len = 0; (c1 = getchar ()) != '\n';)
   {
     if (c1 == EOF)
     {
@@ -901,7 +901,7 @@ dbt_rdump (DBT * dbtp)
         dbenv->err (dbenv, ENOMEM, NULL);
         return (1);
       }
-      p = (u_int8_t *) dbtp->data + len;
+      p = (uint8_t *) dbtp->data + len;
     }
     ++len;
     *p++ = digitize (c1, &e) << 4 | digitize (c2, &e);

--- a/hldb/hldb_stat.cc
+++ b/hldb/hldb_stat.cc
@@ -78,7 +78,7 @@ int main __P ((int, char *[]));
 int mpool_ok __P ((char *));
 int mpool_stats __P ((DB_ENV *));
 void onint __P ((int));
-void prflags __P ((u_int32_t, const FN *));
+void prflags __P ((uint32_t, const FN *));
 int queue_stats __P ((DB_ENV *, DB *));
 void siginit __P ((void));
 int txn_compare __P ((const void *, const void *));
@@ -735,7 +735,7 @@ int
 txn_stats (DB_ENV * dbenvp)
 {
   DB_TXN_STAT *sp;
-  u_int32_t i;
+  uint32_t i;
   int ret;
   const char *p;
 
@@ -864,7 +864,7 @@ dl_bytes (const char *msg, u_long gbytes, u_long mbytes, u_long bytes)
  *  Print out flag values.
  */
 void
-prflags (u_int32_t flags, const FN * fnp)
+prflags (uint32_t flags, const FN * fnp)
 {
   const char *sep;
 
@@ -886,7 +886,7 @@ prflags (u_int32_t flags, const FN * fnp)
 int
 db_init (char *home, test_t ttype)
 {
-  u_int32_t flags;
+  uint32_t flags;
   int ret;
 
   /*

--- a/hlnet/Connection.cc
+++ b/hlnet/Connection.cc
@@ -64,7 +64,7 @@
 
 typedef void (*SIGNAL_HANDLER) (...);
 
-#ifndef _MSC_VER                /* _WIN32 */
+#ifdef HAVE_RRESVPORT
 extern "C"
 {
   int rresvport (int *);
@@ -178,8 +178,7 @@ Connection::Open (int priv)
   {
     int aport = IPPORT_RESERVED - 1;
 
-//  Native Windows (MSVC) has no rresvport
-#ifndef _MSC_VER                /* _WIN32 */
+#ifdef HAVE_RRESVPORT
     sock = rresvport (&aport);
 #else
     return NOTOK;

--- a/hlword/WordDB.cc
+++ b/hlword/WordDB.cc
@@ -68,7 +68,7 @@ WordDB::Open (const String & filename, DBTYPE type, int flags, int mode)
 
   }
 
-  int error = db->open (db, filename, NULL, type, (u_int32_t) flags, mode);
+  int error = db->open (db, filename, NULL, type, (uint32_t) flags, mode);
 
   if (error == 0)
     is_open = 1;

--- a/hlword/WordDB.h
+++ b/hlword/WordDB.h
@@ -114,14 +114,14 @@ public:
   {
     if (!is_open)
       return DB_UNKNOWN;
-    return db->stat (db, sp, db_malloc, (u_int32_t) flags);
+    return db->stat (db, sp, db_malloc, (uint32_t) flags);
   }
 
   inline int Sync (int flags)
   {
     if (!is_open)
       return DB_UNKNOWN;
-    return db->sync (db, (u_int32_t) flags);
+    return db->sync (db, (uint32_t) flags);
   }
 
   inline int get_byteswapped () const
@@ -152,8 +152,8 @@ public:
 
   inline int Get (DB_TXN * txn, String & key, String & data, int flags) const
   {
-    WORD_DBT_INIT (rkey, (void *) key.get (), (u_int32_t) key.length ());
-    WORD_DBT_INIT (rdata, (void *) data.get (), (u_int32_t) data.length ());
+    WORD_DBT_INIT (rkey, (void *) key.get (), (uint32_t) key.length ());
+    WORD_DBT_INIT (rdata, (void *) data.get (), (uint32_t) data.length ());
 
     int error;
     if ((error = db->get (db, txn, &rkey, &rdata, 0)) != 0)
@@ -176,7 +176,7 @@ public:
 
   inline int Del (DB_TXN * txn, const String & key)
   {
-    WORD_DBT_INIT (rkey, (void *) key.get (), (u_int32_t) key.length ());
+    WORD_DBT_INIT (rkey, (void *) key.get (), (uint32_t) key.length ());
 
     return db->del (db, txn, &rkey, 0);
   }
@@ -257,7 +257,7 @@ public:
     return db->set_bt_compare (db, compare);
   }
 
-  inline int set_pagesize (u_int32_t pagesize)
+  inline int set_pagesize (uint32_t pagesize)
   {
     return db->set_pagesize (db, pagesize);
   }
@@ -325,7 +325,7 @@ public:
     }
     int error;
     if ((error =
-         cursor->c_get (cursor, &rkey, &rdata, (u_int32_t) flags)) != 0)
+         cursor->c_get (cursor, &rkey, &rdata, (uint32_t) flags)) != 0)
     {
       if (error != DB_NOTFOUND)
         fprintf (stderr, "WordDBCursor::Get(%d) failed %s\n", flags,
@@ -343,12 +343,12 @@ public:
   {
     WORD_DBT_INIT (rkey, (void *) key.get (), (size_t) key.length ());
     WORD_DBT_INIT (rdata, (void *) data.get (), (size_t) data.length ());
-    return cursor->c_put (cursor, &rkey, &rdata, (u_int32_t) flags);
+    return cursor->c_put (cursor, &rkey, &rdata, (uint32_t) flags);
   }
 
   inline int Del ()
   {
-    return cursor->c_del (cursor, (u_int32_t) 0);
+    return cursor->c_del (cursor, (uint32_t) 0);
   }
 
 private:

--- a/hlword/WordDBCompress.cc
+++ b/hlword/WordDBCompress.cc
@@ -30,9 +30,9 @@
 extern "C"
 {
 
-  static int WordDBCompress_compress_c (const u_int8_t * inbuff,
+  static int WordDBCompress_compress_c (const uint8_t * inbuff,
                                         int inbuff_length,
-                                        u_int8_t ** outbuffp,
+                                        uint8_t ** outbuffp,
                                         int *outbuff_lengthp, void *user_data)
   {
     if (!user_data)
@@ -47,9 +47,9 @@ extern "C"
                                                      outbuff_lengthp);
   }
 
-  static int WordDBCompress_uncompress_c (const u_int8_t * inbuff,
+  static int WordDBCompress_uncompress_c (const uint8_t * inbuff,
                                           int inbuff_length,
-                                          u_int8_t * outbuff,
+                                          uint8_t * outbuff,
                                           int outbuff_length, void *user_data)
   {
     if (!user_data)
@@ -124,8 +124,8 @@ WordDBCompress::CmprInfo ()
 }
 
 int
-WordDBCompress::Compress (const u_int8_t * inbuff, int inbuff_length,
-                          u_int8_t ** outbuffp, int *outbuff_lengthp)
+WordDBCompress::Compress (const uint8_t * inbuff, int inbuff_length,
+                          uint8_t ** outbuffp, int *outbuff_lengthp)
 {
   WordDBPage pg (inbuff, inbuff_length);
 
@@ -166,8 +166,8 @@ WordDBCompress::Compress (const u_int8_t * inbuff, int inbuff_length,
 }
 
 int
-WordDBCompress::Uncompress (const u_int8_t * inbuff, int inbuff_length,
-                            u_int8_t * outbuff, int outbuff_length)
+WordDBCompress::Uncompress (const uint8_t * inbuff, int inbuff_length,
+                            uint8_t * outbuff, int outbuff_length)
 {
   if (debug > 2)
     printf ("WordDBCompress::Uncompress::  %5d -> %5d\n", inbuff_length,
@@ -197,7 +197,7 @@ WordDBCompress::Uncompress (const u_int8_t * inbuff, int inbuff_length,
 }
 
 int
-WordDBCompress::TestCompress (const u_int8_t * pagebuff, int pagebuffsize)
+WordDBCompress::TestCompress (const uint8_t * pagebuff, int pagebuffsize)
 {
   WordDBPage pg (pagebuff, pagebuffsize);
   pg.TestCompress (debug);

--- a/hlword/WordDBCompress.h
+++ b/hlword/WordDBCompress.h
@@ -86,10 +86,10 @@ public:
   WordDBCompress ();
   WordDBCompress (int, int);
 
-  int Compress (const u_int8_t * inbuff, int inbuff_length,
-                u_int8_t ** outbuffp, int *outbuff_lengthp);
-  int Uncompress (const u_int8_t * inbuff, int inbuff_length,
-                  u_int8_t * outbuff, int outbuff_length);
+  int Compress (const uint8_t * inbuff, int inbuff_length,
+                uint8_t ** outbuffp, int *outbuff_lengthp);
+  int Uncompress (const uint8_t * inbuff, int inbuff_length,
+                  uint8_t * outbuff, int outbuff_length);
 
   //
   // Return a new DB_CMPR_INFO initialized with characteristics of the
@@ -110,7 +110,7 @@ private:
 // 1 : TestCompress before each compression (but no debug within Compress Uncompress)
 // 2 : use_tags (BitStream) within TestCompress ->  Compress Uncompress
 // 3 : verbose
-  int TestCompress (const u_int8_t * pagebuff, int pagebuffsize);
+  int TestCompress (const uint8_t * pagebuff, int pagebuffsize);
 };
 
 #endif

--- a/hlword/WordDBPage.h
+++ b/hlword/WordDBPage.h
@@ -637,7 +637,7 @@ public:
     insert_pos = pgsz;
     insert_indx = 0;
   }
-  WordDBPage (const u_int8_t * buff, int buff_length)
+  WordDBPage (const uint8_t * buff, int buff_length)
   {
     init0 ();
     pg = (PAGE *) buff;

--- a/hlword/WordMeta.cc
+++ b/hlword/WordMeta.cc
@@ -168,7 +168,7 @@ WordMeta::Lock (const String & resource, WordLock * &lock)
 {
   lock = new WordLock;
   DB_ENV *dbenv = words->GetContext ()->GetDBInfo ().dbenv;
-  u_int32_t id;
+  uint32_t id;
   if (CDB_lock_id (dbenv, &id) != 0)
   {
     delete lock;

--- a/test/dbbench.cc
+++ b/test/dbbench.cc
@@ -225,9 +225,9 @@ int_cmp(const DBT *a, const DBT *b)
 {
   // First compare word
   size_t len = (a->size > b->size ? b->size : a->size) - (sizeof(unsigned short) + sizeof(int));
-  u_int8_t *p1, *p2;
+  uint8_t *p1, *p2;
 
-  for (p1 = (u_int8_t*)a->data + sizeof(unsigned short) + sizeof(int), p2 = (u_int8_t*)b->data + sizeof(unsigned short) + sizeof(int); len--; ++p1, ++p2)
+  for (p1 = (uint8_t*)a->data + sizeof(unsigned short) + sizeof(int), p2 = (uint8_t*)b->data + sizeof(unsigned short) + sizeof(int); len--; ++p1, ++p2)
     if (*p1 != *p2)
       return ((long)*p1 - (long)*p2);
 
@@ -773,12 +773,12 @@ static void usage()
 
 extern "C"
 {
-    extern int CDB___memp_cmpr_inflate(const u_int8_t *, int, u_int8_t * , int  , void *);
-    extern int CDB___memp_cmpr_deflate(const u_int8_t *, int, u_int8_t **, int *, void *);
+    extern int CDB___memp_cmpr_inflate(const uint8_t *, int, uint8_t * , int  , void *);
+    extern int CDB___memp_cmpr_deflate(const uint8_t *, int, uint8_t **, int *, void *);
 }
 
 int compressone(params_t* params, unsigned char* buffin, int buffin_length) {
-  u_int8_t *buffout = 0;
+  uint8_t *buffout = 0;
   int buffout_length = 0;
 
   if(CDB___memp_cmpr_deflate(buffin, buffin_length, &buffout, &buffout_length,NULL) != 0) {
@@ -789,7 +789,7 @@ int compressone(params_t* params, unsigned char* buffin, int buffin_length) {
   if(verbose) fprintf(stderr, "compressone: %d\n", buffout_length);
 
   if(params->uncompress) {
-    u_int8_t *bufftmp = (u_int8_t*)malloc(buffin_length);
+    uint8_t *bufftmp = (uint8_t*)malloc(buffin_length);
     int bufftmp_length = buffin_length;
 
     if(CDB___memp_cmpr_inflate(buffout, buffout_length, bufftmp, bufftmp_length,NULL) != 0) {


### PR DESCRIPTION
Non-standard types have been reported while attempting to compile under
the Musl C library; this patch resolves those warnings that end in error.
