### PR TITLE
Fix a compile test for gcc-14+

### DIFF
--- a/db/acinclude.m4
+++ b/db/acinclude.m4
@@ -59,6 +59,7 @@ LIBS="-lthread $LIBS"
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <thread.h>
 #include <synch.h>
+#include <stdlib.h>
 main(){
 	mutex_t mutex;
 	cond_t cond;


### PR DESCRIPTION
The lack of the inlude triggers -Wimplicit-function-declaration. In gcc-14+ this triggers an error and thus a false-negative for the test.