### PR TITLE
Fix byte typedef, introducing hlbyte (issue #146).

### DIFF
--- a/hlword/WordBitCompress.cc
+++ b/hlword/WordBitCompress.cc
@@ -29,7 +29,7 @@
 #include"WordBitCompress.h"
 
 // ******** HtVector_byte (implementation)
-#define GType byte
+#define GType hlbyte
 #define HtVectorGType HtVector_byte
 #include "HtVectorGenericCode.h"
 
@@ -478,7 +478,7 @@ bs (nbs)
 // **************************************************
 
 void
-BitStream::put_zone (byte * vals, int n, const char *tag)
+BitStream::put_zone (hlbyte * vals, int n, const char *tag)
 {
   add_tag (tag);
   for (int i = 0; i < (n + 7) / 8; i++)
@@ -488,7 +488,7 @@ BitStream::put_zone (byte * vals, int n, const char *tag)
 }
 
 void
-BitStream::get_zone (byte * vals, int n, const char *tag)
+BitStream::get_zone (hlbyte * vals, int n, const char *tag)
 {
   check_tag (tag);
   for (int i = 0; i < (n + 7) / 8; i++)
@@ -844,10 +844,10 @@ BitStream::show (int a /*=0*/ , int n /*=-1*/ )
 
 }
 
-byte *
+hlbyte *
 BitStream::get_data ()
 {
-  byte *res = (byte *) malloc (buff.size ());
+  hlbyte *res = (hlbyte *) malloc (buff.size ());
   CHECK_MEM (res);
   for (int i = 0; i < buff.size (); i++)
   {
@@ -857,7 +857,7 @@ BitStream::get_data ()
 }
 
 void
-BitStream::set_data (const byte * nbuff, int nbits)
+BitStream::set_data (const hlbyte * nbuff, int nbits)
 {
   if (buff.size () != 1 || bitpos != 0)
   {
@@ -1024,7 +1024,7 @@ Compressor::get_vals (unsigned int **pres, const char *tag /*="BADTAG!"*/ )
 
 
 int
-Compressor::put_fixedbitl (byte * vals, int n, const char *tag)
+Compressor::put_fixedbitl (hlbyte * vals, int n, const char *tag)
 {
   int cpos = bitpos;
   int i, j;
@@ -1036,10 +1036,10 @@ Compressor::put_fixedbitl (byte * vals, int n, const char *tag)
     return 0;
   }
 
-  byte maxv = vals[0];
+  hlbyte maxv = vals[0];
   for (i = 1; i < n; i++)
   {
-    byte v = vals[i];
+    hlbyte v = vals[i];
     if (v > maxv)
     {
       maxv = v;
@@ -1048,13 +1048,13 @@ Compressor::put_fixedbitl (byte * vals, int n, const char *tag)
   int nbits = num_bits (maxv);
   if (n >= pow2 (NBITS_NVALS))
   {
-    errr ("Compressor::put_fixedbitl(byte *) : overflow: nvals>2^16");
+    errr ("Compressor::put_fixedbitl(hlbyte *) : overflow: nvals>2^16");
   }
   put_uint (nbits, NBITS_NBITS_CHARVAL, "nbits");
   add_tag ("data");
   for (i = 0; i < n; i++)
   {
-    byte v = vals[i];
+    hlbyte v = vals[i];
     for (j = 0; j < nbits; j++)
     {
       put (v & pow2 (j));
@@ -1092,11 +1092,11 @@ Compressor::get_fixedbitl (unsigned int *res, int n)
 }
 
 int
-Compressor::get_fixedbitl (byte ** pres, const char *tag /*="BADTAG!"*/ )
+Compressor::get_fixedbitl (hlbyte ** pres, const char *tag /*="BADTAG!"*/ )
 {
   if (check_tag (tag) == NOTOK)
   {
-    errr ("Compressor::get_fixedbitl(byte *): check_tag failed");
+    errr ("Compressor::get_fixedbitl(hlbyte *): check_tag failed");
   }
   int n = get_uint_vl (NBITS_NVALS);
   if (!n)
@@ -1106,9 +1106,9 @@ Compressor::get_fixedbitl (byte ** pres, const char *tag /*="BADTAG!"*/ )
   }
   int nbits = get_uint (NBITS_NBITS_CHARVAL);
   if (verbose)
-    printf ("get_fixedbitl(byte):n%3d nbits:%2d\n", n, nbits);
+    printf ("get_fixedbitl(hlbyte):n%3d nbits:%2d\n", n, nbits);
   int i;
-  byte *res = new byte[n];
+  hlbyte *res = new hlbyte[n];
   CHECK_MEM (res);
   for (i = 0; i < n; i++)
   {

--- a/hlword/WordBitCompress.h
+++ b/hlword/WordBitCompress.h
@@ -28,9 +28,10 @@
 #include"HtVector_int.h"
 #include"HtMaxMin.h"
 
-typedef unsigned char byte;
+//typedef unsigned char hlbyte;
+typedef unsigned char hlbyte;
 // ******** HtVector_byte (header)
-#define GType byte
+#define GType hlbyte
 #define HtVectorGType HtVector_byte
 #include "HtVectorGeneric.h"
 
@@ -137,7 +138,7 @@ public:
   }
 
   // gets a bit from the bitstream
-  inline byte get (const char *tag = (char *) NULL)
+  inline hlbyte get (const char *tag = (char *) NULL)
   {
     // SPEED CRITICAL SECTION
     if (check_tag (tag) == NOTOK)
@@ -148,7 +149,7 @@ public:
     {
       errr ("BitStream::get reading past end of BitStream!");
     }
-    byte res = buff[bitpos >> 3] & pow2 (bitpos & 0x07);
+    hlbyte res = buff[bitpos >> 3] & pow2 (bitpos & 0x07);
 //    printf("get:res:%d bitpos:%5d/%d buff[%3d]=%x\n",res,bitpos,bitpos%8,bitpos/8,buff[bitpos/8]);
     bitpos++;
     return (res);
@@ -159,8 +160,8 @@ public:
   unsigned int get_uint (int n, const char *tag = (char *) NULL);
 
   // get/put n bits of data stored in vals
-  void put_zone (byte * vals, int n, const char *tag);
-  void get_zone (byte * vals, int n, const char *tag);
+  void put_zone (hlbyte * vals, int n, const char *tag);
+  void get_zone (hlbyte * vals, int n, const char *tag);
 
   // 
   inline void add_tag (const char *tag)
@@ -202,9 +203,9 @@ public:
   }
 
   // get a copy of the buffer
-  byte *get_data ();
+  hlbyte *get_data ();
   // set the buffer from outside data (current buffer must be empty)
-  void set_data (const byte * nbuff, int nbits);
+  void set_data (const hlbyte * nbuff, int nbits);
 
   // use this for reading a BitStream after you have written in it 
   // (generally for debuging)
@@ -297,8 +298,8 @@ public:
   int get_vals (unsigned int **pres, const char *tag = (char *) "BADTAG!");
 
   // compress/decompress an array of bytes (very simple)
-  int put_fixedbitl (byte * vals, int n, const char *tag);
-  int get_fixedbitl (byte ** pres, const char *tag = (char *) "BADTAG!");
+  int put_fixedbitl (hlbyte * vals, int n, const char *tag);
+  int get_fixedbitl (hlbyte ** pres, const char *tag = (char *) "BADTAG!");
 
   // compress/decompress an array of unsigned ints (very simple)
   void get_fixedbitl (unsigned int *res, int n);

--- a/hlword/WordDBPage.cc
+++ b/hlword/WordDBPage.cc
@@ -192,7 +192,7 @@ WordDBPage::Uncompress (Compressor * pin, int ndebug,
     Uncompress_main (pin);
     break;
   case CMPRTYPE_BADCOMPRESS:   // this page did not compress correctly
-    pin->get_zone ((byte *) pg, pgsz * 8, "INITIALBUFFER");
+    pin->get_zone ((hlbyte *) pg, pgsz * 8, "INITIALBUFFER");
     break;
   default:
     errr ("WordDBPage::Uncompress: CMPRTYPE incoherent");
@@ -227,7 +227,7 @@ WordDBPage::Uncompress_main (Compressor * pin)
   int *rnum_sizes = new int[nnums];
   CHECK_MEM (rnum_sizes);
   // char differences between words
-  byte *rworddiffs = NULL;
+  hlbyte *rworddiffs = NULL;
   int nrworddiffs;
 
   // *********** read header
@@ -365,7 +365,7 @@ WordDBPage::Uncompress_header (Compressor & in)
     printf (" 12-15: Previous page number. : %d\n", pg->prev_pgno);
     printf (" 16-19: Next page number.     : %d\n", pg->next_pgno);
     printf (" 20-21: Number of item pairs on the page. : %d\n", pg->entries);
-    printf (" 22-23: High free byte page offset.       : %d\n",
+    printf (" 22-23: High free hlbyte page offset.       : %d\n",
             pg->hf_offset);
     printf ("    24: Btree tree level.                 : %d\n", pg->level);
     printf ("    25: Page type.                        : %d\n", pg->type);
@@ -375,7 +375,7 @@ WordDBPage::Uncompress_header (Compressor & in)
 
 void
 WordDBPage::Uncompress_rebuild (unsigned int **rnums, int *rnum_sizes,
-                                int nnums0, byte * rworddiffs,
+                                int nnums0, hlbyte * rworddiffs,
                                 int nrworddiffs)
 {
   int irwordiffs = 0;
@@ -529,7 +529,7 @@ WordDBPage::Uncompress_rebuild (unsigned int **rnums, int *rnum_sizes,
 // display
 void
 WordDBPage::Uncompress_show_rebuild (unsigned int **rnums, int *rnum_sizes,
-                                     int nnums0, byte * rworddiffs,
+                                     int nnums0, hlbyte * rworddiffs,
                                      int nrworddiffs)
 {
   int i, j;
@@ -617,7 +617,7 @@ WordDBPage::Compress (int ndebug, DB_CMPR_INFO * cmprInfo /*=NULL*/ )
                    "COMPRESS_VERSION");
     res->put_uint (CMPRTYPE_BADCOMPRESS, NBITS_CMPRTYPE, "CMPRTYPE");
 
-    res->put_zone ((byte *) pg, pgsz * 8, "INITIALBUFFER");
+    res->put_zone ((hlbyte *) pg, pgsz * 8, "INITIALBUFFER");
   }
 
   if (verbose)
@@ -1037,7 +1037,7 @@ WordDBPage::Compare (WordDBPage & other)
     printf ("compare failed in some unknown place in header:\n");
     for (i = 0; i < (int) (sizeof (PAGE) - sizeof (db_indx_t)); i++)
     {
-      printf ("%3d: %3x %3x\n", i, ((byte *) pg)[i], ((byte *) other.pg)[i]);
+      printf ("%3d: %3x %3x\n", i, ((hlbyte *) pg)[i], ((hlbyte *) other.pg)[i]);
     }
   }
 
@@ -1331,7 +1331,7 @@ WordDBPage::show ()
       printf ("%5d: ", nn);
       for (j = 0; j < 20; j++)
       {
-        printf ("%2x ", ((byte *) pg)[nn++]);
+        printf ("%2x ", ((hlbyte *) pg)[nn++]);
         if (nn >= pgsz)
         {
           break;

--- a/hlword/WordDBPage.h
+++ b/hlword/WordDBPage.h
@@ -74,7 +74,7 @@ public:
 WordDBRecord ():WordRecord ()
   {;
   }
-  WordDBRecord (byte * dat, int len, int rectyp):WordRecord ()
+  WordDBRecord (hlbyte * dat, int len, int rectyp):WordRecord ()
   {
     type = (rectyp ? DefaultType () : WORD_RECORD_STATS);
     Unpack (String ((char *) dat, len));
@@ -138,7 +138,7 @@ WordDBKey (BINTERNAL * nkey):WordKey ()
       Unpack (String ((char *) nkey->data, nkey->len));
     }
   }
-  WordDBKey (byte * data, int len):WordKey ()
+  WordDBKey (hlbyte * data, int len):WordKey ()
   {
     key = NULL;
     if (!data || !len)
@@ -267,7 +267,7 @@ public:
   void *alloc_entry (int size)
   {
     size = WORD_ALIGN_TO (size, 4);
-    int inp_pos = ((byte *) & (pg->inp[insert_indx])) - (byte *) pg;
+    int inp_pos = ((hlbyte *) & (pg->inp[insert_indx])) - (hlbyte *) pg;
     insert_pos -= size;
     if (insert_pos <= inp_pos)
     {
@@ -278,7 +278,7 @@ public:
       errr ("WordDBPage::alloc_entry: PAGE OVERFLOW");
     }
     pg->inp[insert_indx++] = insert_pos;
-    return ((void *) ((byte *) pg + insert_pos));
+    return ((void *) ((hlbyte *) pg + insert_pos));
   }
 
 
@@ -328,7 +328,7 @@ public:
       ky.Pack (pkey);
       keylen = pkey.length ();
     }
-    int size = keylen + ((byte *) & (bti.data)) - ((byte *) & bti);     // pos of data field in BINTERNAL
+    int size = keylen + ((hlbyte *) & (bti.data)) - ((hlbyte *) & bti);     // pos of data field in BINTERNAL
     if (empty)
     {
       if (verbose)
@@ -336,7 +336,7 @@ public:
         printf
           ("WordDBPage::insert_btikey: empty : BINTERNAL:%d datapos:%d keylen:%d size:%d alligned to:%d\n",
            (int) sizeof (BINTERNAL),
-           (int) (((byte *) & (bti.data)) - ((byte *) & bti)), keylen, size,
+           (int) (((hlbyte *) & (bti.data)) - ((hlbyte *) & bti)), keylen, size,
            WORD_ALIGN_TO (size, 4));
       }
     }
@@ -389,9 +389,9 @@ public:
                                      int *pn);
   int Uncompress_header (Compressor & in);
   void Uncompress_rebuild (unsigned int **rnums, int *rnum_sizes, int nnums,
-                           byte * rworddiffs, int nrworddiffs);
+                           hlbyte * rworddiffs, int nrworddiffs);
   void Uncompress_show_rebuild (unsigned int **rnums, int *rnum_sizes,
-                                int nnums, byte * rworddiffs,
+                                int nnums, hlbyte * rworddiffs,
                                 int nrworddiffs);
 
   int TestCompress (int debuglevel);
@@ -422,7 +422,7 @@ public:
                     label_str ("seperatekey_bti_nrecs", i));
       if (len)
       {
-        out.put_zone ((byte *) btikey (i)->data, 8 * len,
+        out.put_zone ((hlbyte *) btikey (i)->data, 8 * len,
                       label_str ("seperatekey_btidata", i));
       }
     }
@@ -434,7 +434,7 @@ public:
       {
         printf ("WordDBPage::compress_key: compress(typ5):%d\n", len);
       }
-      out.put_zone ((byte *) key (i)->data, 8 * len,
+      out.put_zone ((hlbyte *) key (i)->data, 8 * len,
                     label_str ("seperatekey_data", i));
     }
   }
@@ -446,7 +446,7 @@ public:
     {
       printf ("WordDBPage::compress_data: compressdata(typ5):%d\n", len);
     }
-    out.put_zone ((byte *) data (i)->data, 8 * len,
+    out.put_zone ((hlbyte *) data (i)->data, 8 * len,
                   label_str ("seperatedata_data", i));
   }
   WordDBKey uncompress_key (Compressor & in, int i)
@@ -483,7 +483,7 @@ public:
       }
       if (len)
       {
-        byte *gotdata = new byte[len];
+        hlbyte *gotdata = new hlbyte[len];
         CHECK_MEM (gotdata);
         in.get_zone (gotdata, 8 * len, label_str ("seperatekey_btidata", i));
         res = WordDBKey (gotdata, len);
@@ -493,7 +493,7 @@ public:
     }
     else
     {
-      byte *gotdata = new byte[len];
+      hlbyte *gotdata = new hlbyte[len];
       CHECK_MEM (gotdata);
       in.get_zone (gotdata, 8 * len, label_str ("seperatekey_data", i));
       res = WordDBKey (gotdata, len);
@@ -508,7 +508,7 @@ public:
     int len = in.get_uint (NBITS_DATALEN, label_str ("seperatedata_len", i));
     if (verbose)
       printf ("uncompressdata:len:%d\n", len);
-    byte *gotdata = new byte[len];
+    hlbyte *gotdata = new hlbyte[len];
     CHECK_MEM (gotdata);
     in.get_zone (gotdata, 8 * len, label_str ("seperatedata_data", i));
     res = WordDBRecord (gotdata, len, rectyp);
@@ -632,7 +632,7 @@ public:
   {
     init0 ();
     pgsz = npgsz;
-    pg = (PAGE *) (new byte[pgsz]);
+    pg = (PAGE *) (new hlbyte[pgsz]);
     CHECK_MEM (pg);
     insert_pos = pgsz;
     insert_indx = 0;


### PR DESCRIPTION
Allows compilation with GCC 13+. See issue #146.
